### PR TITLE
Add bbox on the index, add topoquantize and chaining of toposimplify and topoquantize

### DIFF
--- a/notebooks/ipywidgets_interaction.ipynb
+++ b/notebooks/ipywidgets_interaction.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas\n",
+    "import topojson\n",
+    "import numpy as np\n",
+    "\n",
+    "from ipywidgets import interact, fixed\n",
+    "import ipywidgets as widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "data = data[(data.continent == \"Africa\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tj = topojson.Topology(data, options={'prequantize':1e6, 'topology':True})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23ef8a4de9bd4ff5a1795a14b09f412a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatSlider(value=0.0, description='Toposimplify Factor', max=10.0, style=SliderStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<function __main__.toposimpquant(epsilon, quant, topo)>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "style = {'description_width': 'initial'}\n",
+    "eps = widgets.FloatSlider(min=0, max=10, step=0.1, value=0, description='Toposimplify Factor', style=style)\n",
+    "qnt = widgets.FloatLogSlider(value=1e6, base=10, min=1,max=6,step=0.5, description='Topoquantize Factor', style=style)\n",
+    "\n",
+    "def toposimpquant(epsilon, quant, topo):\n",
+    "    return topo.toposimplify(epsilon).topoquantize(quant).to_alt()\n",
+    "\n",
+    "interact(toposimpquant, epsilon=eps, quant=qnt, topo=fixed(tj))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -191,6 +191,7 @@ class TestCut(unittest.TestCase):
                 "bookkeeping_geoms",
                 "objects",
                 "options",
+                "bbox",
                 "junctions",
                 "bookkeeping_duplicates",
                 "bookkeeping_linestrings",

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -148,6 +148,7 @@ class TestDedup(unittest.TestCase):
                 "bookkeeping_geoms",
                 "objects",
                 "options",
+                "bbox",
                 "junctions",
                 "bookkeeping_duplicates",
                 "bookkeeping_arcs",

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -56,7 +56,7 @@ class TestHasmap(unittest.TestCase):
         data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
         data = data[(data.name == "Albania") | (data.name == "Greece")]
         topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["arcs"]), 4)
+        self.assertEqual(len(topo["linestrings"]), 4)
 
     # something is wrong with hashmapping in the example of benin
     def test_benin_surrounding_countries(self):
@@ -67,7 +67,7 @@ class TestHasmap(unittest.TestCase):
             | (data.name == "Burkina Faso")
         ]
         topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["arcs"]), 6)
+        self.assertEqual(len(topo["linestrings"]), 6)
 
     # something is wrong with hashmapping once a geometry has only shared arcs
     def test_geom_surrounding_many_geometries(self):
@@ -80,7 +80,7 @@ class TestHasmap(unittest.TestCase):
             | (data.name == "Zambia")
         ]
         topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["arcs"]), 13)
+        self.assertEqual(len(topo["linestrings"]), 13)
 
     # this test was added since the shared_arcs bookkeeping is doing well, but the
     # wrong arc gots deleted. How come?
@@ -94,7 +94,7 @@ class TestHasmap(unittest.TestCase):
             | (data.name == "Zambia")
         ]
         topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["arcs"]), 17)
+        self.assertEqual(len(topo["linestrings"]), 17)
 
     def test_super_function_hashmap(self):
         data = geometry.GeometryCollection(
@@ -105,23 +105,11 @@ class TestHasmap(unittest.TestCase):
         )
         topo = Hashmap(data).to_dict()
         geoms = topo["objects"]["data"]["geometries"][0]["geometries"]
-        self.assertEqual(list(topo.keys()), ["type", "objects", "options", "arcs"])
+        self.assertEqual(
+            list(topo.keys()), ["type", "linestrings", "objects", "options", "bbox"]
+        )
         self.assertEqual(geoms[0]["arcs"], [[-3, 0]])
         self.assertEqual(geoms[1]["arcs"], [[1, 2]])
-
-    # this test was added since geometries of only linestrings resulted in a topojson
-    # file that returns an empty geodataframe when reading
-    def test_linestrings_parsed_to_gdf(self):
-        data = [
-            {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
-            {
-                "type": "LineString",
-                "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]],
-            },
-        ]
-        topo = Hashmap(data).to_gdf()
-        self.assertNotEqual(topo["geometry"][0].wkt, "GEOMETRYCOLLECTION EMPTY")
-        self.assertEqual(topo["geometry"][0].type, "LineString")
 
     # this test was added since objects with nested geometreycollections seems not
     # being parsed in the topojson format.

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -559,4 +559,4 @@ class TestJoin(unittest.TestCase):
         ])   
         topo = Join(data).to_dict()  
         self.assertEqual(list(topo.keys()), 
-        ["type", "linestrings", "bookkeeping_geoms", "objects", "options", "junctions"])
+        ["type", "linestrings", "bookkeeping_geoms", "objects", "options","bbox", "junctions"])

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -78,3 +78,12 @@ class TestOptions(unittest.TestCase):
             data, options={"topology": False, "prequantize": 1e4, "delta_encode": True}
         ).to_dict()
         self.assertEqual("transform" in topo.keys(), True)
+
+    # test toposimplify
+    def test_toposimplify_including_prequantization(self):
+        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        data = data[(data.name == "Antarctica")]
+        topo = topojson.Topology(
+            data, options={"prequantize": True, "simplifypackage": "simplification"}
+        )
+        topos = topo.toposimplify(2)

--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -6,6 +6,7 @@ from shapely.strtree import STRtree
 from .join import Join
 from ..ops import insert_coords_in_line
 from ..ops import fast_split
+from ..ops import np_array_from_lists
 from ..ops import select_unique_combs
 from ..utils import serialize_as_svg
 
@@ -112,7 +113,7 @@ class Cut(Join):
             self.bookkeeping_linestrings = bk_array.astype(float)
 
         else:
-            bk_array = self.index_array(data["bookkeeping_geoms"]).ravel()
+            bk_array = np_array_from_lists(data["bookkeeping_geoms"]).ravel()
             bk_array = np.expand_dims(bk_array[~np.isnan(bk_array)].astype(int), axis=1)
             self.segments_list = data["linestrings"]
             self.find_duplicates(data["linestrings"])
@@ -124,22 +125,6 @@ class Cut(Join):
         data["bookkeeping_linestrings"] = self.bookkeeping_linestrings
 
         return data
-
-    def index_array(self, parameter_list):
-        """
-        Create numpy array from list of lists. The number of lists and and the max 
-        length determines the size of the array.
-        
-        Parameters
-        ----------
-        parameter_list : list of lists
-            each lists contains values
-        
-        """
-        array_bk = np.array(
-            list(itertools.zip_longest(*parameter_list, fillvalue=np.nan))
-        ).T
-        return array_bk
 
     def flatten_and_index(self, slist):
         """
@@ -169,7 +154,7 @@ class Cut(Join):
         ]
         # index array
         list_bk = [range(len(segmntlist))[s[0] : s[1]] for s in slice_pair]
-        array_bk = self.index_array(list_bk)
+        array_bk = np_array_from_lists(list_bk)
 
         return segmntlist, array_bk
 

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -401,7 +401,11 @@ class Extract(object):
             GeoDataFrame or GeoSeries instance
         """
 
-        self.obj = geom.__geo_interface__
+        try:
+            self.obj = geom.__geo_interface__
+        except ValueError as e:
+            raise SystemExit(e)
+
         self.extract_featurecollection(self.obj)
 
     @serialize_geom_type.register(list)

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -117,8 +117,14 @@ class Join(Extract):
                 simplify_factor = self.options.presimplify
 
             data["linestrings"] = simplify(
-                data["linestrings"], simplify_factor, package="shapely"
+                data["linestrings"],
+                simplify_factor,
+                package="shapely",
+                input_as="linestring",
             )
+
+        # compute the bounding box of input geometry
+        data["bbox"] = geometry.asMultiLineString(data["linestrings"]).bounds
 
         # prequantize linestrings if required
         if self.options.prequantize > 0:
@@ -128,8 +134,7 @@ class Join(Extract):
             else:
                 quant_factor = self.options.prequantize
 
-            data["bbox"] = geometry.MultiLineString(data["linestrings"]).bounds
-            data["transform"] = quantize(
+            data["linestrings"], data["transform"] = quantize(
                 data["linestrings"], data["bbox"], quant_factor
             )
 

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -6,7 +6,7 @@ from shapely.ops import linemerge
 from shapely import speedups
 from ..ops import select_unique_combs
 from ..ops import simplify
-from ..ops import prequantize
+from ..ops import quantize
 from ..utils import serialize_as_svg
 import numpy as np
 import itertools
@@ -128,7 +128,10 @@ class Join(Extract):
             else:
                 quant_factor = self.options.prequantize
 
-            data["transform"] = prequantize(data["linestrings"], quant_factor)
+            data["bbox"] = geometry.MultiLineString(data["linestrings"]).bounds
+            data["transform"] = quantize(
+                data["linestrings"], data["bbox"], quant_factor
+            )
 
         if not self.options.topology or not data["linestrings"]:
             data["junctions"] = self.junctions

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -243,6 +243,52 @@ def properties_foreign(objects):
     return objects
 
 
+def np_array_from_lists(nested_lists):
+    """
+    Function to create numpy array from nested lists. The shape of the numpy array 
+    are the number of nested lists (rows) x the length of the longest nested list 
+    (columns). Rows that contain less values are filled with np.nan values.        
+    
+    Parameters
+    ----------
+    nested_lists : list of lists
+        list containing nested lists of different sizes.
+    
+    Returns
+    -------
+    numpy.ndarray
+        array created from nested lists, np.nan is used to fill the array
+    """
+
+    np_array = np.array(list(itertools.zip_longest(*nested_lists, fillvalue=np.nan))).T
+    return np_array
+
+
+def lists_from_np_array(np_array):
+    """
+    Function to convert numpy array to list, where elements set as np.nan 
+    are filtered
+    """
+
+    nested_lists = [obj[~np.isnan(obj)].astype(int).tolist() for obj in np_array]
+    return nested_lists
+
+
+def np_array_from_arcs(arcs):
+    max_len_arc = len(max(arcs, key=len))
+    no_arcs = len(arcs)
+    np_array = np.empty((no_arcs, max_len_arc, 2))
+    np_array.fill(np.nan)
+    for idx in range(no_arcs):
+        np_array[idx, 0 : len(arcs[idx])] = arcs[idx]
+    return np_array
+
+
+def dequantize(np_arcs, scale, translate):
+    dequantized_arcs = np_arcs.cumsum(axis=1) * scale + translate
+    return dequantized_arcs
+
+
 def get_matches(geoms, tree_idx):
     """
     Function to return the indici of the rtree that intersects with the input geometries
@@ -334,11 +380,10 @@ def select_unique_combs(linestrings):
     return uniq_line_combs
 
 
-def prequantize(linestrings, quant_factor=1e6):
+def quantize(linestrings, bbox, quant_factor=1e6):
     """
-    Function that applies quantization prior computing topology. Quantization removes 
-    information by reducing the precision of each coordinate, effectively snapping each 
-    point to a regular grid.
+    Function that applies quantization. Quantization removes information by reducing 
+    the precision of each coordinate, effectively snapping each point to a regular grid.
 
     Parameters
     ----------
@@ -350,19 +395,22 @@ def prequantize(linestrings, quant_factor=1e6):
 
     Returns
     -------
-    kx, ky, x0, y0 : int
-        Scale (kx, ky) and translation (x0, y0) values
-    linestrings : list of shapely.geometry.LineStrings    
-        LineStrings that are quantized 
+    transform : dict
+        scale (kx, ky) and translation (x0, y0) values
+    bbox : array
+        bbox of all linestrings
     """
 
-    x0, y0, x1, y1 = geometry.MultiLineString(linestrings).bounds
+    x0, y0, x1, y1 = bbox
 
     kx = 1 / ((quant_factor - 1) / (x1 - x0))
     ky = 1 / ((quant_factor - 1) / (y1 - y0))
 
-    for ls in linestrings:
-        ls_xy = np.array(ls.xy)
+    for idx, ls in enumerate(linestrings):
+        if hasattr(ls, "xy"):
+            ls_xy = np.array(ls.xy)
+        else:
+            ls_xy = np.array(ls)
         ls_xy = (
             np.array([(ls_xy[0] - x0) / kx, (ls_xy[1] - y0) / ky]).round().astype(int).T
         )
@@ -371,11 +419,14 @@ def prequantize(linestrings, quant_factor=1e6):
             np.insert(np.absolute(np.diff(ls_xy, 1, axis=0)).sum(axis=1), 0, 1) != 0
         )
         if not bool_slice.sum() == 1:
-            ls.coords = ls_xy[bool_slice]
-        # else:
-        #     ls.coords = ls_xy[[0, -1]]
+            if hasattr(ls, "coords"):
+                ls.coords = ls_xy[bool_slice]
+            else:
+                linestrings[idx] = ls_xy[bool_slice].tolist()
 
-    return {"scale": [kx, ky], "translate": [x0, y0]}
+    transform = {"scale": [kx, ky], "translate": [x0, y0]}
+
+    return transform
 
 
 def simplify(linestrings, epsilon, algorithm="dp", package="simplification"):
@@ -417,15 +468,22 @@ def simplify(linestrings, epsilon, algorithm="dp", package="simplification"):
     * https://bost.ocks.org/mike/simplify/
     """
     if package == "shapely":
-        for idx, ls in enumerate(linestrings):
-            linestrings[idx] = ls.simplify(epsilon, preserve_topology=False)
+        list_arcs = []
+        for ls in linestrings:
+            coords_to_simp = ls[~np.isnan(ls)[:, 0]]
+            simple_ls = geometry.LineString(coords_to_simp)
+            simple_ls.simplify(epsilon, preserve_topology=False)
+            list_arcs.append(np.array(simple_ls.coords).tolist())
 
     if package == "simplification":
         from simplification import cutil
 
-        for idx, ls in enumerate(linestrings):
-            linestrings[idx] = cutil.simplify_coords(np.array(ls), epsilon)
-    return linestrings
+        list_arcs = []
+        for ls in linestrings:
+            coords_to_simp = ls[~np.isnan(ls)[:, 0]]
+            simple_ls = cutil.simplify_coords(coords_to_simp, epsilon)
+            list_arcs.append(simple_ls.tolist())
+    return list_arcs
 
 
 def winding_order(geom, order="CW_CCW"):

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -58,7 +58,7 @@ class TopoOptions(object):
         else:
             self.prequantize = False
 
-        if "topquantize" in arguments:
+        if "topoquantize" in arguments:
             self.topoquantize = arguments["topoquantize"]
         else:
             self.topoquantize = False

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -36,8 +36,10 @@ class TopoOptions(object):
         object={},
         topology=True,
         prequantize=False,
+        topoquantize=False,
         presimplify=False,
         toposimplify=False,
+        simplifypackage="simplification",
         winding_order=None,  # default should become "CW_CCW",
     ):
         # get all arguments and check if `object` is created.
@@ -56,6 +58,11 @@ class TopoOptions(object):
         else:
             self.prequantize = False
 
+        if "topquantize" in arguments:
+            self.topoquantize = arguments["topoquantize"]
+        else:
+            self.topoquantize = False
+
         if "presimplify" in arguments:
             self.presimplify = arguments["presimplify"]
         else:
@@ -65,6 +72,11 @@ class TopoOptions(object):
             self.toposimplify = arguments["toposimplify"]
         else:
             self.toposimplify = False
+
+        if "simplifypackage" in arguments:
+            self.simplifypackage = arguments["simplifypackage"]
+        else:
+            self.simplifypackage = "simplification"
 
         if "winding_order" in arguments:
             self.winding_order = arguments["winding_order"]


### PR DESCRIPTION
This PR adds the ability to apply topoquantization (`topoquantize`). Therefor it was necessary to have `bbox` as key in the object.

Also chaining of the `toposimplify()` and `topoquantize()` functions is possible now.

This is coded as follow:


```python
import geopandas
import topojson
```


```python
data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
data = data[(data.continent == "Africa")]
```


```python
tj = topojson.Topology(data, options={'prequantize':1e6, 'topology':True})
tj.toposimplify(2.9).topoquantize(1e4).to_alt()
```


![output_2_0](https://user-images.githubusercontent.com/5186265/62814861-9cbe4a00-bb13-11e9-90ca-eb667aac6a2e.png)


Or interactively using ipywidgets:


```python
from ipywidgets import interact, fixed
import ipywidgets as widgets
```


```python
style = {'description_width': 'initial'}
eps = widgets.FloatSlider(min=0, max=10, step=0.1, value=0, description='Toposimplify Factor', style=style)
qnt = widgets.FloatLogSlider(value=1e6, base=10, min=1,max=6,step=0.5, description='Topoquantize Factor', style=style)

def toposimpquant(epsilon, quant, topo):
    return topo.toposimplify(epsilon).topoquantize(quant).to_alt()

interact(toposimpquant, epsilon=eps, quant=qnt, topo=fixed(tj))
```

Gif output:
![toposimplify_topoquantize](https://user-images.githubusercontent.com/5186265/62814913-f0309800-bb13-11e9-85e8-e4ad6651708f.gif)

 