### PR TITLE
resolve winding order shared arcs

### DIFF
--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -150,3 +150,14 @@ class TestHasmap(unittest.TestCase):
         # topo = Hashmap(data).to_gdf()
         # self.assertNotEqual(topo["geometry"][0].wkt, "GEOMETRYCOLLECTION EMPTY")
 
+    # this test was added because the winding order is still giving issues.
+    # see related issue: https://github.com/mattijn/topojson/issues/30
+    def test_winding_order_geom_solely_shared_arcs(self):
+        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        data = data[
+            (data.name == "Jordan")
+            | (data.name == "Palestine")
+            | (data.name == "Israel")
+        ]
+        topo = Hashmap(data).to_dict()
+        self.assertEqual(topo["objects"]["data"]["geometries"][1]["arcs"], [[1, -6]])

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -162,6 +162,44 @@ def fast_split(line, splitter):
     return slines
 
 
+def signed_area(ring):
+    """
+    compute the signed area of a ring (polygon)
+    
+    note: implementation is numpy variant of shapely's version:
+    https://github.com/Toblerity/Shapely/blob/master/shapely/algorithms/cga.py
+    
+    Parameters
+    ----------
+    ring : shapely.geometry.LinearRing
+        an exterior or inner ring of a shapely.geometry.Polygon
+    
+    Returns
+    -------
+    float
+        the signed area
+    """
+    xs, ys = np.array(ring.coords.xy)
+    signed_area = (xs * (np.roll(ys, -1) - np.roll(ys, +1))).sum() / 2
+    return signed_area
+
+
+def is_ccw(ring):
+    """provide information if a given ring is clockwise or counterclockwise.
+    
+    Parameters
+    ----------
+    ring : shapely.geometry.LinearRing
+        an exterior or inner ring of a shapely.geometry.Polygon
+    
+    Returns
+    -------
+    boolean
+        True if ring is counterclockwise and False if ring is clockwise
+    """
+    return signed_area(ring) >= 0.0
+
+
 def get_matches(geoms, tree_idx):
     """
     Function to return the indici of the rtree that intersects with the input geometries
@@ -374,8 +412,8 @@ def winding_order(geom, order="CW_CCW"):
         Geometry objects where the chosen winding order is forced upon.
     """
 
-    # CW_CWW will orient the outer polygon clockwise and the inner polygon to be
-    # counterclockwise to conform TopoJSON standard
+    # CW_CWW will orient the outer polygon clockwise and the inner polygon counter-
+    # clockwise to conform TopoJSON standard
     if order == "CW_CCW":
         geom = geometry.polygon.orient(geom, sign=-1.0)
     elif order == "CCW_CW":


### PR DESCRIPTION
Resolved by providing a double check on the ordered arcs if the geometry only exists out of shared arcs. It analyses if the geometry is exterior or interior and compares it with the winding order setting, from there it decides if the arcs needs to be reversed or not.

```python
import topojson
import geopandas

data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))

topo = topojson.Topology(
    data[(data.continent == "Asia")], 
    options={'winding_order':'CW_CCW'}
)

topo.to_alt(color='properties.name:N', projection='mercator')
```

![output_3_0](https://user-images.githubusercontent.com/5186265/62420411-5193d980-b6c4-11e9-8245-a362a32f29cb.png)

Fix https://github.com/mattijn/topojson/issues/30