### PR TITLE
foreign members as properties and improved hashing of geometry collections

### DIFF
--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -30,9 +30,9 @@ class TestHasmap(unittest.TestCase):
             }
         }
         topo = Hashmap(data).to_dict()
-        # print(topo)
         self.assertEqual(
-            topo["objects"]["data"]["geometries"][0]["arcs"], [[[4, 0]], [[1]], [[2]]]
+            topo["objects"]["data"]["geometries"][0]["geometries"][0]["arcs"],
+            [[[4, 0]], [[1]], [[2]]],
         )
 
     def test_hashmap_backward_polygon(self):
@@ -104,7 +104,10 @@ class TestHasmap(unittest.TestCase):
             ]
         )
         topo = Hashmap(data).to_dict()
+        geoms = topo["objects"]["data"]["geometries"][0]["geometries"]
         self.assertEqual(list(topo.keys()), ["type", "objects", "options", "arcs"])
+        self.assertEqual(geoms[0]["arcs"], [[-3, 0]])
+        self.assertEqual(geoms[1]["arcs"], [[1, 2]])
 
     # this test was added since geometries of only linestrings resulted in a topojson
     # file that returns an empty geodataframe when reading
@@ -122,7 +125,6 @@ class TestHasmap(unittest.TestCase):
 
     # this test was added since objects with nested geometreycollections seems not
     # being parsed in the topojson format.
-    # TODO: Not sure if this supposed to be done like this. Need further investigation.
     # Pass for now:
     def test_hashing_of_nested_geometrycollection(self):
         data = {

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -150,3 +150,14 @@ class TestHasmap(unittest.TestCase):
         # topo = Hashmap(data).to_gdf()
         # self.assertNotEqual(topo["geometry"][0].wkt, "GEOMETRYCOLLECTION EMPTY")
 
+    # this test was added because the winding order is still giving issues.
+    # see related issue: https://github.com/mattijn/topojson/issues/30
+    def test_winding_order_geom_solely_shared_arcs(self):
+        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        data = data[
+            (data.name == "Jordan")
+            | (data.name == "Palestine")
+            | (data.name == "Israel")
+        ]
+        topo = Hashmap(data).to_dict()
+        self.assertEqual(topo["objects"]["data"]["geometries"][1]["arcs"], [[1, -6]])

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -63,7 +63,15 @@ class Extract(object):
         self.linestrings = []
         self.geomcollection_counter = 0
         self.invalid_geoms = 0
-        self.output = self.extractor(copy.deepcopy(data))
+
+        # FIXME: try except is not necessary once the following issue is fixed:
+        # https://github.com/geopandas/geopandas/issues/1070
+        try:
+            deep_data = copy.deepcopy(data)
+            self.output = self.extractor(deep_data)
+        except TypeError:
+            shallow_data = data.copy()
+            self.output = self.extractor(shallow_data)
 
     def __repr__(self):
         return "Extract(\n{}\n)".format(pprint.pformat(self.output))

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -95,7 +95,7 @@ class Hashmap(Dedup):
         for idx, feature in enumerate(data["objects"]):
             feat = data["objects"][feature]
 
-            if "geometries" in feat:
+            if "geometries" in feat and len(feat["geometries"]) == 1:
                 feat["type"] = feat["geometries"][0]["type"]
 
             self.resolve_arcs(feat)
@@ -374,7 +374,7 @@ class Hashmap(Dedup):
             if "geometries" in feat:
                 f_arcs = feat["geometries"][0]["arcs"]
             else:
-                f_arcs["arcs"]
+                f_arcs = feat["arcs"]
             feat["arcs"] = [[arc] for arc in f_arcs]
             feat.pop("geometries", None)
 

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -2,6 +2,7 @@ import pprint
 import json
 import copy
 from .hashmap import Hashmap
+from ..ops import properties_foreign
 from ..utils import serialize_as_geodataframe
 from ..utils import serialize_as_svg
 from ..utils import serialize_as_json
@@ -49,6 +50,12 @@ class Topology(Hashmap):
         return serialize_as_altair(
             topo_object, mesh, color, tooltip, projection, objectname
         )
+
+    def flatten_properties(self):
+        objects = self.output["objects"]["data"]["geometries"]
+        if objects:
+            objects = properties_foreign(objects)
+            self.output["objects"]["data"]["geometries"] = objects
 
         # if simplify_factor is not None:
         #     if simplify_factor >= 1:

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -162,6 +162,44 @@ def fast_split(line, splitter):
     return slines
 
 
+def signed_area(ring):
+    """
+    compute the signed area of a ring (polygon)
+    
+    note: implementation is numpy variant of shapely's version:
+    https://github.com/Toblerity/Shapely/blob/master/shapely/algorithms/cga.py
+    
+    Parameters
+    ----------
+    ring : shapely.geometry.LinearRing
+        an exterior or inner ring of a shapely.geometry.Polygon
+    
+    Returns
+    -------
+    float
+        the signed area
+    """
+    xs, ys = np.array(ring.coords.xy)
+    signed_area = (xs * (np.roll(ys, -1) - np.roll(ys, +1))).sum() / 2
+    return signed_area
+
+
+def is_ccw(ring):
+    """provide information if a given ring is clockwise or counterclockwise.
+    
+    Parameters
+    ----------
+    ring : shapely.geometry.LinearRing
+        an exterior or inner ring of a shapely.geometry.Polygon
+    
+    Returns
+    -------
+    boolean
+        True if ring is counterclockwise and False if ring is clockwise
+    """
+    return signed_area(ring) >= 0.0
+
+
 def get_matches(geoms, tree_idx):
     """
     Function to return the indici of the rtree that intersects with the input geometries
@@ -374,8 +412,8 @@ def winding_order(geom, order="CW_CCW"):
         Geometry objects where the chosen winding order is forced upon.
     """
 
-    # CW_CWW will orient the outer polygon clockwise and the inner polygon to be
-    # counterclockwise to conform TopoJSON standard
+    # CW_CWW will orient the outer polygon clockwise and the inner polygon counter-
+    # clockwise to conform TopoJSON standard
     if order == "CW_CCW":
         geom = geometry.polygon.orient(geom, sign=-1.0)
     elif order == "CCW_CW":

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -200,6 +200,49 @@ def is_ccw(ring):
     return signed_area(ring) >= 0.0
 
 
+def properties_foreign(objects):
+    """
+    Try to parse the object properties as foreign members. Reserved keys are:
+    ["type", "bbox", "coordinates", "geometries", "geometry", "properties", "features"]
+
+    If these keys are detected they will not be set as a foreign member and will remain
+    nested within properties. 
+
+    Only if the 
+    
+    Parameters
+    ----------
+    objects : [type]
+        [description]
+    """
+    reserved_keys = [
+        "type",
+        "bbox",
+        "coordinates",
+        "geometries",
+        "geometry",
+        "properties",
+        "features",
+        "arcs",
+    ]
+    reserved_keys_used = bool(
+        set(objects[0]["properties"].keys()).intersection(reserved_keys)
+    )
+
+    for obj in objects:
+        reserved_keys = False
+        for k, v in list(obj["properties"].items()):
+
+            if not reserved_keys_used or k in reserved_keys:
+                obj[k] = v
+                obj["properties"].pop(k, None)
+
+        if not reserved_keys_used:
+            obj.pop("properties", None)
+
+    return objects
+
+
 def get_matches(geoms, tree_idx):
     """
     Function to return the indici of the rtree that intersects with the input geometries


### PR DESCRIPTION
I was hoping I could register properties as foreign members in topojson format, so they also will be parsed as foreign members when using in Altair. But while this function is now included it cannot be used as was hoped for. 

Observe the following:



```python
import geopandas
import topojson
```


```python
data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
data = data[
    (data.name == "Netherlands")
    | (data.name == "Belgium")
    | (data.name == "Luxembourg")
]
topo = topojson.Topology(data, options={'topology':True})
topo.to_dict()['objects']['data']['geometries'][0]
```
The information about the geometry is stored in the `properties` key.



    {'id': '128',
     'type': 'Polygon',
     'properties': {'continent': 'Europe',
      'gdp_md_est': 58740.0,
      'iso_a3': 'LUX',
      'name': 'Luxembourg',
      'pop_est': 594130},
     'bbox': (5.674051954784829,
      49.44266714130711,
      6.242751092156993,
      50.128051662794235),
     'arcs': [[0, -3]]}



Thats the reason we have to define `properties.name:N` to access the nested information in Altair.
```python
topo.to_alt(projection='mercator', color='properties.name:N')
```




![output_2_0](https://user-images.githubusercontent.com/5186265/62425154-87f44780-b70a-11e9-938b-3ed9c03af42b.png)


So when flatten the properties (preserving reserved keys) as such
```python
topo.flatten_properties()
topo.to_dict()['objects']['data']['geometries'][0]
```




    {'id': '128',
     'type': 'Polygon',
     'bbox': (5.674051954784829,
      49.44266714130711,
      6.242751092156993,
      50.128051662794235),
     'arcs': [[0, -3]],
     'continent': 'Europe',
     'gdp_md_est': 58740.0,
     'iso_a3': 'LUX',
     'name': 'Luxembourg',
     'pop_est': 594130}



I hoped I could do the following. 
```python
topo.to_alt(projection='mercator', color='name:N')
```



![output_4_0](https://user-images.githubusercontent.com/5186265/62425157-8cb8fb80-b70a-11e9-898a-bf62f18c0659.png)

But this doesn't work. This is happening because Altair (read: vega/javascript-topojson) converts the parsed TopoJSON into GeoJSON and in this proces only set the `type`, `id`, `bbox`, `properties` and `geometry`:
<img width="781" alt="image" src="https://user-images.githubusercontent.com/5186265/62425267-c76f6380-b70b-11e9-9ef5-7953083632a5.png">


I will keep the function part of the package. Maybe one day the javascript-topojson package will be able to read foreign members.