### PR TITLE
include functions for presimplify and toposimplify

### DIFF
--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -1,13 +1,11 @@
 import numpy as np
 from itertools import compress
-from simplification import cutil
 import copy
 import pprint
 import json
 from shapely import geometry
 from shapely.ops import linemerge
 from .dedup import Dedup
-from ..ops import delta_encoding
 from ..ops import is_ccw
 from ..utils import serialize_as_geodataframe
 from ..utils import serialize_as_svg
@@ -60,7 +58,7 @@ class Hashmap(Dedup):
             topo_object, mesh, color, tooltip, projection, objectname
         )
 
-    def hashmapper(self, data, simplify_factor=None):
+    def hashmapper(self, data):
         """
         Hashmap function resolves bookkeeping results to object arcs.
 
@@ -82,17 +80,10 @@ class Hashmap(Dedup):
         # resolve bookkeeping to arcs in objects, including backward check of arcs
         list(self.resolve_objects("arcs", self.data["objects"]))
 
-        # apply delta-encoding if prequantization is applied
-        if self.options.prequantize > 0:
-            self.data["linestrings"] = delta_encoding(data["linestrings"])
-        else:
-            for idx, ls in enumerate(data["linestrings"]):
-                self.data["linestrings"][idx] = np.array(ls).tolist()
-
         objects = {}
         objects["geometries"] = []
         objects["type"] = "GeometryCollection"
-        for idx, feature in enumerate(data["objects"]):
+        for feature in data["objects"]:
             feat = data["objects"][feature]
 
             if "geometries" in feat and len(feat["geometries"]) == 1:
@@ -107,8 +98,6 @@ class Hashmap(Dedup):
 
         # prepare to return object
         data = self.data
-        data["arcs"] = data["linestrings"]
-        del data["linestrings"]
         del data["junctions"]
         del data["bookkeeping_geoms"]
         del data["bookkeeping_duplicates"]

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -5,6 +5,7 @@ from shapely.ops import shared_paths
 from shapely.ops import linemerge
 from shapely import speedups
 from ..ops import select_unique_combs
+from ..ops import simplify
 from ..ops import prequantize
 from ..utils import serialize_as_svg
 import numpy as np
@@ -106,6 +107,18 @@ class Join(Extract):
             - new key: junctions
             - new key: transform (if quant_factor is not None)        
         """
+
+        # presimplify linestrings if required
+        if self.options.presimplify > 0:
+            # set default if not specifically given in the options
+            if type(self.options.presimplify) == bool:
+                simplify_factor = 2
+            else:
+                simplify_factor = self.options.presimplify
+
+            data["linestrings"] = simplify(
+                data["linestrings"], simplify_factor, package="shapely"
+            )
 
         # prequantize linestrings if required
         if self.options.prequantize > 0:

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -416,7 +416,16 @@ def simplify(linestrings, epsilon, algorithm="dp", package="simplification"):
     * https://www.jasondavies.com/simplify/
     * https://bost.ocks.org/mike/simplify/
     """
-    return
+    if package == "shapely":
+        for idx, ls in enumerate(linestrings):
+            linestrings[idx] = ls.simplify(epsilon, preserve_topology=False)
+
+    if package == "simplification":
+        from simplification import cutil
+
+        for idx, ls in enumerate(linestrings):
+            linestrings[idx] = cutil.simplify_coords(np.array(ls), epsilon)
+    return linestrings
 
 
 def winding_order(geom, order="CW_CCW"):

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -36,8 +36,8 @@ class TopoOptions(object):
         object={},
         topology=True,
         prequantize=False,
-        simplify=None,
-        simplify_factor=None,
+        presimplify=False,
+        toposimplify=False,
         winding_order=None,  # default should become "CW_CCW",
     ):
         # get all arguments and check if `object` is created.
@@ -56,15 +56,15 @@ class TopoOptions(object):
         else:
             self.prequantize = False
 
-        if "simplify" in arguments:
-            self.simplify = arguments["simplify"]
+        if "presimplify" in arguments:
+            self.presimplify = arguments["presimplify"]
         else:
-            self.simplify = None
+            self.presimplify = False
 
-        if "simplify_factor" in arguments:
-            self.simplify_factor = arguments["simplify_factor"]
+        if "toposimplify" in arguments:
+            self.toposimplify = arguments["toposimplify"]
         else:
-            self.simplify_factor = None
+            self.toposimplify = False
 
         if "winding_order" in arguments:
             self.winding_order = arguments["winding_order"]


### PR DESCRIPTION
This can now works as follow:



```python
import geopandas
import topojson
```

Select some data
```python
data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
data = data[
    (data.continent == "South America")
]
```

Use the `presimplify` option to set a value to simplify. Presimplify applies simplification on the LineStrings before any computation on the topology has happened.

```python
topojson.Topology(
    data, options={'topology':True, 'presimplify':2}
).to_alt(color='properties.name:N', projection='mercator')
```




![output_2_0](https://user-images.githubusercontent.com/5186265/62444390-f4655a00-b78f-11e9-934f-d12772f28289.png)




Use `toposimplify` for applying simplification on the LineStrings after performing of topology computation. 
```python
topojson.Topology(
    data, options={'topology':True, 'toposimplify':2}
).to_alt(color='properties.name:N', projection='mercator')
```




![output_3_0](https://user-images.githubusercontent.com/5186265/62444395-f8917780-b78f-11e9-8c78-3caf9a303629.png)



Notes: 

- Applying `toposimplify` in combination with `topology: False` behave the same as `presimplify`. 
- Currently `toposimplify` does not work in combination with `prequantize`. 
- A lot of counter cases where too small or too high values are used for the simplifying is not covered, since I have not yet a clear feeling what these values for simplification mean.