### PR TITLE
change all int to np.int64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ ws_topojson.code-workspace
 highres.topojson
 testing.ipynb
 test_geoms.ipynb
+topo.code-workspace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,27 @@
 {
-  "python.unitTest.unittestArgs": ["-v", "-s", "./tests", "-p", "test_*.py"],
-  "python.unitTest.pyTestEnabled": false,
-  "python.unitTest.nosetestsEnabled": false,
-  "python.unitTest.unittestEnabled": true,
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s",
+    "./tests",
+    "-p",
+    "test_*.py"
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.unittestEnabled": true,
   "python.formatting.provider": "black",
-  "python.formatting.blackArgs": ["--line-length", "88", "--py36"],
+  "python.formatting.blackArgs": [
+    "--line-length",
+    "88",
+    "--py36"
+  ],
   "editor.formatOnSave": true,
   "[python]": {
-    "editor.rulers": [88, 120]
+    "editor.rulers": [
+      88,
+      120
+    ]
   },
-  "python.pythonPath": "/usr/local/bin/python3"
+  "python.pythonPath": "C:\\Python37\\python.exe"
+  //"python.pythonPath": "/usr/local/bin/python3"
 }

--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -117,7 +117,9 @@ class Cut(Join):
 
         else:
             bk_array = np_array_from_lists(data["bookkeeping_geoms"]).ravel()
-            bk_array = np.expand_dims(bk_array[~np.isnan(bk_array)].astype(int), axis=1)
+            bk_array = np.expand_dims(
+                bk_array[~np.isnan(bk_array)].astype(np.int64), axis=1
+            )
             self.segments_list = data["linestrings"]
             self.find_duplicates(data["linestrings"])
             self.bookkeeping_linestrings = bk_array

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -85,7 +85,7 @@ class Dedup(Cut):
         del data["bookkeeping_linestrings"]
         data["bookkeeping_arcs"] = lists_from_np_array(array_bk)
         if data["bookkeeping_duplicates"].size != 0:
-            data["bookkeeping_shared_arcs"] = array_bk_sarcs.astype(int).tolist()
+            data["bookkeeping_shared_arcs"] = array_bk_sarcs.astype(np.int64).tolist()
             data["bookkeeping_duplicates"] = lists_from_np_array(
                 data["bookkeeping_duplicates"][dup_pair_list != -99]
             )
@@ -194,7 +194,7 @@ class Dedup(Cut):
 
         for arcs_geom_bk in sliced_array_bk_ndp:
             # set number of arcs before trying linemerge
-            ndp_arcs_bk = arcs_geom_bk[~np.isnan(arcs_geom_bk)].astype(int)
+            ndp_arcs_bk = arcs_geom_bk[~np.isnan(arcs_geom_bk)].astype(np.int64)
             no_ndp_arcs_bk = len(ndp_arcs_bk)
 
             # apply linemerge

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -31,7 +31,7 @@ def asvoid(arr):
         np.array([-0.]).view(np.void) != np.array([0.]).view(np.void)
         Adding 0. converts -0. to 0.
         """
-        arr += 0.
+        arr += 0.0
     return arr.view(np.dtype((np.void, arr.dtype.itemsize * arr.shape[-1])))
 
 
@@ -78,8 +78,8 @@ def insert_coords_in_line(line, tree_splitter):
     tol_float_prc = 1e8
     pts_xy_nonexst = pts_xy_on_line[
         ~np.in1d(
-            asvoid(np.around(pts_xy_on_line * tol_float_prc).astype(int)),
-            asvoid(np.around(ls_xy * tol_float_prc).astype(int)),
+            asvoid(np.around(pts_xy_on_line * tol_float_prc).astype(np.int64)),
+            asvoid(np.around(ls_xy * tol_float_prc).astype(np.int64)),
         )
     ]
     if pts_xy_nonexst.size == 0:
@@ -135,8 +135,8 @@ def fast_split(line, splitter):
     tol = 1e8
     splitter_indices = np.flatnonzero(
         np.in1d(
-            asvoid(np.around(line * tol).astype(int)),
-            asvoid(np.around(splitter * tol).astype(int)),
+            asvoid(np.around(line * tol).astype(np.int64)),
+            asvoid(np.around(splitter * tol).astype(np.int64)),
         )
     )
 
@@ -148,7 +148,7 @@ def fast_split(line, splitter):
 
     # split the linestring where each sub-array includes the split-point
     # create a new array with the index elements repeated
-    tmp_indices = np.zeros(line.shape[0], dtype=int)
+    tmp_indices = np.zeros(line.shape[0], dtype=np.int64)
     tmp_indices[splitter_indices] = 1
     tmp_indices += 1
     ls_xy = np.repeat(line, tmp_indices, axis=0)
@@ -270,7 +270,7 @@ def lists_from_np_array(np_array):
     are filtered
     """
 
-    nested_lists = [obj[~np.isnan(obj)].astype(int).tolist() for obj in np_array]
+    nested_lists = [obj[~np.isnan(obj)].astype(np.int64).tolist() for obj in np_array]
     return nested_lists
 
 
@@ -412,7 +412,10 @@ def quantize(linestrings, bbox, quant_factor=1e6):
         else:
             ls_xy = np.array(ls).T
         ls_xy = (
-            np.array([(ls_xy[0] - x0) / kx, (ls_xy[1] - y0) / ky]).round().astype(int).T
+            np.array([(ls_xy[0] - x0) / kx, (ls_xy[1] - y0) / ky])
+            .round()
+            .astype(np.int64)
+            .T
         )
         # get boolean slice where consecutive repeating coordinates are filtered
         bool_slice = (
@@ -649,7 +652,7 @@ def delta_encoding(linestrings):
     """
 
     for idx, ls in enumerate(linestrings):
-        ls = np.array(ls).astype(int)
+        ls = np.array(ls).astype(np.int64)
         ls_p1 = copy.copy(ls[0])
         ls -= np.roll(ls, 1, axis=0)
         ls[0] = ls_p1


### PR DESCRIPTION
Apparently on Windows the `astype(int)` defaults to `int32` where it defaults on macOS to `int64`. 
This PR change all `astype(int)` to `astype(np.int64)` which will make all the tests pass on Windows too.