### PR TITLE
FIX: popping of contiguous line-elements was too rigorous

### DIFF
--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -158,7 +158,7 @@ class TestDedup(unittest.TestCase):
         )
 
     # this test was added since there is an error stating the following during Dedup:
-    # TypeError: list indices must be integers or slices, not NoneType
+    # TypeError: list indices must be integers or slices, not NoneType, see #50
     def test_s2_geometries(self):
         data = [
             wkt.loads(

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -94,7 +94,7 @@ class TestHasmap(unittest.TestCase):
             | (data.name == "Zambia")
         ]
         topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 15)
+        self.assertEqual(len(topo["linestrings"]), 17)
 
     def test_super_function_hashmap(self):
         data = geometry.GeometryCollection(


### PR DESCRIPTION
There was one more test I changed in https://github.com/mattijn/topojson/pull/51 because it gave different results.
Upon better looking, I'd to conclude that https://github.com/mattijn/topojson/pull/51 was to rigorous.

Current assumption, until its proven wrong: the first and last arc can be contiguous line-elements, in this case only 1 arc is poped. OR all the arcs are contigous in the given geometry and all arcs minus 1 are popped.
Introduced wrong behavior did pop all arcs minus 1 even only 1 arc should be popped.