### PR TITLE
include vw as simplify algorithm including in the widget

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -148,3 +148,29 @@ class TestTopology(unittest.TestCase):
         widget = topo.to_widget()
 
         self.assertEqual(len(widget.widget.children), 3)
+
+    def test_topology_simplification_vw(self):
+        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        data = data[(data.continent == "South America")]
+        topo = topojson.Topology(
+            data,
+            prequantize=False,
+            topology=True,
+            toposimplify=1,
+            simplify_with="simplification",
+            simplify_algorithm="vw",
+        ).to_dict()
+        self.assertEqual(len(topo["arcs"][0]), 4)
+
+    def test_topology_simplification_dp(self):
+        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        data = data[(data.continent == "South America")]
+        topo = topojson.Topology(
+            data,
+            prequantize=False,
+            topology=True,
+            toposimplify=1,
+            simplify_with="simplification",
+            simplify_algorithm="dp",
+        ).to_dict()
+        self.assertEqual(len(topo["arcs"][0]), 3)

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -119,7 +119,8 @@ class Join(Extract):
             data["linestrings"] = simplify(
                 data["linestrings"],
                 simplify_factor,
-                package="shapely",
+                algorithm=self.options.simplify_algorithm,
+                package=self.options.simplify_with,
                 input_as="linestring",
             )
 

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -458,8 +458,8 @@ def simplify(
         Defaults to `dp`, as its evaluation maintains to be good (Song & Miao, 2016).
     package : str, optional
         Choose between `simplification` or `shapely`. Both pachakges contains 
-        simplification algorithms (`shapely` only `rdp`, and `simplification` both `rdp`
-        and `vw` but quicker).
+        simplification algorithms (`shapely` only `dp`, and `simplification` both `dp`
+        and `vw`).
     input_as : str, optional
         Choose between `linestring` or `array`. This function is being called from 
         different locations with different input types. Choose `linestring` if the input
@@ -494,18 +494,31 @@ def simplify(
     elif package == "simplification":
         from simplification import cutil
 
+        if algorithm == "vw":
+            alg = cutil.simplify_coords_vw
+
+        else:
+            alg = cutil.simplify_coords
+
         if input_as == "array":
             list_arcs = []
             for ls in linestrings:
                 coords_to_simp = ls[~np.isnan(ls)[:, 0]]
-                simple_ls = cutil.simplify_coords(coords_to_simp, epsilon)
+                simple_ls = alg(coords_to_simp, epsilon)
                 list_arcs.append(simple_ls.tolist())
         elif input_as == "linestring":
             for ls in linestrings:
                 coords_to_simp = np.array(ls)
-                simple_ls = cutil.simplify_coords(coords_to_simp, epsilon)
+                simple_ls = alg(coords_to_simp, epsilon)
                 ls.coords = simple_ls
             list_arcs = linestrings
+    else:
+        raise NameError(
+            "Could not recognize parameter for `simplify_with`. Choose between \
+                'shapely' or 'simplification'. '{}' was given".format(
+                package
+            )
+        )
     return list_arcs
 
 


### PR DESCRIPTION
The `simplify_algorithm` listens to `vw` for Visvalingam-Whyatt and `dp` for Douglas-Peucker. Defaults to `dp`.
This is now also included in the `to_widget()`.

```python
import geopandas
import topojson

data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
data = data[(data.continent == "North America")]

tj = topojson.Topology(data)
tj.to_widget()
```

See gif:
![ezgif com-resize-2](https://user-images.githubusercontent.com/5186265/62838901-ae722f80-bc82-11e9-911c-d4f786b37e7b.gif)
