### PR TITLE
Migrate tests to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: pip
 python:
   - "3.6"
   - "3.7"
-  - "3.8-dev"
 dist: xenial
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: pip
 python:
   - "3.6"
   - "3.7"
-  - "3.7-dev"
+  - "3.8-dev"
 dist: xenial
 
 jobs:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,9 @@
 {
-  "python.testing.unittestArgs": ["-v", "-s", "./tests", "-p", "test_*.py"],
-  "python.testing.pytestEnabled": false,
-  "python.testing.nosetestsEnabled": false,
-  "python.testing.unittestEnabled": true,
   "python.formatting.blackArgs": ["--line-length", "88", "--py36"],
   "editor.formatOnSave": true,
   "[python]": {
     "editor.rulers": [88, 120]
   },
-  "python.pythonPath": "/usr/local/bin/python3"
+  "python.pythonPath": "/usr/local/bin/python3",
+  "python.formatting.provider": "black"
 }

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,228 +1,219 @@
-import unittest
 import topojson
 import geopandas
 from shapely import geometry
 from topojson.core.cut import Cut
 
 
-class TestCut(unittest.TestCase):
-    # cut exact duplicate lines ABC & ABC have no cuts
-    def test_exact_duplicate_lines_ABC_ABC_no_cuts(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "abc2": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
+# cut exact duplicate lines ABC & ABC have no cuts
+def test_exact_duplicate_lines_ABC_ABC_no_cuts(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abc2": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    }
+    topo = Cut(data).to_dict()
 
-    # cut reversed duplicate lines ABC & CBA have no cuts
-    def test_reversed_duplicate_lines_ABC_CBA_no_cuts(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
-    # cut exact duplicate rings ABCA & ABCA have no cuts
-    def test_exact_duplicate_rings_ABCA_ABCA_no_cuts(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-            },
-            "abca2": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
 
-    # cut reversed rings ABCA & ACBA have no cuts
-    def test_reversed_rings_ABCA_ACBA_no_cuts(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-            },
-            "acba": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [2, 1], [1, 0], [0, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
+# cut reversed duplicate lines ABC & CBA have no cuts
+def test_reversed_duplicate_lines_ABC_CBA_no_cuts(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+    }
+    topo = Cut(data).to_dict()
 
-    # cut rotated duplicate rings BCAB & ABCA have no cuts
-    def test_rotated_duplicates_rings_BCAB_ABCA_no_cuts(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-            },
-            "bcab": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
-    # cut ring ABCA & line ABCA have no cuts
-    def test_ring_ABCA_line_ABCA_no_cuts(self):
-        data = {
-            "abcaLine": {
-                "type": "Linestring",
-                "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
-            },
-            "abcaPolygon": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
 
-    # cut ring BCAB & line ABCA have no cuts
-    def test_ring_BCAB_line_ABCA_no_cuts(self):
-        data = {
-            "abcaLine": {
-                "type": "Linestring",
-                "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
-            },
-            "bcabPolygon": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
+# cut exact duplicate rings ABCA & ABCA have no cuts
+def test_exact_duplicate_rings_ABCA_ABCA_no_cuts(self):
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+    }
+    topo = Cut(data).to_dict()
 
-    # cut ring ABCA & line BCAB have no cuts
-    def test_ring_ABCA_line_BCAB_no_cuts(self):
-        data = {
-            "bcabLine": {
-                "type": "Linestring",
-                "coordinates": [[1, 0], [2, 1], [0, 0], [1, 0]],
-            },
-            "abcaPolygon": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["junctions"]), 0)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[1, 0]])
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
-    # overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB
-    def test_overlapping_rings_are_cut(self):
-        data = {
-            "abcda": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },  # rotated to BCDAB, cut BC-CDAB
-            "befcb": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
-            },
-        }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(topo["bookkeeping_linestrings"].size, 6)
-        self.assertSequenceEqual(topo["bookkeeping_duplicates"].tolist(), [[4, 1]])
 
-    # currently the border between Sudan and Eqypt is not recognized as duplicate
-    # because of floating-precision. Should be solved by a "snap_to_grid" option.
-    def test_to_cut_border_egypt_sudan(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Egypt") | (data.name == "Sudan")]
-        topo = Cut(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_duplicates"].tolist()), 1)
+# cut reversed rings ABCA & ACBA have no cuts
+def test_reversed_rings_ABCA_ACBA_no_cuts(self):
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 1], [1, 0], [0, 0]]]},
+    }
+    topo = Cut(data).to_dict()
 
-    def test_nybb_fast_split(self):
-        nybb_path = geopandas.datasets.get_path("nybb")
-        data = geopandas.read_file(nybb_path)
-        data.set_index("BoroCode", inplace=True)
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
-        topo = Cut(data).to_dict()
-        self.assertEqual(topo["bookkeeping_linestrings"].size, 5618)
 
-    # this test was added since the fast_split was really slow on geometries
-    # when there are many junctions in the geometry. During debugging this test ran
-    # eventually 8x more quick.
-    def test_many_junctions(self):
-        data = geopandas.read_file(
-            "tests/files_geojson/mesh2d.geojson", driver="GeoJSON"
-        )
-        # previous test ran in 8.798s (best of 3)
-        # current test ran in 8.182s (best of 3)
-        topo = Cut(data).to_dict()
-        self.assertEqual(topo["bookkeeping_linestrings"].size, 11010)
+# cut rotated duplicate rings BCAB & ABCA have no cuts
+def test_rotated_duplicates_rings_BCAB_ABCA_no_cuts(self):
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]]},
+    }
+    topo = Cut(data).to_dict()
 
-    def test_super_function_cut(self):
-        data = geometry.GeometryCollection(
-            [
-                geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
-                geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
-            ]
-        )
-        topo = Cut(data).to_dict()
-        self.assertEqual(
-            list(topo.keys()),
-            [
-                "type",
-                "linestrings",
-                "bookkeeping_geoms",
-                "objects",
-                "options",
-                "bbox",
-                "junctions",
-                "bookkeeping_duplicates",
-                "bookkeeping_linestrings",
-            ],
-        )
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
-    # this geometry is added on several classes (extract and hashmap). Not yet clear in
-    # which phase it is going wrong
-    def test_cut_geomcol_multipolygon_polygon(self):
-        data = {
-            "foo": {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {
-                        "type": "MultiPolygon",
-                        "coordinates": [
-                            [
-                                [[10, 20], [20, 0], [0, 0], [10, 20]],
-                                [[3, 2], [10, 16], [17, 2], [3, 2]],
-                            ],
-                            [[[6, 4], [14, 4], [10, 12], [6, 4]]],
+
+# cut ring ABCA & line ABCA have no cuts
+def test_ring_ABCA_line_ABCA_no_cuts(self):
+    data = {
+        "abcaLine": {
+            "type": "Linestring",
+            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut ring BCAB & line ABCA have no cuts
+def test_ring_BCAB_line_ABCA_no_cuts(self):
+    data = {
+        "abcaLine": {
+            "type": "Linestring",
+            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
+        },
+        "bcabPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut ring ABCA & line BCAB have no cuts
+def test_ring_ABCA_line_BCAB_no_cuts(self):
+    data = {
+        "bcabLine": {
+            "type": "Linestring",
+            "coordinates": [[1, 0], [2, 1], [0, 0], [1, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB
+def test_overlapping_rings_are_cut(self):
+    data = {
+        "abcda": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },  # rotated to BCDAB, cut BC-CDAB
+        "befcb": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert topo["bookkeeping_linestrings"].size == 6
+    assert topo["bookkeeping_duplicates"].tolist() == [[4, 1]]
+
+
+# currently the border between Sudan and Eqypt is not recognized as duplicate
+# because of floating-precision. Should be solved by a "snap_to_grid" option.
+def test_to_cut_border_egypt_sudan(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Egypt") | (data.name == "Sudan")]
+    topo = Cut(data).to_dict()
+
+    assert len(topo["bookkeeping_duplicates"].tolist()) == 1
+
+
+def test_nybb_fast_split(self):
+    nybb_path = geopandas.datasets.get_path("nybb")
+    data = geopandas.read_file(nybb_path)
+    data.set_index("BoroCode", inplace=True)
+    topo = Cut(data).to_dict()
+
+    assert topo["bookkeeping_linestrings"].size == 5618
+
+
+# this test was added since the fast_split was really slow on geometries
+# when there are many junctions in the geometry. During debugging this test ran
+# eventually 8x more quick.
+def test_many_junctions(self):
+    data = geopandas.read_file("tests/files_geojson/mesh2d.geojson", driver="GeoJSON")
+    # previous test ran in 8.798s (best of 3)
+    # current test ran in 8.182s (best of 3)
+    topo = Cut(data).to_dict()
+
+    assert topo["bookkeeping_linestrings"].size == 11010
+
+
+def test_super_function_cut(self):
+    data = geometry.GeometryCollection(
+        [
+            geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+            geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
+        ]
+    )
+    topo = Cut(data).to_dict()
+
+    assert list(topo.keys()) == [
+        "type",
+        "linestrings",
+        "bookkeeping_geoms",
+        "objects",
+        "options",
+        "bbox",
+        "junctions",
+        "bookkeeping_duplicates",
+        "bookkeeping_linestrings",
+    ]
+
+
+# this geometry is added on several classes (extract and hashmap). Not yet clear in
+# which phase it is going wrong
+def test_cut_geomcol_multipolygon_polygon(self):
+    data = {
+        "foo": {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [
+                            [[10, 20], [20, 0], [0, 0], [10, 20]],
+                            [[3, 2], [10, 16], [17, 2], [3, 2]],
                         ],
-                    },
-                    {
-                        "type": "Polygon",
-                        "coordinates": [[[20, 0], [35, 5], [10, 20], [20, 0]]],
-                    },
-                ],
-            }
+                        [[[6, 4], [14, 4], [10, 12], [6, 4]]],
+                    ],
+                },
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[20, 0], [35, 5], [10, 20], [20, 0]]],
+                },
+            ],
         }
-        topo = Cut(data).to_dict()
-        # print(topo)
-        self.assertEqual(topo["bookkeeping_linestrings"].size, 8)
+    }
+    topo = Cut(data).to_dict()
+
+    assert topo["bookkeeping_linestrings"].size == 8
 

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -5,7 +5,7 @@ from topojson.core.cut import Cut
 
 
 # cut exact duplicate lines ABC & ABC have no cuts
-def test_exact_duplicate_lines_ABC_ABC_no_cuts(self):
+def test_exact_duplicate_lines_ABC_ABC_no_cuts():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "abc2": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
@@ -17,7 +17,7 @@ def test_exact_duplicate_lines_ABC_ABC_no_cuts(self):
 
 
 # cut reversed duplicate lines ABC & CBA have no cuts
-def test_reversed_duplicate_lines_ABC_CBA_no_cuts(self):
+def test_reversed_duplicate_lines_ABC_CBA_no_cuts():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
@@ -29,7 +29,7 @@ def test_reversed_duplicate_lines_ABC_CBA_no_cuts(self):
 
 
 # cut exact duplicate rings ABCA & ABCA have no cuts
-def test_exact_duplicate_rings_ABCA_ABCA_no_cuts(self):
+def test_exact_duplicate_rings_ABCA_ABCA_no_cuts():
     data = {
         "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
         "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
@@ -41,7 +41,7 @@ def test_exact_duplicate_rings_ABCA_ABCA_no_cuts(self):
 
 
 # cut reversed rings ABCA & ACBA have no cuts
-def test_reversed_rings_ABCA_ACBA_no_cuts(self):
+def test_reversed_rings_ABCA_ACBA_no_cuts():
     data = {
         "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
         "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 1], [1, 0], [0, 0]]]},
@@ -53,7 +53,7 @@ def test_reversed_rings_ABCA_ACBA_no_cuts(self):
 
 
 # cut rotated duplicate rings BCAB & ABCA have no cuts
-def test_rotated_duplicates_rings_BCAB_ABCA_no_cuts(self):
+def test_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
     data = {
         "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
         "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]]},
@@ -65,7 +65,7 @@ def test_rotated_duplicates_rings_BCAB_ABCA_no_cuts(self):
 
 
 # cut ring ABCA & line ABCA have no cuts
-def test_ring_ABCA_line_ABCA_no_cuts(self):
+def test_ring_ABCA_line_ABCA_no_cuts():
     data = {
         "abcaLine": {
             "type": "Linestring",
@@ -83,7 +83,7 @@ def test_ring_ABCA_line_ABCA_no_cuts(self):
 
 
 # cut ring BCAB & line ABCA have no cuts
-def test_ring_BCAB_line_ABCA_no_cuts(self):
+def test_ring_BCAB_line_ABCA_no_cuts():
     data = {
         "abcaLine": {
             "type": "Linestring",
@@ -101,7 +101,7 @@ def test_ring_BCAB_line_ABCA_no_cuts(self):
 
 
 # cut ring ABCA & line BCAB have no cuts
-def test_ring_ABCA_line_BCAB_no_cuts(self):
+def test_ring_ABCA_line_BCAB_no_cuts():
     data = {
         "bcabLine": {
             "type": "Linestring",
@@ -119,7 +119,7 @@ def test_ring_ABCA_line_BCAB_no_cuts(self):
 
 
 # overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB
-def test_overlapping_rings_are_cut(self):
+def test_overlapping_rings_are_cut():
     data = {
         "abcda": {
             "type": "Polygon",
@@ -138,7 +138,7 @@ def test_overlapping_rings_are_cut(self):
 
 # currently the border between Sudan and Eqypt is not recognized as duplicate
 # because of floating-precision. Should be solved by a "snap_to_grid" option.
-def test_to_cut_border_egypt_sudan(self):
+def test_to_cut_border_egypt_sudan():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[(data.name == "Egypt") | (data.name == "Sudan")]
     topo = Cut(data).to_dict()
@@ -146,7 +146,7 @@ def test_to_cut_border_egypt_sudan(self):
     assert len(topo["bookkeeping_duplicates"].tolist()) == 1
 
 
-def test_nybb_fast_split(self):
+def test_nybb_fast_split():
     nybb_path = geopandas.datasets.get_path("nybb")
     data = geopandas.read_file(nybb_path)
     data.set_index("BoroCode", inplace=True)
@@ -158,7 +158,7 @@ def test_nybb_fast_split(self):
 # this test was added since the fast_split was really slow on geometries
 # when there are many junctions in the geometry. During debugging this test ran
 # eventually 8x more quick.
-def test_many_junctions(self):
+def test_many_junctions():
     data = geopandas.read_file("tests/files_geojson/mesh2d.geojson", driver="GeoJSON")
     # previous test ran in 8.798s (best of 3)
     # current test ran in 8.182s (best of 3)
@@ -167,7 +167,7 @@ def test_many_junctions(self):
     assert topo["bookkeeping_linestrings"].size == 11010
 
 
-def test_super_function_cut(self):
+def test_super_function_cut():
     data = geometry.GeometryCollection(
         [
             geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
@@ -191,7 +191,7 @@ def test_super_function_cut(self):
 
 # this geometry is added on several classes (extract and hashmap). Not yet clear in
 # which phase it is going wrong
-def test_cut_geomcol_multipolygon_polygon(self):
+def test_cut_geomcol_multipolygon_polygon():
     data = {
         "foo": {
             "type": "GeometryCollection",

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -6,7 +6,7 @@ from topojson.core.dedup import Dedup
 
 
 # duplicate rotated geometry bar with hole interior in geometry foo
-def test_duplicate_rotated_hole_interior(self):
+def test_duplicate_rotated_hole_interior():
     data = {
         "foo": {
             "type": "MultiPolygon",
@@ -29,7 +29,7 @@ def test_duplicate_rotated_hole_interior(self):
     assert topo["bookkeeping_geoms"] == [[0, 1], [2], [3]]
 
 
-def test_two_polygon_reversed_shared_arc(self):
+def test_two_polygon_reversed_shared_arc():
     data = {
         "abcda": {
             "type": "Polygon",
@@ -47,7 +47,7 @@ def test_two_polygon_reversed_shared_arc(self):
     assert topo["bookkeeping_arcs"] == [[2, 0], [1, 2]]
 
 
-def test_duplicate_polygon_no_junctions(self):
+def test_duplicate_polygon_no_junctions():
     data = {
         "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
         "acba": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]]},
@@ -60,7 +60,7 @@ def test_duplicate_polygon_no_junctions(self):
     assert topo["bookkeeping_geoms"] == [[0], [1]]
 
 
-def test_shared_line_ABCDBE_and_FBCG(self):
+def test_shared_line_ABCDBE_and_FBCG():
     data = {
         "abcdbe": {
             "type": "LineString",
@@ -77,7 +77,7 @@ def test_shared_line_ABCDBE_and_FBCG(self):
 
 # this test was added since the shared_arcs bookkeeping is not doing well. Next runs
 # can affect previous runs where dup_pair_list should update properly.
-def test_shared_junctions_in_shared_paths(self):
+def test_shared_junctions_in_shared_paths():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Togo") | (data.name == "Benin") | (data.name == "Burkina Faso")
@@ -92,7 +92,7 @@ def test_shared_junctions_in_shared_paths(self):
 # wrong arc gots deleted. How come?
 # the problem arose in wrongly linemerging of contigiuous line-elements
 # merged linestring is not always placed upfront.
-def test_arc_not_shared_arcs_got_deleted(self):
+def test_arc_not_shared_arcs_got_deleted():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Botswana")
@@ -109,7 +109,7 @@ def test_arc_not_shared_arcs_got_deleted(self):
 
 # this test was added since there is no test for non-intersecting geometries.
 # as was raised in https://github.com/mattijn/topojson/issues/1
-def test_no_shared_paths_in_geoms(self):
+def test_no_shared_paths_in_geoms():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[(data.name == "Togo") | (data.name == "Liberia")]
     topo = Dedup(data).to_dict()
@@ -121,7 +121,7 @@ def test_no_shared_paths_in_geoms(self):
 # this test was added since the local variable "array_bk_sarcs" was
 # referenced before assignment. As was raised in:
 # https://github.com/mattijn/topojson/issues/3
-def test_array_bk_sarcs_reference(self):
+def test_array_bk_sarcs_reference():
     data = {
         "foo": {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
         "bar": {
@@ -135,7 +135,7 @@ def test_array_bk_sarcs_reference(self):
     assert len(topo["junctions"]) == 4
 
 
-def test_super_function_dedup(self):
+def test_super_function_dedup():
     data = geometry.GeometryCollection(
         [
             geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
@@ -160,7 +160,7 @@ def test_super_function_dedup(self):
 
 # this test was added since there is an error stating the following during Dedup:
 # TypeError: list indices must be integers or slices, not NoneType, see #50
-def test_s2_geometries(self):
+def test_s2_geometries():
     data = [
         wkt.loads(
             "MULTILINESTRING ((-51.17176115208171 -30.05269620283153, -51.18859500873385 -29.99305326146263, -51.1541142383379 -29.95234110496228, -51.13731737261026 -30.01193511071039, -51.17176115208171 -30.05269620283153), (-51.13731737261026 -30.01193511071039, -51.1541142383379 -29.95234110496228, -51.11963364027719 -29.91170657721793, -51.10287369862932 -29.97125162042611, -51.13731737261026 -30.01193511071039), (-51.13799328025614 -30.17188406207867, -51.17176115208171 -30.05269620283153, -51.10287369862932 -29.97125162042611, -51.06925390117097 -30.09024489967364, -51.13799328025614 -30.17188406207867), (-51.06925390117097 -30.09024489967364, -51.0860804353923 -30.03076444145886, -51.05167386668366 -29.99010960397871, -51.03488427131447 -30.04954147652281, -51.06925390117097 -30.09024489967364), (-51.0860804353923 -30.03076444145886, -51.10287369862932 -29.97125162042611, -51.0684302317277 -29.9306455702365, -51.05167386668366 -29.99010960397871, -51.0860804353923 -30.03076444145886))"

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,4 +1,3 @@
-import unittest
 import topojson
 import geopandas
 from shapely import geometry
@@ -6,166 +5,169 @@ from shapely import wkt
 from topojson.core.dedup import Dedup
 
 
-class TestDedup(unittest.TestCase):
-    # duplicate rotated geometry bar with hole interior in geometry foo
-    def test_duplicate_rotated_hole_interior(self):
-        data = {
-            "foo": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [[0, 0], [20, 0], [10, 20], [0, 0]],  # CCW
-                        [[3, 2], [10, 16], [17, 2], [3, 2]],  # CW
-                    ],
-                    [[[6, 4], [14, 4], [10, 12], [6, 4]]],  # CCW
+# duplicate rotated geometry bar with hole interior in geometry foo
+def test_duplicate_rotated_hole_interior(self):
+    data = {
+        "foo": {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [
+                    [[0, 0], [20, 0], [10, 20], [0, 0]],  # CCW
+                    [[3, 2], [10, 16], [17, 2], [3, 2]],  # CW
                 ],
-            },
-            "bar": {
-                "type": "Polygon",
-                "coordinates": [[[17, 2], [3, 2], [10, 16], [17, 2]]],
-            },
-        }
-        topo = Dedup(data).to_dict()
-        # print(topo)
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-        self.assertEqual(topo["bookkeeping_geoms"], [[0, 1], [2], [3]])
-
-    def test_two_polygon_reversed_shared_arc(self):
-        data = {
-            "abcda": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },  # rotated to BCDAB, cut BC-CDAB
-            "befcb": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
-            },
-        }
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-        self.assertEqual(topo["bookkeeping_shared_arcs"], [2])
-        self.assertEqual(topo["bookkeeping_arcs"], [[2, 0], [1, 2]])
-
-    def test_duplicate_polygon_no_junctions(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "acba": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]],
-            },
-        }
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-        self.assertEqual(topo["bookkeeping_shared_arcs"], [0])
-        self.assertEqual(topo["bookkeeping_arcs"], [[0], [0]])
-        self.assertEqual(topo["bookkeeping_geoms"], [[0], [1]])
-
-    def test_shared_line_ABCDBE_and_FBCG(self):
-        data = {
-            "abcdbe": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
-            },
-            "fbcg": {
-                "type": "LineString",
-                "coordinates": [[0, 1], [1, 0], [2, 0], [3, 1]],
-            },
-        }
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-        self.assertEqual(topo["bookkeeping_shared_arcs"], [4])
-        self.assertEqual(topo["bookkeeping_arcs"], [[0, 4, 1, 2], [3, 4, 5]])
-
-    # this test was added since the shared_arcs bookkeeping is not doing well. Next runs
-    # can affect previous runs where dup_pair_list should update properly.
-    def test_shared_junctions_in_shared_paths(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Togo")
-            | (data.name == "Benin")
-            | (data.name == "Burkina Faso")
-        ]
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_shared_arcs"]), 3)
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-
-    # this test was added since the shared_arcs bookkeeping is doing well, but the
-    # wrong arc gots deleted. How come?
-    # the problem arose in wrongly linemerging of contigiuous line-elements
-    # merged linestring is not always placed upfront.
-    def test_arc_not_shared_arcs_got_deleted(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Botswana")
-            | (data.name == "South Africa")
-            | (data.name == "Zimbabwe")
-            | (data.name == "Mozambique")
-            | (data.name == "Zambia")
-        ]
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_shared_arcs"]), 9)
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-
-    # this test was added since there is no test for non-intersecting geometries.
-    # as was raised in https://github.com/mattijn/topojson/issues/1
-    def test_no_shared_paths_in_geoms(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Togo") | (data.name == "Liberia")]
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_shared_arcs"]), 0)
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
-
-    # this test was added since the local variable "array_bk_sarcs" was
-    # referenced before assignment. As was raised in:
-    # https://github.com/mattijn/topojson/issues/3
-    def test_array_bk_sarcs_reference(self):
-        data = {
-            "foo": {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
-            "bar": {
-                "type": "LineString",
-                "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]],
-            },
-        }
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_shared_arcs"]), 1)
-        self.assertEqual(len(topo["junctions"]), 4)
-
-    def test_super_function_dedup(self):
-        data = geometry.GeometryCollection(
-            [
-                geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
-                geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
-            ]
-        )
-        topo = Dedup(data).to_dict()
-        self.assertEqual(
-            list(topo.keys()),
-            [
-                "type",
-                "linestrings",
-                "bookkeeping_geoms",
-                "objects",
-                "options",
-                "bbox",
-                "junctions",
-                "bookkeeping_duplicates",
-                "bookkeeping_arcs",
-                "bookkeeping_shared_arcs",
+                [[[6, 4], [14, 4], [10, 12], [6, 4]]],  # CCW
             ],
-        )
+        },
+        "bar": {
+            "type": "Polygon",
+            "coordinates": [[[17, 2], [3, 2], [10, 16], [17, 2]]],
+        },
+    }
+    topo = Dedup(data).to_dict()
 
-    # this test was added since there is an error stating the following during Dedup:
-    # TypeError: list indices must be integers or slices, not NoneType, see #50
-    def test_s2_geometries(self):
-        data = [
-            wkt.loads(
-                "MULTILINESTRING ((-51.17176115208171 -30.05269620283153, -51.18859500873385 -29.99305326146263, -51.1541142383379 -29.95234110496228, -51.13731737261026 -30.01193511071039, -51.17176115208171 -30.05269620283153), (-51.13731737261026 -30.01193511071039, -51.1541142383379 -29.95234110496228, -51.11963364027719 -29.91170657721793, -51.10287369862932 -29.97125162042611, -51.13731737261026 -30.01193511071039), (-51.13799328025614 -30.17188406207867, -51.17176115208171 -30.05269620283153, -51.10287369862932 -29.97125162042611, -51.06925390117097 -30.09024489967364, -51.13799328025614 -30.17188406207867), (-51.06925390117097 -30.09024489967364, -51.0860804353923 -30.03076444145886, -51.05167386668366 -29.99010960397871, -51.03488427131447 -30.04954147652281, -51.06925390117097 -30.09024489967364), (-51.0860804353923 -30.03076444145886, -51.10287369862932 -29.97125162042611, -51.0684302317277 -29.9306455702365, -51.05167386668366 -29.99010960397871, -51.0860804353923 -30.03076444145886))"
-            )
+    assert len(topo["bookkeeping_duplicates"]) == 0
+    assert topo["bookkeeping_geoms"] == [[0, 1], [2], [3]]
+
+
+def test_two_polygon_reversed_shared_arc(self):
+    data = {
+        "abcda": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },  # rotated to BCDAB, cut BC-CDAB
+        "befcb": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
+        },
+    }
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_duplicates"]) == 0
+    assert topo["bookkeeping_shared_arcs"] == [2]
+    assert topo["bookkeeping_arcs"] == [[2, 0], [1, 2]]
+
+
+def test_duplicate_polygon_no_junctions(self):
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]]},
+    }
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_duplicates"]) == 0
+    assert topo["bookkeeping_shared_arcs"] == [0]
+    assert topo["bookkeeping_arcs"] == [[0], [0]]
+    assert topo["bookkeeping_geoms"] == [[0], [1]]
+
+
+def test_shared_line_ABCDBE_and_FBCG(self):
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
+        },
+        "fbcg": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 0], [3, 1]]},
+    }
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_duplicates"]) == 0
+    assert topo["bookkeeping_shared_arcs"] == [4]
+    assert topo["bookkeeping_arcs"] == [[0, 4, 1, 2], [3, 4, 5]]
+
+
+# this test was added since the shared_arcs bookkeeping is not doing well. Next runs
+# can affect previous runs where dup_pair_list should update properly.
+def test_shared_junctions_in_shared_paths(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Togo") | (data.name == "Benin") | (data.name == "Burkina Faso")
+    ]
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_shared_arcs"]) == 3
+    assert len(topo["bookkeeping_duplicates"]) == 0
+
+
+# this test was added since the shared_arcs bookkeeping is doing well, but the
+# wrong arc gots deleted. How come?
+# the problem arose in wrongly linemerging of contigiuous line-elements
+# merged linestring is not always placed upfront.
+def test_arc_not_shared_arcs_got_deleted(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Botswana")
+        | (data.name == "South Africa")
+        | (data.name == "Zimbabwe")
+        | (data.name == "Mozambique")
+        | (data.name == "Zambia")
+    ]
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_shared_arcs"]) == 9
+    assert len(topo["bookkeeping_duplicates"]) == 0
+
+
+# this test was added since there is no test for non-intersecting geometries.
+# as was raised in https://github.com/mattijn/topojson/issues/1
+def test_no_shared_paths_in_geoms(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Togo") | (data.name == "Liberia")]
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_shared_arcs"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 0
+
+
+# this test was added since the local variable "array_bk_sarcs" was
+# referenced before assignment. As was raised in:
+# https://github.com/mattijn/topojson/issues/3
+def test_array_bk_sarcs_reference(self):
+    data = {
+        "foo": {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
+        "bar": {
+            "type": "LineString",
+            "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]],
+        },
+    }
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["bookkeeping_shared_arcs"]) == 1
+    assert len(topo["junctions"]) == 4
+
+
+def test_super_function_dedup(self):
+    data = geometry.GeometryCollection(
+        [
+            geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+            geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
         ]
-        topo = Dedup(data).to_dict()
-        self.assertEqual(len(topo["junctions"]), 6)
-        self.assertEqual(len(topo["bookkeeping_duplicates"]), 0)
+    )
+    topo = Dedup(data).to_dict()
+
+    assert list(topo.keys()) == [
+        "type",
+        "linestrings",
+        "bookkeeping_geoms",
+        "objects",
+        "options",
+        "bbox",
+        "junctions",
+        "bookkeeping_duplicates",
+        "bookkeeping_arcs",
+        "bookkeeping_shared_arcs",
+    ]
+
+
+# this test was added since there is an error stating the following during Dedup:
+# TypeError: list indices must be integers or slices, not NoneType, see #50
+def test_s2_geometries(self):
+    data = [
+        wkt.loads(
+            "MULTILINESTRING ((-51.17176115208171 -30.05269620283153, -51.18859500873385 -29.99305326146263, -51.1541142383379 -29.95234110496228, -51.13731737261026 -30.01193511071039, -51.17176115208171 -30.05269620283153), (-51.13731737261026 -30.01193511071039, -51.1541142383379 -29.95234110496228, -51.11963364027719 -29.91170657721793, -51.10287369862932 -29.97125162042611, -51.13731737261026 -30.01193511071039), (-51.13799328025614 -30.17188406207867, -51.17176115208171 -30.05269620283153, -51.10287369862932 -29.97125162042611, -51.06925390117097 -30.09024489967364, -51.13799328025614 -30.17188406207867), (-51.06925390117097 -30.09024489967364, -51.0860804353923 -30.03076444145886, -51.05167386668366 -29.99010960397871, -51.03488427131447 -30.04954147652281, -51.06925390117097 -30.09024489967364), (-51.0860804353923 -30.03076444145886, -51.10287369862932 -29.97125162042611, -51.0684302317277 -29.9306455702365, -51.05167386668366 -29.99010960397871, -51.0860804353923 -30.03076444145886))"
+        )
+    ]
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["junctions"]) == 6
+    assert len(topo["bookkeeping_duplicates"]) == 0
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,272 +1,287 @@
 import json
-import unittest
 from topojson.core.extract import Extract
 from shapely import geometry
 import geopandas
 import geojson
 
 
-class TestExtract(unittest.TestCase):
-    # extract copies coordinates sequentially into a buffer
-    def test_linestring(self):
-        data = {
-            "foo": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "bar": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 2)
+# extract copies coordinates sequentially into a buffer
+def test_linestring(self):
+    data = {
+        "foo": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "bar": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    }
+    topo = Extract(data).to_dict()
 
-    # assess if a multipolygon with hole is processed into the right number of rings
-    def test_multipolygon(self):
-        # multipolygon with hole
-        data = {
-            "foo": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [[0, 0], [20, 0], [10, 20], [0, 0]],  # CCW
-                        [[3, 2], [10, 16], [17, 2], [3, 2]],  # CW
+    assert len(topo["linestrings"]) == 2
+
+
+# assess if a multipolygon with hole is processed into the right number of rings
+def test_multipolygon(self):
+    # multipolygon with hole
+    data = {
+        "foo": {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [
+                    [[0, 0], [20, 0], [10, 20], [0, 0]],  # CCW
+                    [[3, 2], [10, 16], [17, 2], [3, 2]],  # CW
+                ],
+                [[[6, 4], [14, 4], [10, 12], [6, 4]]],  # CCW
+                [[[25, 5], [30, 10], [35, 5], [25, 5]]],
+            ],
+        }
+    }
+    topo = Extract(data).to_dict()
+
+    assert len(topo["bookkeeping_geoms"]) == 3
+    assert len(topo["linestrings"]) == 4
+
+
+# a LineString without coordinates is ke polygon geometry
+def test_empty_linestring(self):
+    data = {"empty_ls": {"type": "LineString", "coordinates": None}}
+    topo = Extract(data).to_dict()
+
+    assert topo["objects"]["empty_ls"]["arcs"] == None
+
+
+# invalid polygon geometry
+def test_invalid_polygon(self):
+    data = {
+        "wrong": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+        "valid": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]]},
+    }
+    topo = Extract(data).to_dict()
+
+    assert len(topo["linestrings"]) == 1
+
+
+# test multiliinestring
+def test_multilinestring(self):
+    data = {
+        "foo": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [[0.0, 0.0], [1, 1], [3, 3]],
+                [[1, 1], [0, 1]],
+                [[3, 3], [4, 4], [0, 1]],
+            ],
+        }
+    }
+    topo = Extract(data).to_dict()
+
+    assert len(topo["linestrings"]) == 3
+
+
+# test nested geojosn geometrycollection collection
+def test_nested_geometrycollection(self):
+    data = {
+        "foo": {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "LineString", "coordinates": [[0.1, 0.2], [0.3, 0.4]]}
                     ],
-                    [[[6, 4], [14, 4], [10, 12], [6, 4]]],  # CCW
-                    [[[25, 5], [30, 10], [35, 5], [25, 5]]],
-                ],
-            }
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["bookkeeping_geoms"]), 3)
-        self.assertEqual(len(topo["linestrings"]), 4)
-
-    # a LineString without coordinates is ke polygon geometry
-    def test_empty_linestring(self):
-        data = {"empty_ls": {"type": "LineString", "coordinates": None}}
-        topo = Extract(data).to_dict()
-        self.assertEqual(topo["objects"]["empty_ls"]["arcs"], None)
-
-    # invalid polygon geometry
-    def test_invalid_polygon(self):
-        data = {
-            "wrong": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [2, 0], [0, 0]]],
-            },
-            "valid": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]],
-            },
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 1)
-
-    # test multiliinestring
-    def test_multilinestring(self):
-        data = {
-            "foo": {
-                "type": "MultiLineString",
-                "coordinates": [
-                    [[0.0, 0.0], [1, 1], [3, 3]],
-                    [[1, 1], [0, 1]],
-                    [[3, 3], [4, 4], [0, 1]],
-                ],
-            }
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 3)
-
-    # test nested geojosn geometrycollection collection
-    def test_nested_geometrycollection(self):
-        data = {
-            "foo": {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {
-                        "type": "GeometryCollection",
-                        "geometries": [
-                            {
-                                "type": "LineString",
-                                "coordinates": [[0.1, 0.2], [0.3, 0.4]],
-                            }
-                        ],
-                    },
-                    {
-                        "type": "Polygon",
-                        "coordinates": [[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]],
-                    },
-                ],
-            }
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(
-            len(topo["objects"]["foo"]["geometries"][0]["geometries"][0]["arcs"]), 1
-        )
-
-    # test geometry collection + polygon
-    def test_geometrycollection_polygon(self):
-        data = {
-            "bar": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0]]]},
-            "foo": {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {"type": "LineString", "coordinates": [[0.1, 0.2], [0.3, 0.4]]}
-                ],
-            },
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 2)
-
-    # test feature type
-    def test_features(self):
-        data = {
-            "foo": {
-                "type": "Feature",
-                "geometry": {"type": "LineString", "coordinates": [[.1, .2], [.3, .4]]},
-            },
-            "bar": {
-                "type": "Feature",
-                "geometry": {
+                },
+                {
                     "type": "Polygon",
                     "coordinates": [[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]],
                 },
+            ],
+        }
+    }
+    topo = Extract(data).to_dict()
+
+    assert len(topo["objects"]["foo"]["geometries"][0]["geometries"][0]["arcs"]) == 1
+
+
+# test geometry collection + polygon
+def test_geometrycollection_polygon(self):
+    data = {
+        "bar": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0]]]},
+        "foo": {
+            "type": "GeometryCollection",
+            "geometries": [
+                {"type": "LineString", "coordinates": [[0.1, 0.2], [0.3, 0.4]]}
+            ],
+        },
+    }
+    topo = Extract(data).to_dict()
+
+    assert len(topo["linestrings"]) == 2
+
+
+# test feature type
+def test_features(self):
+    data = {
+        "foo": {
+            "type": "Feature",
+            "geometry": {"type": "LineString", "coordinates": [[0.1, 0.2], [0.3, 0.4]]},
+        },
+        "bar": {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]],
             },
-        }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 2)
+        },
+    }
+    topo = Extract(data).to_dict()
 
-    # test feature collection including geometry collection
-    def test_featurecollection(self):
-        data = {
-            "collection": {
-                "type": "FeatureCollection",
-                "features": [
-                    {
-                        "type": "Feature",
-                        "geometry": {
-                            "type": "LineString",
-                            "coordinates": [[.1, .2], [.3, .4]],
-                        },
+    assert len(topo["linestrings"]) == 2
+
+
+# test feature collection including geometry collection
+def test_featurecollection(self):
+    data = {
+        "collection": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.1, 0.2], [0.3, 0.4]],
                     },
-                    {
-                        "type": "Feature",
-                        "geometry": {
-                            "type": "GeometryCollection",
-                            "geometries": [
-                                {
-                                    "type": "Polygon",
-                                    "coordinates": [
-                                        [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]
-                                    ],
-                                }
-                            ],
-                        },
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "GeometryCollection",
+                        "geometries": [
+                            {
+                                "type": "Polygon",
+                                "coordinates": [[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]],
+                            }
+                        ],
                     },
-                ],
-            }
+                },
+            ],
         }
-        topo = Extract(data).to_dict()
-        # print(topology)
-        self.assertEqual(len(topo["objects"]), 2)
-        self.assertEqual(len(topo["bookkeeping_geoms"]), 2)
-        self.assertEqual(len(topo["linestrings"]), 2)
-        self.assertEqual(
-            topo["objects"]["feature_0"]["geometries"][0]["type"], "LineString"
-        )
-        self.assertEqual(
-            topo["objects"]["feature_1"]["geometries"][0]["geometries"][0]["type"],
-            "Polygon",
-        )
+    }
+    topo = Extract(data).to_dict()
 
-    # test to parse feature collection from a geojson file through geojson library
-    def test_geojson_feat_col_geom_col(self):
-        with open("tests/files_geojson/feature_collection.geojson") as f:
-            data = geojson.load(f)
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["objects"]), 1)
-        self.assertEqual(len(topo["bookkeeping_geoms"]), 3)
-        self.assertEqual(len(topo["linestrings"]), 3)
+    assert len(topo["objects"]) == 2
+    assert len(topo["bookkeeping_geoms"]) == 2
+    assert len(topo["linestrings"]) == 2
+    assert topo["objects"]["feature_0"]["geometries"][0]["type"] == "LineString"
+    assert (
+        topo["objects"]["feature_1"]["geometries"][0]["geometries"][0]["type"]
+        == "Polygon"
+    )
 
-    # test to parse a feature from a geojson file through geojson library
-    def test_geojson_feature_geom_col(self):
-        with open("tests/files_geojson/feature.geojson") as f:
-            data = geojson.load(f)
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["objects"]), 1)
-        self.assertEqual(len(topo["bookkeeping_geoms"]), 3)
-        self.assertEqual(len(topo["linestrings"]), 3)
 
-    # test feature collection including geometry collection
-    def test_geopandas_geoseries(self):
-        data = geopandas.GeoSeries(
-            [
-                geometry.Polygon([(0, 0), (1, 0), (1, 1)]),
-                geometry.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
-                geometry.Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
-            ]
-        )
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["objects"]), 3)
-        self.assertEqual(len(topo["bookkeeping_geoms"]), 3)
-        self.assertEqual(len(topo["linestrings"]), 3)
-        # TEST FAILS because of https://github.com/geopandas/geopandas/issues/1070
+# test to parse feature collection from a geojson file through geojson library
+def test_geojson_feat_col_geom_col(self):
+    with open("tests/files_geojson/feature_collection.geojson") as f:
+        data = geojson.load(f)
+    topo = Extract(data).to_dict()
 
-    # test shapely geometry collection.
-    def test_shapely_geometrycollection(self):
-        data = geometry.GeometryCollection(
-            [
-                geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
-                geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
-            ]
-        )
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["objects"]), 1)
-        self.assertEqual(len(topo["bookkeeping_geoms"]), 2)
-        self.assertEqual(len(topo["linestrings"]), 2)
+    assert len(topo["objects"]) == 1
+    assert len(topo["bookkeeping_geoms"]) == 3
+    assert len(topo["linestrings"]) == 3
 
-    def test_geo_interface_from_list(self):
-        data = [
-            {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+
+# test to parse a feature from a geojson file through geojson library
+def test_geojson_feature_geom_col(self):
+    with open("tests/files_geojson/feature.geojson") as f:
+        data = geojson.load(f)
+    topo = Extract(data).to_dict()
+
+    assert len(topo["objects"]) == 1
+    assert len(topo["bookkeeping_geoms"]) == 3
+    assert len(topo["linestrings"]) == 3
+
+
+# test feature collection including geometry collection
+def test_geopandas_geoseries(self):
+    data = geopandas.GeoSeries(
+        [
+            geometry.Polygon([(0, 0), (1, 0), (1, 1)]),
+            geometry.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            geometry.Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
         ]
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 2)
+    )
+    topo = Extract(data).to_dict()
 
-    def test_shapely_geo_interface_from_list(self):
-        data = [
+    assert len(topo["objects"]) == 3
+    assert len(topo["bookkeeping_geoms"]) == 3
+    assert len(topo["linestrings"]) == 3
+    # TEST FAILS because of https://github.com/geopandas/geopandas/issues/1070
+
+
+# test shapely geometry collection.
+def test_shapely_geometrycollection(self):
+    data = geometry.GeometryCollection(
+        [
             geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
             geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
         ]
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 2)
-        self.assertEqual(isinstance(topo["objects"][0], dict), True)
+    )
+    topo = Extract(data).to_dict()
 
-    # duplicate rotated geometry bar with hole interior in geometry foo
-    def test_extract_geomcol_multipolygon_polygon(self):
-        data = {
-            "foo": {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {
-                        "type": "MultiPolygon",
-                        "coordinates": [
-                            [
-                                [[10, 20], [20, 0], [0, 0], [3, 13], [10, 20]],
-                                [[3, 2], [10, 16], [17, 2], [3, 2]],
-                            ],
-                            [[[10, 4], [14, 4], [10, 12], [10, 4]]],
+    assert len(topo["objects"]) == 1
+    assert len(topo["bookkeeping_geoms"]) == 2
+    assert len(topo["linestrings"]) == 2
+
+
+def test_geo_interface_from_list(self):
+    data = [
+        {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    ]
+    topo = Extract(data).to_dict()
+
+    assert len(topo["linestrings"]) == 2
+
+
+def test_shapely_geo_interface_from_list(self):
+    data = [
+        geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+        geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
+    ]
+    topo = Extract(data).to_dict()
+
+    assert len(topo["linestrings"]) == 2
+    assert isinstance(topo["objects"][0], dict)
+
+
+# duplicate rotated geometry bar with hole interior in geometry foo
+def test_extract_geomcol_multipolygon_polygon(self):
+    data = {
+        "foo": {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [
+                            [[10, 20], [20, 0], [0, 0], [3, 13], [10, 20]],
+                            [[3, 2], [10, 16], [17, 2], [3, 2]],
                         ],
-                    },
-                    {
-                        "type": "Polygon",
-                        "coordinates": [[[20, 0], [35, 5], [10, 20], [20, 0]]],
-                    },
-                ],
-            }
+                        [[[10, 4], [14, 4], [10, 12], [10, 4]]],
+                    ],
+                },
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[20, 0], [35, 5], [10, 20], [20, 0]]],
+                },
+            ],
         }
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 4)
+    }
+    topo = Extract(data).to_dict()
 
-    def test_extract_geo_interface_shapefile(self):
-        import shapefile
+    assert len(topo["linestrings"]) == 4
 
-        data = shapefile.Reader("tests/files_shapefile/southamerica.shp")
-        topo = Extract(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 15)
+
+def test_extract_geo_interface_shapefile(self):
+    import shapefile
+
+    data = shapefile.Reader("tests/files_shapefile/southamerica.shp")
+    topo = Extract(data).to_dict()
+
+    assert len(topo["linestrings"]) == 15
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -6,7 +6,7 @@ import geojson
 
 
 # extract copies coordinates sequentially into a buffer
-def test_linestring(self):
+def test_linestring():
     data = {
         "foo": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "bar": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
@@ -17,7 +17,7 @@ def test_linestring(self):
 
 
 # assess if a multipolygon with hole is processed into the right number of rings
-def test_multipolygon(self):
+def test_multipolygon():
     # multipolygon with hole
     data = {
         "foo": {
@@ -39,7 +39,7 @@ def test_multipolygon(self):
 
 
 # a LineString without coordinates is ke polygon geometry
-def test_empty_linestring(self):
+def test_empty_linestring():
     data = {"empty_ls": {"type": "LineString", "coordinates": None}}
     topo = Extract(data).to_dict()
 
@@ -47,7 +47,7 @@ def test_empty_linestring(self):
 
 
 # invalid polygon geometry
-def test_invalid_polygon(self):
+def test_invalid_polygon():
     data = {
         "wrong": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
         "valid": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]]},
@@ -58,7 +58,7 @@ def test_invalid_polygon(self):
 
 
 # test multiliinestring
-def test_multilinestring(self):
+def test_multilinestring():
     data = {
         "foo": {
             "type": "MultiLineString",
@@ -75,7 +75,7 @@ def test_multilinestring(self):
 
 
 # test nested geojosn geometrycollection collection
-def test_nested_geometrycollection(self):
+def test_nested_geometrycollection():
     data = {
         "foo": {
             "type": "GeometryCollection",
@@ -99,7 +99,7 @@ def test_nested_geometrycollection(self):
 
 
 # test geometry collection + polygon
-def test_geometrycollection_polygon(self):
+def test_geometrycollection_polygon():
     data = {
         "bar": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0]]]},
         "foo": {
@@ -115,7 +115,7 @@ def test_geometrycollection_polygon(self):
 
 
 # test feature type
-def test_features(self):
+def test_features():
     data = {
         "foo": {
             "type": "Feature",
@@ -135,7 +135,7 @@ def test_features(self):
 
 
 # test feature collection including geometry collection
-def test_featurecollection(self):
+def test_featurecollection():
     data = {
         "collection": {
             "type": "FeatureCollection",
@@ -175,7 +175,7 @@ def test_featurecollection(self):
 
 
 # test to parse feature collection from a geojson file through geojson library
-def test_geojson_feat_col_geom_col(self):
+def test_geojson_feat_col_geom_col():
     with open("tests/files_geojson/feature_collection.geojson") as f:
         data = geojson.load(f)
     topo = Extract(data).to_dict()
@@ -186,7 +186,7 @@ def test_geojson_feat_col_geom_col(self):
 
 
 # test to parse a feature from a geojson file through geojson library
-def test_geojson_feature_geom_col(self):
+def test_geojson_feature_geom_col():
     with open("tests/files_geojson/feature.geojson") as f:
         data = geojson.load(f)
     topo = Extract(data).to_dict()
@@ -197,7 +197,7 @@ def test_geojson_feature_geom_col(self):
 
 
 # test feature collection including geometry collection
-def test_geopandas_geoseries(self):
+def test_geopandas_geoseries():
     data = geopandas.GeoSeries(
         [
             geometry.Polygon([(0, 0), (1, 0), (1, 1)]),
@@ -214,7 +214,7 @@ def test_geopandas_geoseries(self):
 
 
 # test shapely geometry collection.
-def test_shapely_geometrycollection(self):
+def test_shapely_geometrycollection():
     data = geometry.GeometryCollection(
         [
             geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
@@ -228,7 +228,7 @@ def test_shapely_geometrycollection(self):
     assert len(topo["linestrings"]) == 2
 
 
-def test_geo_interface_from_list(self):
+def test_geo_interface_from_list():
     data = [
         {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
@@ -238,7 +238,7 @@ def test_geo_interface_from_list(self):
     assert len(topo["linestrings"]) == 2
 
 
-def test_shapely_geo_interface_from_list(self):
+def test_shapely_geo_interface_from_list():
     data = [
         geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
         geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
@@ -250,7 +250,7 @@ def test_shapely_geo_interface_from_list(self):
 
 
 # duplicate rotated geometry bar with hole interior in geometry foo
-def test_extract_geomcol_multipolygon_polygon(self):
+def test_extract_geomcol_multipolygon_polygon():
     data = {
         "foo": {
             "type": "GeometryCollection",
@@ -277,7 +277,7 @@ def test_extract_geomcol_multipolygon_polygon(self):
     assert len(topo["linestrings"]) == 4
 
 
-def test_extract_geo_interface_shapefile(self):
+def test_extract_geo_interface_shapefile():
     import shapefile
 
     data = shapefile.Reader("tests/files_shapefile/southamerica.shp")

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -1,153 +1,156 @@
-import unittest
 import topojson
 import geopandas
 from shapely import geometry
 from topojson.core.hashmap import Hashmap
 
-
-class TestHasmap(unittest.TestCase):
-    # duplicate rotated geometry bar with hole interior in geometry foo
-    def test_hashmap_geomcol_multipolygon_polygon(self):
-        data = {
-            "foo": {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {
-                        "type": "MultiPolygon",
-                        "coordinates": [
-                            [
-                                [[10, 20], [20, 0], [0, 0], [10, 20]],
-                                [[3, 2], [10, 16], [17, 2], [3, 2]],
-                            ],
-                            [[[6, 4], [14, 4], [10, 12], [6, 4]]],
+# duplicate rotated geometry bar with hole interior in geometry foo
+def test_hashmap_geomcol_multipolygon_polygon(self):
+    data = {
+        "foo": {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [
+                            [[10, 20], [20, 0], [0, 0], [10, 20]],
+                            [[3, 2], [10, 16], [17, 2], [3, 2]],
                         ],
-                    },
-                    {
-                        "type": "Polygon",
-                        "coordinates": [[[20, 0], [35, 5], [10, 20], [20, 0]]],
-                    },
-                ],
-            }
+                        [[[6, 4], [14, 4], [10, 12], [6, 4]]],
+                    ],
+                },
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[20, 0], [35, 5], [10, 20], [20, 0]]],
+                },
+            ],
         }
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(
-            topo["objects"]["data"]["geometries"][0]["geometries"][0]["arcs"],
-            [[[4, 0]], [[1]], [[2]]],
-        )
+    }
+    topo = Hashmap(data).to_dict()
 
-    def test_hashmap_backward_polygon(self):
-        data = {
-            "abc": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },
-            "def": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
-            },
+    assert topo["objects"]["data"]["geometries"][0]["geometries"][0]["arcs"] == [
+        [[4, 0]],
+        [[1]],
+        [[2]],
+    ]
+
+
+def test_hashmap_backward_polygon(self):
+    data = {
+        "abc": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+        "def": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
+        },
+    }
+    topo = Hashmap(data).to_dict()
+
+    assert topo["objects"]["data"]["geometries"][0]["arcs"] == [[-3, 0]]
+    assert topo["objects"]["data"]["geometries"][1]["arcs"] == [[1, 2]]
+
+
+# this test should catch a shared boundary and a hashed multipolgon
+# related to https://github.com/Toblerity/Shapely/issues/535
+def test_albania_greece(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Albania") | (data.name == "Greece")]
+    topo = Hashmap(data).to_dict()
+
+    assert len(topo["linestrings"]) == 4
+
+
+# something is wrong with hashmapping in the example of benin
+def test_benin_surrounding_countries(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Togo") | (data.name == "Benin") | (data.name == "Burkina Faso")
+    ]
+    topo = Hashmap(data).to_dict()
+
+    assert len(topo["linestrings"]) == 6
+
+
+# something is wrong with hashmapping once a geometry has only shared arcs
+def test_geom_surrounding_many_geometries(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Botswana")
+        | (data.name == "South Africa")
+        | (data.name == "Zimbabwe")
+        | (data.name == "Namibia")
+        | (data.name == "Zambia")
+    ]
+    topo = Hashmap(data).to_dict()
+
+    assert len(topo["linestrings"]) == 13
+
+
+# this test was added since the shared_arcs bookkeeping is doing well, but the
+# wrong arc gots deleted. How come?
+def test_shared_arcs_ordering_issues(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Botswana")
+        | (data.name == "South Africa")
+        | (data.name == "Zimbabwe")
+        | (data.name == "Mozambique")
+        | (data.name == "Zambia")
+    ]
+    topo = Hashmap(data).to_dict()
+    assert len(topo["linestrings"]) == 17
+
+
+def test_super_function_hashmap(self):
+    data = geometry.GeometryCollection(
+        [
+            geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+            geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
+        ]
+    )
+    topo = Hashmap(data).to_dict()
+    geoms = topo["objects"]["data"]["geometries"][0]["geometries"]
+
+    assert list(topo.keys()) == ["type", "linestrings", "objects", "options", "bbox"]
+    assert geoms[0]["arcs"] == [[-3, 0]]
+    assert geoms[1]["arcs"] == [[1, 2]]
+
+
+# this test was added since objects with nested geometreycollections seems not
+# being parsed in the topojson format.
+# Pass for now:
+def test_hashing_of_nested_geometrycollection(self):
+    data = {
+        "foo": {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "LineString", "coordinates": [[0.1, 0.2], [0.3, 0.4]]}
+                    ],
+                },
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]],
+                },
+            ],
         }
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(topo["objects"]["data"]["geometries"][0]["arcs"], [[-3, 0]])
-        self.assertEqual(topo["objects"]["data"]["geometries"][1]["arcs"], [[1, 2]])
+    }
+    topo = Hashmap(data).to_dict()
 
-    # this test should catch a shared boundary and a hashed multipolgon
-    # related to https://github.com/Toblerity/Shapely/issues/535
-    def test_albania_greece(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Albania") | (data.name == "Greece")]
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 4)
+    assert topo["objects"]["data"]["type"] == "GeometryCollection"
 
-    # something is wrong with hashmapping in the example of benin
-    def test_benin_surrounding_countries(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Togo")
-            | (data.name == "Benin")
-            | (data.name == "Burkina Faso")
-        ]
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 6)
 
-    # something is wrong with hashmapping once a geometry has only shared arcs
-    def test_geom_surrounding_many_geometries(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Botswana")
-            | (data.name == "South Africa")
-            | (data.name == "Zimbabwe")
-            | (data.name == "Namibia")
-            | (data.name == "Zambia")
-        ]
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 13)
+# this test was added because the winding order is still giving issues.
+# see related issue: https://github.com/mattijn/topojson/issues/30
+def test_winding_order_geom_solely_shared_arcs(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Jordan") | (data.name == "Palestine") | (data.name == "Israel")
+    ]
+    topo = Hashmap(data).to_dict()
 
-    # this test was added since the shared_arcs bookkeeping is doing well, but the
-    # wrong arc gots deleted. How come?
-    def test_shared_arcs_ordering_issues(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Botswana")
-            | (data.name == "South Africa")
-            | (data.name == "Zimbabwe")
-            | (data.name == "Mozambique")
-            | (data.name == "Zambia")
-        ]
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(len(topo["linestrings"]), 17)
-
-    def test_super_function_hashmap(self):
-        data = geometry.GeometryCollection(
-            [
-                geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
-                geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
-            ]
-        )
-        topo = Hashmap(data).to_dict()
-        geoms = topo["objects"]["data"]["geometries"][0]["geometries"]
-        self.assertEqual(
-            list(topo.keys()), ["type", "linestrings", "objects", "options", "bbox"]
-        )
-        self.assertEqual(geoms[0]["arcs"], [[-3, 0]])
-        self.assertEqual(geoms[1]["arcs"], [[1, 2]])
-
-    # this test was added since objects with nested geometreycollections seems not
-    # being parsed in the topojson format.
-    # Pass for now:
-    def test_hashing_of_nested_geometrycollection(self):
-        data = {
-            "foo": {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {
-                        "type": "GeometryCollection",
-                        "geometries": [
-                            {
-                                "type": "LineString",
-                                "coordinates": [[0.1, 0.2], [0.3, 0.4]],
-                            }
-                        ],
-                    },
-                    {
-                        "type": "Polygon",
-                        "coordinates": [[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]],
-                    },
-                ],
-            }
-        }
-        topo = Hashmap(data).to_dict()  # .to_gdf()
-        self.assertEqual(topo["objects"]["data"]["type"], "GeometryCollection")
-        # topo = Hashmap(data).to_gdf()
-        # self.assertNotEqual(topo["geometry"][0].wkt, "GEOMETRYCOLLECTION EMPTY")
-
-    # this test was added because the winding order is still giving issues.
-    # see related issue: https://github.com/mattijn/topojson/issues/30
-    def test_winding_order_geom_solely_shared_arcs(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Jordan")
-            | (data.name == "Palestine")
-            | (data.name == "Israel")
-        ]
-        topo = Hashmap(data).to_dict()
-        self.assertEqual(topo["objects"]["data"]["geometries"][1]["arcs"], [[1, -6]])
+    assert topo["objects"]["data"]["geometries"][1]["arcs"] == [[1, -6]]

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -4,7 +4,7 @@ from shapely import geometry
 from topojson.core.hashmap import Hashmap
 
 # duplicate rotated geometry bar with hole interior in geometry foo
-def test_hashmap_geomcol_multipolygon_polygon(self):
+def test_hashmap_geomcol_multipolygon_polygon():
     data = {
         "foo": {
             "type": "GeometryCollection",
@@ -35,7 +35,7 @@ def test_hashmap_geomcol_multipolygon_polygon(self):
     ]
 
 
-def test_hashmap_backward_polygon(self):
+def test_hashmap_backward_polygon():
     data = {
         "abc": {
             "type": "Polygon",
@@ -54,7 +54,7 @@ def test_hashmap_backward_polygon(self):
 
 # this test should catch a shared boundary and a hashed multipolgon
 # related to https://github.com/Toblerity/Shapely/issues/535
-def test_albania_greece(self):
+def test_albania_greece():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[(data.name == "Albania") | (data.name == "Greece")]
     topo = Hashmap(data).to_dict()
@@ -63,7 +63,7 @@ def test_albania_greece(self):
 
 
 # something is wrong with hashmapping in the example of benin
-def test_benin_surrounding_countries(self):
+def test_benin_surrounding_countries():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Togo") | (data.name == "Benin") | (data.name == "Burkina Faso")
@@ -74,7 +74,7 @@ def test_benin_surrounding_countries(self):
 
 
 # something is wrong with hashmapping once a geometry has only shared arcs
-def test_geom_surrounding_many_geometries(self):
+def test_geom_surrounding_many_geometries():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Botswana")
@@ -90,7 +90,7 @@ def test_geom_surrounding_many_geometries(self):
 
 # this test was added since the shared_arcs bookkeeping is doing well, but the
 # wrong arc gots deleted. How come?
-def test_shared_arcs_ordering_issues(self):
+def test_shared_arcs_ordering_issues():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Botswana")
@@ -103,7 +103,7 @@ def test_shared_arcs_ordering_issues(self):
     assert len(topo["linestrings"]) == 17
 
 
-def test_super_function_hashmap(self):
+def test_super_function_hashmap():
     data = geometry.GeometryCollection(
         [
             geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
@@ -121,7 +121,7 @@ def test_super_function_hashmap(self):
 # this test was added since objects with nested geometreycollections seems not
 # being parsed in the topojson format.
 # Pass for now:
-def test_hashing_of_nested_geometrycollection(self):
+def test_hashing_of_nested_geometrycollection():
     data = {
         "foo": {
             "type": "GeometryCollection",
@@ -146,7 +146,7 @@ def test_hashing_of_nested_geometrycollection(self):
 
 # this test was added because the winding order is still giving issues.
 # see related issue: https://github.com/mattijn/topojson/issues/30
-def test_winding_order_geom_solely_shared_arcs(self):
+def test_winding_order_geom_solely_shared_arcs():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Jordan") | (data.name == "Palestine") | (data.name == "Israel")

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -5,17 +5,17 @@ from topojson.core.join import Join
 
 
 # the returned hashmap has true for junction points
-def test_true_for_junction_points(self):
+def test_true_for_junction_points():
     data = {
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
         "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
     }
-    topo = Join(data).to_dict()
+    topo = Join(data).to_dict() 
 
-    assert geometry.MultiPoint([(0.0, 0.0),(1.0, 0.0),(2.0, 0.0)]) == geometry.MultiPoint(topo["junctions"])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(1.0, 0.0),(0.0, 0.0),(2.0, 0.0)]))
 
 # the returned hashmap has undefined for non-junction points
-def test_undefined_for_non_junction_points(self):
+def test_undefined_for_non_junction_points():
     data = {
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
         "ab": {"type": "LineString", "coordinates": [[0, 0], [2, 0]]},
@@ -25,7 +25,7 @@ def test_undefined_for_non_junction_points(self):
     assert geometry.Point(1.0, 0.0) not in geometry.MultiPoint(topo["junctions"])
 
 # forward backward lines
-def test_forward_backward_lines(self):
+def test_forward_backward_lines():
     data = {
         "foo": {
             "type": "LineString",
@@ -38,10 +38,10 @@ def test_forward_backward_lines(self):
     }
     topo = Join(data).to_dict()
     
-    assert len(topo["junctions"]) == 4
+    assert len(topo["junctions"]) == 5
 
 # more than two lines
-def test_more_than_two_lines(self):
+def test_more_than_two_lines():
     data = {
         "foo": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
         "bar": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
@@ -56,10 +56,10 @@ def test_more_than_two_lines(self):
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 6
+    assert len(topo["junctions"]) == 5
 
 # exact duplicate lines ABC & ABC have no junctions
-def test_duplicate_lines_junction_endpoints(self):
+def test_duplicate_lines_junction_endpoints():
     data = {
         "abc1": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "abc2": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
@@ -69,7 +69,7 @@ def test_duplicate_lines_junction_endpoints(self):
     assert topo["junctions"] == []
 
 # reversed duplicate lines ABC & CBA have no junctions
-def test_reversed_duplicate_lines_junction_endpoints(self):
+def test_reversed_duplicate_lines_junction_endpoints():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
@@ -79,7 +79,7 @@ def test_reversed_duplicate_lines_junction_endpoints(self):
     assert topo["junctions"] == []
 
 # exact duplicate rings ABCA & ABCA have no junctions
-def test_exact_duplicate_rings(self):
+def test_exact_duplicate_rings():
     data = {
         "abca1": {
             "type": "Polygon",
@@ -95,7 +95,7 @@ def test_exact_duplicate_rings(self):
     assert topo["junctions"] == []
 
 # reversed duplicate rings ABCA & ACBA have no junctions
-def test_reversed_duplicate_rings(self):
+def test_reversed_duplicate_rings():
     data = {
         "abca": {
             "type": "Polygon",
@@ -111,7 +111,7 @@ def test_reversed_duplicate_rings(self):
     assert topo["junctions"] == []
 
 # rotated duplicate rings BCAB & ABCA have no junctions
-def test_rotated_duplicate_rings(self):
+def test_rotated_duplicate_rings():
     data = {
         "abca": {
             "type": "Polygon",
@@ -126,7 +126,7 @@ def test_rotated_duplicate_rings(self):
     assert topo["junctions"] == []
 
 # ring ABCA & line ABCA have no junction at A
-def test_equal_ring_and_line_no_junctions(self):
+def test_equal_ring_and_line_no_junctions():
     data = {
         "abcaLine": {
             "type": "LineString",
@@ -142,7 +142,7 @@ def test_equal_ring_and_line_no_junctions(self):
     assert topo["junctions"] == []
 
 # ring ABCA & line ABCA have no junctions
-def test_rotated_ring_and_line_no_junctions(self):
+def test_rotated_ring_and_line_no_junctions():
     data = {
         "abcaLine": {
             "type": "LineString",
@@ -158,7 +158,7 @@ def test_rotated_ring_and_line_no_junctions(self):
     assert topo["junctions"] == []
 
 # when an old arc ABC extends a new arc AB, there is a junction at B
-def test_line_ABC_extends_new_line_AB(self):
+def test_line_ABC_extends_new_line_AB():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
@@ -168,7 +168,7 @@ def test_line_ABC_extends_new_line_AB(self):
     assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
 
 # when a reversed old arc CBA extends a new arc AB, there is a junction at B
-def test_reversed_line_CBA_extends_new_line_AB(self):
+def test_reversed_line_CBA_extends_new_line_AB():
     data = {
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
         "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
@@ -178,7 +178,7 @@ def test_reversed_line_CBA_extends_new_line_AB(self):
     assert geometry.Point(1.0, 0.0) in geometry.MultiPoint(topo["junctions"])
 
 # when a new arc ADE shares its start with an old arc ABC, there is no junction at A
-def test_line_ADE_share_starts_with_ABC(self):
+def test_line_ADE_share_starts_with_ABC():
     data = {
         "ade": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
@@ -188,7 +188,7 @@ def test_line_ADE_share_starts_with_ABC(self):
     assert topo["junctions"] == []
 
 # ring ABA has no junctions
-def test_single_ring_ABCA(self):
+def test_single_ring_ABCA():
     data = {
         "abca": {
             "type": "LineString",
@@ -200,14 +200,14 @@ def test_single_ring_ABCA(self):
     assert topo["junctions"] == []
 
 # ring AA is not a proper polygon geometry.
-def test_single_ring_AA(self):
+def test_single_ring_AA():
     data = {"aa": {"type": "Polygon", "coordinates": [[0, 0], [0, 0]]}}
     topo = Join(data).to_dict()
 
     assert topo["junctions"] == []
 
 # when a new line DEC shares its end with an old line ABC, there is no junction at C
-def test_line_DEC_share_line_ABC(self):
+def test_line_DEC_share_line_ABC():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "dec": {"type": "LineString", "coordinates": [[0, 1], [1, 1], [2, 0]]},
@@ -216,7 +216,7 @@ def test_line_DEC_share_line_ABC(self):
     assert topo["junctions"] == []
 
 # when a new line ABC extends an old line AB, there is a junction at B
-def test_line_ABC_extends_line_AB(self):
+def test_line_ABC_extends_line_AB():
     data = {
         "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
@@ -226,30 +226,30 @@ def test_line_ABC_extends_line_AB(self):
     assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
 
 # when a new line ABC extends a reversed old line BA, there is a junction at B
-def test_line_ABC_extends_line_BA(self):
+def test_line_ABC_extends_line_BA():
     data = {
         "ba": {"type": "LineString", "coordinates": [[1, 0], [0, 0]]},
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)]))
 
 # when a new line starts BC in the middle of an old line ABC, there is a 
 # junction at B
-def test_line_ABC_extends_line_BC(self):
+def test_line_ABC_extends_line_BC():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)]))
 
 
 # when a new line BC starts in the middle of a reversed old line CBA, there is a 
 # junction at B
-def test_line_BC_start_middle_reversed_line_CBA(self):
+def test_line_BC_start_middle_reversed_line_CBA():
     data = {
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
         "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
@@ -260,51 +260,51 @@ def test_line_BC_start_middle_reversed_line_CBA(self):
 
 
 # when a new line ABD deviates from an old line ABC, there is a junction at B
-def test_line_ABD_deviates_line_ABC(self):
+def test_line_ABD_deviates_line_ABC():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)]))
 
 
 # when a new line ABD deviates from a reversed old line CBA, there is a 
 # junction at B
-def test_line_ABD_deviates_line_CBA(self):
+def test_line_ABD_deviates_line_CBA():
     data = {
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
         "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)]))
 
 # when a new line DBC merges into an old line ABC, there is a junction at B
-def test_line_DBC_merge_line_ABC(self):
+def test_line_DBC_merge_line_ABC():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)]))
 
 
 # when a new line DBC merges into a reversed old line CBA, there is a junction at B
-def test_line_DBC_merge_reversed_line_CBA(self):
+def test_line_DBC_merge_reversed_line_CBA():
     data = {
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
         "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)]))
 
 # when a new line DBE shares a single midpoint with an old line ABC, there is 
 # no junction at B
-def test_line_DBE_share_singe_midpoint_line_ABC(self):
+def test_line_DBE_share_singe_midpoint_line_ABC():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
@@ -313,7 +313,7 @@ def test_line_DBE_share_singe_midpoint_line_ABC(self):
     assert topo["junctions"] == []
 
 # when a new line ABDE skips a point with an old line ABCDE, there is a no junction
-def test_line_ABDE_skips_point_line_ABCDE(self):
+def test_line_ABDE_skips_point_line_ABCDE():
     data = {
         "abcde": {
             "type": "LineString",
@@ -329,7 +329,7 @@ def test_line_ABDE_skips_point_line_ABCDE(self):
 
 # when a new line ABDE skips a point with a reversed old line EDCBA, there is 
 # no junction
-def test_line_ABDE_skips_point_reversed_line_EDCBA(self):
+def test_line_ABDE_skips_point_reversed_line_EDCBA():
     data = {
         "edcba": {
             "type": "LineString",
@@ -344,7 +344,7 @@ def test_line_ABDE_skips_point_reversed_line_EDCBA(self):
     assert topo["junctions"] == []
 
 # when a line ABCDBE self-intersects with its middle, there are no junctions
-def test_line_ABCDBE_self_intersects_with_middle(self):
+def test_line_ABCDBE_self_intersects_with_middle():
     data = {
         "abcdbe": {
             "type": "LineString",
@@ -356,7 +356,7 @@ def test_line_ABCDBE_self_intersects_with_middle(self):
     assert topo["junctions"] == []
 
 # when a line ABACD self-intersects with its start, there are no junctions
-def test_line_ABACD_self_intersects_with_middle(self):
+def test_line_ABACD_self_intersects_with_middle():
     data = {
         "abacd": {
             "type": "LineString",
@@ -368,7 +368,7 @@ def test_line_ABACD_self_intersects_with_middle(self):
     assert topo["junctions"] == []
 
 # when a line ABCDBD self-intersects with its end, there are no junctions
-def test_line_ABCDBD_self_intersects_with_end(self):
+def test_line_ABCDBD_self_intersects_with_end():
     data = {
         "abcdbd": {
             "type": "LineString",
@@ -381,7 +381,7 @@ def test_line_ABCDBD_self_intersects_with_end(self):
 
 # when an old line ABCDBE self-intersects and shares a point B, there is 
 # no junction at B
-def test_line_ABCDB_self_intersects(self):
+def test_line_ABCDB_self_intersects():
     data = {
         "abcdbe": {
             "type": "LineString",
@@ -394,7 +394,7 @@ def test_line_ABCDB_self_intersects(self):
     assert topo["junctions"] == []
 
 # when a line ABCA is closed, there is no junction at A
-def test_line_ABCA_is_closed(self):
+def test_line_ABCA_is_closed():
     data = {
         "abca": {
             "type": "LineString",
@@ -405,7 +405,7 @@ def test_line_ABCA_is_closed(self):
     assert topo["junctions"] == []
 
 # when a ring ABCA is closed, there are no junctions
-def test_ring_ABCA_is_closed(self):
+def test_ring_ABCA_is_closed():
     data = {
         "abca": {
             "type": "Polygon",
@@ -417,7 +417,7 @@ def test_ring_ABCA_is_closed(self):
     assert topo["junctions"] == []
 
 # exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
-def test_exact_duplicate_rings_ABCA_ABCA_share_ABCA(self):
+def test_exact_duplicate_rings_ABCA_ABCA_share_ABCA():
     data = {
         "abca": {
             "type": "Polygon",
@@ -433,7 +433,7 @@ def test_exact_duplicate_rings_ABCA_ABCA_share_ABCA(self):
     assert topo["junctions"] == []
 
 # reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no juctions
-def test_exact_duplicate_rings_ABCA_ACBA_share_ABCA(self):
+def test_exact_duplicate_rings_ABCA_ACBA_share_ABCA():
     data = {
         "abca": {
             "type": "Polygon",
@@ -451,7 +451,7 @@ def test_exact_duplicate_rings_ABCA_ACBA_share_ABCA(self):
 # coincident rings ABCA & BCAB share the arc BCAB, but contain no junctinos
 # this is a problem though as they are considered equal in a MultiPolygon geometry.
 # test will pass, but coincident rings should be rotated before dedup
-def test_coincident_rings_ABCA_BCAB_share_BCAB(self):
+def test_coincident_rings_ABCA_BCAB_share_BCAB():
     data = {
         "abca": {
             "type": "Polygon",
@@ -467,7 +467,7 @@ def test_coincident_rings_ABCA_BCAB_share_BCAB(self):
     assert topo["junctions"] == []
 
 # coincident rings ABCA & BACB share the arc BCAB, but contain no junctions
-def test_coincident_rings_ABCA_BACB_share_BCAB(self):
+def test_coincident_rings_ABCA_BACB_share_BCAB():
     data = {
         "abca": {
             "type": "Polygon",
@@ -483,7 +483,7 @@ def test_coincident_rings_ABCA_BACB_share_BCAB(self):
     assert topo["junctions"] == []
 
 # coincident rings ABCA & DBED share the point B, but is no junction
-def test_coincident_rings_ABCA_DBED_share_B(self):
+def test_coincident_rings_ABCA_DBED_share_B():
     data = {
         "abca": {
             "type": "Polygon",
@@ -499,7 +499,7 @@ def test_coincident_rings_ABCA_DBED_share_B(self):
     assert topo["junctions"] == []
 
 # coincident ring ABCA & line DBE share the point B
-def test_coincident_ring_ABCA_and_line_DBE_share_B(self):
+def test_coincident_ring_ABCA_and_line_DBE_share_B():
     data = {
         "abca": {
             "type": "Polygon",
@@ -514,7 +514,7 @@ def test_coincident_ring_ABCA_and_line_DBE_share_B(self):
 # should keep junctions from partly shared paths
 # this test was added since the a shared path of ABC and another shared path of ABD
 # only kept the junctions at A, C and D, but not at B.
-def test_shared_junctions_in_shared_paths(self):
+def test_shared_junctions_in_shared_paths():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[(data.name == "Togo") | (data.name == "Benin") | 
         (data.name == "Burkina Faso")]
@@ -528,7 +528,7 @@ def test_shared_junctions_in_shared_paths(self):
 # linestrings to be considerd as junction. Not sure what happened if this introduces
 # another problem since this coordinates may not be unique anymore, and this can be 
 # skipped as a junction..
-def test_shared_segment_partly_start_partly_end_segment(self):
+def test_shared_segment_partly_start_partly_end_segment():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[
         (data.name == "Eritrea")
@@ -539,13 +539,13 @@ def test_shared_segment_partly_start_partly_end_segment(self):
 
     assert len(topo["junctions"]) == 6
 
-def test_non_noded_interesection(self):
+def test_non_noded_interesection():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     topo = Join(data).to_dict()#, quant_factor=1e6)
 
     assert len(topo["junctions"]) == 321
 
-def test_super_function_extract(self):
+def test_super_function_extract():
     data = geometry.GeometryCollection([
         geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]), 
         geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]])

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -165,7 +165,7 @@ def test_line_ABC_extends_new_line_AB():
     }
     topo = Join(data).to_dict()
     
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)]))
 
 # when a reversed old arc CBA extends a new arc AB, there is a junction at B
 def test_reversed_line_CBA_extends_new_line_AB():
@@ -223,7 +223,7 @@ def test_line_ABC_extends_line_AB():
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)]))
 
 # when a new line ABC extends a reversed old line BA, there is a junction at B
 def test_line_ABC_extends_line_BA():
@@ -256,7 +256,7 @@ def test_line_BC_start_middle_reversed_line_CBA():
     }
     topo = Join(data).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)])
+    assert geometry.MultiPoint(topo["junctions"]).equals(geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)]))
 
 
 # when a new line ABD deviates from an old line ABC, there is a junction at B

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,562 +1,555 @@
 from shapely import geometry
-import unittest
 import topojson
 import geopandas
 from topojson.core.join import Join
 
 
-class TestJoin(unittest.TestCase):
-    # the returned hashmap has true for junction points
-    def test_true_for_junction_points(self):
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+# the returned hashmap has true for junction points
+def test_true_for_junction_points(self):
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint([(0.0, 0.0),(1.0, 0.0),(2.0, 0.0)]) == geometry.MultiPoint(topo["junctions"])
+
+# the returned hashmap has undefined for non-junction points
+def test_undefined_for_non_junction_points(self):
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.Point(1.0, 0.0) not in geometry.MultiPoint(topo["junctions"])
+
+# forward backward lines
+def test_forward_backward_lines(self):
+    data = {
+        "foo": {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        "bar": {
+            "type": "LineString",
+            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
+        },
+    }
+    topo = Join(data).to_dict()
+    
+    assert len(topo["junctions"]) == 4
+
+# more than two lines
+def test_more_than_two_lines(self):
+    data = {
+        "foo": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
+        "bar": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
+        "baz": {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        "qux": {
+            "type": "LineString",
+            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 6
+
+# exact duplicate lines ABC & ABC have no junctions
+def test_duplicate_lines_junction_endpoints(self):
+    data = {
+        "abc1": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abc2": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# reversed duplicate lines ABC & CBA have no junctions
+def test_reversed_duplicate_lines_junction_endpoints(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# exact duplicate rings ABCA & ABCA have no junctions
+def test_exact_duplicate_rings(self):
+    data = {
+        "abca1": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+        "abca2": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# reversed duplicate rings ABCA & ACBA have no junctions
+def test_reversed_duplicate_rings(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+        "acba": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
+    
+    assert topo["junctions"] == []
+
+# rotated duplicate rings BCAB & ABCA have no junctions
+def test_rotated_duplicate_rings(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+        "bcab": {
+            "type": "Polygon",
+            "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
+        },
+    }
+    topo = Join(data).to_dict()
+    assert topo["junctions"] == []
+
+# ring ABCA & line ABCA have no junction at A
+def test_equal_ring_and_line_no_junctions(self):
+    data = {
+        "abcaLine": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# ring ABCA & line ABCA have no junctions
+def test_rotated_ring_and_line_no_junctions(self):
+    data = {
+        "abcaLine": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
+        },
+        "bcabPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# when an old arc ABC extends a new arc AB, there is a junction at B
+def test_line_ABC_extends_new_line_AB(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data).to_dict()
+    
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+
+# when a reversed old arc CBA extends a new arc AB, there is a junction at B
+def test_reversed_line_CBA_extends_new_line_AB(self):
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.Point(1.0, 0.0) in geometry.MultiPoint(topo["junctions"])
+
+# when a new arc ADE shares its start with an old arc ABC, there is no junction at A
+def test_line_ADE_share_starts_with_ABC(self):
+    data = {
+        "ade": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
+    }
+    topo = Join(data).to_dict()
+    
+    assert topo["junctions"] == []
+
+# ring ABA has no junctions
+def test_single_ring_ABCA(self):
+    data = {
+        "abca": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [1, 1], [0, 0]],
         }
-        topo = Join(data).to_dict()
-        self.assertTrue(geometry.MultiPoint([
-            (0.0, 0.0),(1.0, 0.0),(2.0, 0.0)
-            ]).equals(geometry.MultiPoint(topo["junctions"])))
+    }
+    topo = Join(data).to_dict()
 
-    # the returned hashmap has undefined for non-junction points
-    def test_undefined_for_non_junction_points(self):
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "ab": {"type": "LineString", "coordinates": [[0, 0], [2, 0]]},
+    assert topo["junctions"] == []
+
+# ring AA is not a proper polygon geometry.
+def test_single_ring_AA(self):
+    data = {"aa": {"type": "Polygon", "coordinates": [[0, 0], [0, 0]]}}
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# when a new line DEC shares its end with an old line ABC, there is no junction at C
+def test_line_DEC_share_line_ABC(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dec": {"type": "LineString", "coordinates": [[0, 1], [1, 1], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+    assert topo["junctions"] == []
+
+# when a new line ABC extends an old line AB, there is a junction at B
+def test_line_ABC_extends_line_AB(self):
+    data = {
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+
+# when a new line ABC extends a reversed old line BA, there is a junction at B
+def test_line_ABC_extends_line_BA(self):
+    data = {
+        "ba": {"type": "LineString", "coordinates": [[1, 0], [0, 0]]},
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])
+
+# when a new line starts BC in the middle of an old line ABC, there is a 
+# junction at B
+def test_line_ABC_extends_line_BC(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
+
+
+# when a new line BC starts in the middle of a reversed old line CBA, there is a 
+# junction at B
+def test_line_BC_start_middle_reversed_line_CBA(self):
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)])
+
+
+# when a new line ABD deviates from an old line ABC, there is a junction at B
+def test_line_ABD_deviates_line_ABC(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)])
+
+
+# when a new line ABD deviates from a reversed old line CBA, there is a 
+# junction at B
+def test_line_ABD_deviates_line_CBA(self):
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
+
+# when a new line DBC merges into an old line ABC, there is a junction at B
+def test_line_DBC_merge_line_ABC(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)])
+
+
+# when a new line DBC merges into a reversed old line CBA, there is a junction at B
+def test_line_DBC_merge_reversed_line_CBA(self):
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]) == geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)])
+
+# when a new line DBE shares a single midpoint with an old line ABC, there is 
+# no junction at B
+def test_line_DBE_share_singe_midpoint_line_ABC(self):
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
+    }
+    topo = Join(data).to_dict()
+    assert topo["junctions"] == []
+
+# when a new line ABDE skips a point with an old line ABCDE, there is a no junction
+def test_line_ABDE_skips_point_line_ABCDE(self):
+    data = {
+        "abcde": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]],
+        },
+        "abde": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]],
+        },
+    }
+    topo = Join(data).to_dict()
+    assert topo["junctions"] == []
+
+# when a new line ABDE skips a point with a reversed old line EDCBA, there is 
+# no junction
+def test_line_ABDE_skips_point_reversed_line_EDCBA(self):
+    data = {
+        "edcba": {
+            "type": "LineString",
+            "coordinates": [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]],
+        },
+        "abde": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]],
+        },
+    }
+    topo = Join(data).to_dict()
+    assert topo["junctions"] == []
+
+# when a line ABCDBE self-intersects with its middle, there are no junctions
+def test_line_ABCDBE_self_intersects_with_middle(self):
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
         }
-        topo = Join(data).to_dict()
-        # print(topo)
-        self.assertFalse(
-            geometry.Point(1.0, 0.0) in geometry.MultiPoint(topo["junctions"])
-        )
+    }
+    topo = Join(data).to_dict()
+    
+    assert topo["junctions"] == []
 
-        # forward backward lines
-
-    def test_forward_backward_lines(self):
-        data = {
-            "foo": {
-                "type": "LineString",
-                "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
-            },
-            "bar": {
-                "type": "LineString",
-                "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
-            },
+# when a line ABACD self-intersects with its start, there are no junctions
+def test_line_ABACD_self_intersects_with_middle(self):
+    data = {
+        "abacd": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]],
         }
-        topo = Join(data).to_dict()
-        # print(topo)
-        self.assertTrue(len(topo["junctions"]), 4)
+    }
+    topo = Join(data).to_dict()
+    
+    assert topo["junctions"] == []
 
-    # more than two lines
-    def test_more_than_two_lines(self):
-        data = {
-            "foo": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
-            "bar": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
-            "baz": {
-                "type": "LineString",
-                "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
-            },
-            "qux": {
-                "type": "LineString",
-                "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
-            },
+# when a line ABCDBD self-intersects with its end, there are no junctions
+def test_line_ABCDBD_self_intersects_with_end(self):
+    data = {
+        "abcdbd": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]],
         }
-        topo = Join(data).to_dict()
-        # print(topo)
-        self.assertTrue(len(topo["junctions"]), 6)
+    }
+    topo = Join(data).to_dict()
 
-    # exact duplicate lines ABC & ABC have no junctions
-    def test_duplicate_lines_junction_endpoints(self):
-        data = {
-            "abc1": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "abc2": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    assert topo["junctions"] == []
+
+# when an old line ABCDBE self-intersects and shares a point B, there is 
+# no junction at B
+def test_line_ABCDB_self_intersects(self):
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
+        },
+        "fbg": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+# when a line ABCA is closed, there is no junction at A
+def test_line_ABCA_is_closed(self):
+    data = {
+        "abca": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [0, 1], [0, 0]],
         }
-        topo = Join(data).to_dict()
-        # print(topo)
-        self.assertListEqual(topo["junctions"], [])
+    }
+    topo = Join(data).to_dict()
+    assert topo["junctions"] == []
 
-    # reversed duplicate lines ABC & CBA have no junctions
-    def test_reversed_duplicate_lines_junction_endpoints(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+# when a ring ABCA is closed, there are no junctions
+def test_ring_ABCA_is_closed(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
         }
-        topo = Join(data).to_dict()
-        # print(topo)
-        self.assertListEqual(topo["junctions"], [])
+    }
+    topo = Join(data).to_dict()
+    
+    assert topo["junctions"] == []
 
-    # exact duplicate rings ABCA & ABCA have no junctions
-    def test_exact_duplicate_rings(self):
-        data = {
-            "abca1": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
-            },
-            "abca2": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        # print(topo)
-        self.assertListEqual(topo["junctions"], [])
+# exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
+def test_exact_duplicate_rings_ABCA_ABCA_share_ABCA(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+        "abca2": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
 
-    # reversed duplicate rings ABCA & ACBA have no junctions
-    def test_reversed_duplicate_rings(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
-            },
-            "acba": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+    assert topo["junctions"] == []
 
-    # rotated duplicate rings BCAB & ABCA have no junctions
-    def test_rotated_duplicate_rings(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
-            },
-            "bcab": {
-                "type": "Polygon",
-                "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+# reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no juctions
+def test_exact_duplicate_rings_ABCA_ACBA_share_ABCA(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+        "acba": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
 
-    # ring ABCA & line ABCA have no junction at A
-    def test_equal_ring_and_line_no_junctions(self):
-        data = {
-            "abcaLine": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
-            },
-            "abcaPolygon": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+    assert topo["junctions"] == []
 
-    # ring ABCA & line ABCA have no junctions
-    def test_rotated_ring_and_line_no_junctions(self):
-        data = {
-            "abcaLine": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
-            },
-            "bcabPolygon": {
-                "type": "Polygon",
-                "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+# coincident rings ABCA & BCAB share the arc BCAB, but contain no junctinos
+# this is a problem though as they are considered equal in a MultiPolygon geometry.
+# test will pass, but coincident rings should be rotated before dedup
+def test_coincident_rings_ABCA_BCAB_share_BCAB(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+        "bcab": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [0, 1], [0, 0], [1, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
 
-    # when an old arc ABC extends a new arc AB, there is a junction at B
-    def test_line_ABC_extends_new_line_AB(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
-            )
-        )
+    assert topo["junctions"] == []
 
-    # when a reversed old arc CBA extends a new arc AB, there is a junction at B
-    def test_reversed_line_CBA_extends_new_line_AB(self):
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.Point(1.0, 0.0).within(geometry.MultiPoint(topo["junctions"]))
-        )
+# coincident rings ABCA & BACB share the arc BCAB, but contain no junctions
+def test_coincident_rings_ABCA_BACB_share_BCAB(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+        "bacb": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [0, 0], [0, 1], [1, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
 
-    # when a new arc ADE shares its start with an old arc ABC, there is no junction at A
-    def test_line_ADE_share_starts_with_ABC(self):
-        data = {
-            "ade": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+    assert topo["junctions"] == []
 
-    # ring ABA has no junctions
-    def test_single_ring_ABCA(self):
-        data = {
-            "abca": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [1, 1], [0, 0]],
-            }
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+# coincident rings ABCA & DBED share the point B, but is no junction
+def test_coincident_rings_ABCA_DBED_share_B(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+        "dbed": {
+            "type": "Polygon",
+            "coordinates": [[[2, 1], [1, 0], [2, 2], [2, 1]]],
+        },
+    }
+    topo = Join(data).to_dict()
+    
+    assert topo["junctions"] == []
 
-    # ring AA is not a proper polygon geometry.
-    def test_single_ring_AA(self):
-        data = {"aa": {"type": "Polygon", "coordinates": [[0, 0], [0, 0]]}}
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+# coincident ring ABCA & line DBE share the point B
+def test_coincident_ring_ABCA_and_line_DBE_share_B(self):
+    data = {
+        "abca": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
+        },
+        "dbe": {"type": "LineString", "coordinates": [[2, 1], [1, 0], [2, 2]]},
+    }
+    topo = Join(data).to_dict()
 
-    # when a new line DEC shares its end with an old line ABC, there is no junction at C
-    def test_line_DEC_share_line_ABC(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "dec": {"type": "LineString", "coordinates": [[0, 1], [1, 1], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
+    assert topo["junctions"] == []
 
-    # when a new line ABC extends an old line AB, there is a junction at B
-    def test_line_ABC_extends_line_AB(self):
-        data = {
-            "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-            geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])),
-        )
+# should keep junctions from partly shared paths
+# this test was added since the a shared path of ABC and another shared path of ABD
+# only kept the junctions at A, C and D, but not at B.
+def test_shared_junctions_in_shared_paths(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Togo") | (data.name == "Benin") | 
+        (data.name == "Burkina Faso")]
+    topo = Join(data).to_dict()
 
-    # when a new line ABC extends a reversed old line BA, there is a junction at B
-    def test_line_ABC_extends_line_BA(self):
-        data = {
-            "ba": {"type": "LineString", "coordinates": [[1, 0], [0, 0]]},
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-            geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])))
+    assert len(topo["junctions"]) == 6
 
-    # when a new line starts BC in the middle of an old line ABC, there is a 
-    # junction at B
-    def test_line_ABC_extends_line_BC(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
-            )
-        )
+# this test was added since a shared path can be detected of two linestrings where 
+# the shared path is partly from the start and partly of the end part of the 
+# linestring. If any shared path are detected also add the first coordinates of both
+# linestrings to be considerd as junction. Not sure what happened if this introduces
+# another problem since this coordinates may not be unique anymore, and this can be 
+# skipped as a junction..
+def test_shared_segment_partly_start_partly_end_segment(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Eritrea")
+        | (data.name == "Ethiopia")
+        | (data.name == "Sudan")
+    ]
+    topo = Join(data).to_dict()
 
-    # when a new line BC starts in the middle of a reversed old line CBA, there is a 
-    # junction at B
-    def test_line_BC_start_middle_reversed_line_CBA(self):
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)])
-            )
-        )
+    assert len(topo["junctions"]) == 6
 
-    # when a new line ABD deviates from an old line ABC, there is a junction at B
-    def test_line_ABD_deviates_line_ABC(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)])
-            )
-        )
+def test_non_noded_interesection(self):
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    topo = Join(data).to_dict()#, quant_factor=1e6)
 
-    # when a new line ABD deviates from a reversed old line CBA, there is a 
-    # junction at B
-    def test_line_ABD_deviates_line_CBA(self):
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
-            )
-        )
+    assert len(topo["junctions"]) == 321
 
-    # when a new line DBC merges into an old line ABC, there is a junction at B
-    def test_line_DBC_merge_line_ABC(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)])
-            )
-        )
+def test_super_function_extract(self):
+    data = geometry.GeometryCollection([
+        geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]), 
+        geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]])
+    ])   
+    topo = Join(data).to_dict()  
 
-    # when a new line DBC merges into a reversed old line CBA, there is a junction at B
-    def test_line_DBC_merge_reversed_line_CBA(self):
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertTrue(
-            geometry.MultiPoint(topo["junctions"]).equals(
-                geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)])
-            )
-        )
-
-    # when a new line DBE shares a single midpoint with an old line ABC, there is 
-    # no junction at B
-    def test_line_DBE_share_singe_midpoint_line_ABC(self):
-        data = {
-            "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-            "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a new line ABDE skips a point with an old line ABCDE, there is a no junction
-    def test_line_ABDE_skips_point_line_ABCDE(self):
-        data = {
-            "abcde": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]],
-            },
-            "abde": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a new line ABDE skips a point with a reversed old line EDCBA, there is 
-    # no junction
-    def test_line_ABDE_skips_point_reversed_line_EDCBA(self):
-        data = {
-            "edcba": {
-                "type": "LineString",
-                "coordinates": [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]],
-            },
-            "abde": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a line ABCDBE self-intersects with its middle, there are no junctions
-    def test_line_ABCDBE_self_intersects_with_middle(self):
-        data = {
-            "abcdbe": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
-            }
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a line ABACD self-intersects with its start, there are no junctions
-    def test_line_ABACD_self_intersects_with_middle(self):
-        data = {
-            "abacd": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]],
-            }
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a line ABCDBD self-intersects with its end, there are no junctions
-    def test_line_ABCDBD_self_intersects_with_end(self):
-        data = {
-            "abcdbd": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]],
-            }
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when an old line ABCDBE self-intersects and shares a point B, there is 
-    # no junction at B
-    def test_line_ABCDB_self_intersects(self):
-        data = {
-            "abcdbe": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
-            },
-            "fbg": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a line ABCA is closed, there is no junction at A
-    def test_line_ABCA_is_closed(self):
-        data = {
-            "abca": {
-                "type": "LineString",
-                "coordinates": [[0, 0], [1, 0], [0, 1], [0, 0]],
-            }
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # when a ring ABCA is closed, there are no junctions
-    def test_ring_ABCA_is_closed(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            }
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
-    def test_exact_duplicate_rings_ABCA_ABCA_share_ABCA(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "abca2": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no juctions
-    def test_exact_duplicate_rings_ABCA_ACBA_share_ABCA(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "acba": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # coincident rings ABCA & BCAB share the arc BCAB, but contain no junctinos
-    # this is a problem though as they are considered equal in a MultiPolygon geometry.
-    # test will pass, but coincident rings should be rotated before dedup
-    def test_coincident_rings_ABCA_BCAB_share_BCAB(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "bcab": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [0, 1], [0, 0], [1, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # coincident rings ABCA & BACB share the arc BCAB, but contain no junctions
-    def test_coincident_rings_ABCA_BACB_share_BCAB(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "bacb": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [0, 0], [0, 1], [1, 0]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # coincident rings ABCA & DBED share the point B, but is no junction
-    def test_coincident_rings_ABCA_DBED_share_B(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "dbed": {
-                "type": "Polygon",
-                "coordinates": [[[2, 1], [1, 0], [2, 2], [2, 1]]],
-            },
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # coincident ring ABCA & line DBE share the point B
-    def test_coincident_ring_ABCA_and_line_DBE_share_B(self):
-        data = {
-            "abca": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]],
-            },
-            "dbe": {"type": "LineString", "coordinates": [[2, 1], [1, 0], [2, 2]]},
-        }
-        topo = Join(data).to_dict()
-        self.assertListEqual(topo["junctions"], [])
-
-    # should keep junctions from partly shared paths
-    # this test was added since the a shared path of ABC and another shared path of ABD
-    # only kept the junctions at A, C and D, but not at B.
-    def test_shared_junctions_in_shared_paths(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Togo") | (data.name == "Benin") | 
-            (data.name == "Burkina Faso")]
-        topo = Join(data).to_dict()
-        self.assertEqual(len(topo["junctions"]), 6)
-
-    # this test was added since a shared path can be detected of two linestrings where 
-    # the shared path is partly from the start and partly of the end part of the 
-    # linestring. If any shared path are detected also add the first coordinates of both
-    # linestrings to be considerd as junction. Not sure what happened if this introduces
-    # another problem since this coordinates may not be unique anymore, and this can be 
-    # skipped as a junction..
-    def test_shared_segment_partly_start_partly_end_segment(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Eritrea")
-            | (data.name == "Ethiopia")
-            | (data.name == "Sudan")
-        ]
-        topo = Join(data).to_dict()
-        self.assertEqual(len(topo["junctions"]), 6)  
-
-    def test_non_noded_interesection(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        topo = Join(data).to_dict()#, quant_factor=1e6)
-        self.assertEqual(len(topo["junctions"]), 321)   
-
-    def test_super_function_extract(self):
-        data = geometry.GeometryCollection([
-            geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]), 
-            geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]])
-        ])   
-        topo = Join(data).to_dict()  
-        self.assertEqual(list(topo.keys()), 
-        ["type", "linestrings", "bookkeeping_geoms", "objects", "options","bbox", "junctions"])
+    assert list(topo.keys()) == ["type", "linestrings", "bookkeeping_geoms", "objects", "options","bbox", "junctions"]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -3,7 +3,6 @@ from shapely import geometry
 import geopandas
 import geojson
 import topojson
-from topojson.utils import TopoOptions
 
 
 # this test was added since geometries of only linestrings resulted in a topojson
@@ -21,8 +20,6 @@ def test_linestrings_parsed_to_gdf():
 
 # test winding order using TopoOptions object
 def test_winding_order_TopoOptions():
-    from topojson.utils import TopoOptions
-
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     data = data[(data.name == "South Africa")]
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict()

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from shapely import geometry
 import geopandas
 import geojson
@@ -7,170 +6,175 @@ import topojson
 from topojson.utils import TopoOptions
 
 
-class TestTopology(unittest.TestCase):
+# this test was added since geometries of only linestrings resulted in a topojson
+# file that returns an empty geodataframe when reading
+def test_linestrings_parsed_to_gdf():
+    data = [
+        {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
+        {"type": "LineString", "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]]},
+    ]
+    topo = topojson.Topology(data).to_gdf()
 
-    # this test was added since geometries of only linestrings resulted in a topojson
-    # file that returns an empty geodataframe when reading
-    def test_linestrings_parsed_to_gdf(self):
-        data = [
-            {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
-            {
-                "type": "LineString",
-                "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]],
-            },
-        ]
-        topo = topojson.Topology(data).to_gdf()
-        self.assertNotEqual(topo["geometry"][0].wkt, "GEOMETRYCOLLECTION EMPTY")
-        self.assertEqual(topo["geometry"][0].type, "LineString")
+    assert topo["geometry"][0].wkt != "GEOMETRYCOLLECTION EMPTY"
+    assert topo["geometry"][0].type == "LineString"
 
-    # test winding order using TopoOptions object
-    def test_winding_order_TopoOptions(self):
-        from topojson.utils import TopoOptions
 
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "South Africa")]
+# test winding order using TopoOptions object
+def test_winding_order_TopoOptions():
+    from topojson.utils import TopoOptions
 
-        topo = topojson.Topology(data, winding_order="CW_CCW").to_dict()
-        self.assertEqual(len(topo["objects"]), 1)
-        self.assertEqual(isinstance(topo["options"], dict), True)
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "South Africa")]
+    topo = topojson.Topology(data, winding_order="CW_CCW").to_dict()
 
-    # test winding order using kwarg variables
-    def test_winding_order_kwarg_vars(self):
+    assert len(topo["objects"]) == 1
+    assert isinstance(topo["options"], dict) == True
 
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "South Africa")]
 
-        topo = topojson.Topology(data, winding_order="CW_CCW").to_dict()
-        self.assertEqual(len(topo["objects"]), 1)
-        self.assertEqual(isinstance(topo["options"], dict), True)
+# test winding order using kwarg variables
+def test_winding_order_kwarg_vars():
 
-    def test_computing_topology(self):
-        data = [
-            {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
-            {
-                "type": "LineString",
-                "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]],
-            },
-        ]
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "South Africa")]
+    topo = topojson.Topology(data, winding_order="CW_CCW").to_dict()
 
-        no_topo = topojson.Topology(data, topology=False, prequantize=False).to_dict()
-        topo = topojson.Topology(data, topology=True, prequantize=False).to_dict()
+    assert len(topo["objects"]) == 1
+    assert isinstance(topo["options"], dict) == True
 
-        self.assertEqual(len(topo["arcs"]), 5)
-        self.assertEqual(len(no_topo["arcs"]), 2)
 
-    # test prequantization without computing topology
-    def test_prequantization(self):
+def test_computing_topology():
+    data = [
+        {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
+        {"type": "LineString", "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]]},
+    ]
+    no_topo = topojson.Topology(data, topology=False, prequantize=False).to_dict()
+    topo = topojson.Topology(data, topology=True, prequantize=False).to_dict()
 
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Botswana")
-            | (data.name == "South Africa")
-            | (data.name == "Zimbabwe")
-            | (data.name == "Mozambique")
-            | (data.name == "Zambia")
-        ]
+    assert len(topo["arcs"]) == 5
+    assert len(no_topo["arcs"]) == 2
 
-        topo = topojson.Topology(data, topology=False, prequantize=1e4).to_dict()
-        self.assertEqual("transform" in topo.keys(), True)
 
-    # test prequantization without computing topology
-    def test_prequantization_including_delta_encoding(self):
+# test prequantization without computing topology
+def test_prequantization():
 
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[
-            (data.name == "Botswana")
-            | (data.name == "South Africa")
-            | (data.name == "Zimbabwe")
-            | (data.name == "Mozambique")
-            | (data.name == "Zambia")
-        ]
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Botswana")
+        | (data.name == "South Africa")
+        | (data.name == "Zimbabwe")
+        | (data.name == "Mozambique")
+        | (data.name == "Zambia")
+    ]
+    topo = topojson.Topology(data, topology=False, prequantize=1e4).to_dict()
 
-        topo = topojson.Topology(data, topology=False, prequantize=1e4).to_dict()
-        self.assertEqual("transform" in topo.keys(), True)
+    assert "transform" in topo.keys()
 
-    def test_toposimplify_set_in_options(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Antarctica")]
-        topo = topojson.Topology(
-            data, prequantize=True, simplify_with="shapely", toposimplify=4
-        ).to_dict()
-        self.assertEqual("transform" in topo.keys(), True)
 
-    def test_toposimplify_as_chaining(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Antarctica")]
-        topo = topojson.Topology(data, prequantize=True, simplify_with="shapely")
-        topos = topo.toposimplify(2).to_dict()
-        self.assertEqual("transform" in topos.keys(), True)
+# test prequantization without computing topology
+def test_prequantization_including_delta_encoding():
 
-    def test_topoquantize_as_chaining(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Antarctica")]
-        topo = topojson.Topology(data, prequantize=False, simplify_with="shapely")
-        topos = topo.topoquantize(1e2).to_dict()
-        self.assertEqual("transform" in topos.keys(), True)
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[
+        (data.name == "Botswana")
+        | (data.name == "South Africa")
+        | (data.name == "Zimbabwe")
+        | (data.name == "Mozambique")
+        | (data.name == "Zambia")
+    ]
+    topo = topojson.Topology(data, topology=False, prequantize=1e4).to_dict()
 
-    def test_prequantize_topoquantize_as_chaining(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Antarctica")]
-        topo = topojson.Topology(data, prequantize=1e6, topology=True)
-        topos = topo.topoquantize(1e5).to_dict()
-        self.assertEqual("transform" in topos.keys(), True)
+    assert "transform" in topo.keys()
 
-    def test_topology_to_svg(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.name == "Antarctica")]
-        topo = topojson.Topology(data, prequantize=1e6, presimplify=50, topology=True)
-        svg = topo.to_svg()
-        self.assertEqual(svg, None)
 
-    def test_topology_with_arcs_without_linestrings(self):
-        data = [
-            {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },
-            {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
-            },
-        ]
+def test_toposimplify_set_in_options():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Antarctica")]
+    topo = topojson.Topology(
+        data, prequantize=True, simplify_with="shapely", toposimplify=4
+    ).to_dict()
 
-        topo = topojson.Topology(data, prequantize=False, topology=True).to_dict()
-        self.assertEqual("linestrings" in topo.keys(), False)
+    assert "transform" in topo.keys()
 
-    def test_topology_widget(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.continent == "Africa")]
 
-        topo = topojson.Topology(data, prequantize=1e6, topology=True)
-        widget = topo.to_widget()
+def test_toposimplify_as_chaining():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Antarctica")]
+    topo = topojson.Topology(data, prequantize=True, simplify_with="shapely")
+    topos = topo.toposimplify(2).to_dict()
 
-        self.assertEqual(len(widget.widget.children), 4)
+    assert "transform" in topos.keys()
 
-    def test_topology_simplification_vw(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.continent == "South America")]
-        topo = topojson.Topology(
-            data,
-            prequantize=False,
-            topology=True,
-            toposimplify=1,
-            simplify_with="simplification",
-            simplify_algorithm="vw",
-        ).to_dict()
-        self.assertEqual(len(topo["arcs"][0]), 4)
 
-    def test_topology_simplification_dp(self):
-        data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-        data = data[(data.continent == "South America")]
-        topo = topojson.Topology(
-            data,
-            prequantize=False,
-            topology=True,
-            toposimplify=1,
-            simplify_with="simplification",
-            simplify_algorithm="dp",
-        ).to_dict()
-        self.assertEqual(len(topo["arcs"][0]), 3) 
+def test_topoquantize_as_chaining():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Antarctica")]
+    topo = topojson.Topology(data, prequantize=False, simplify_with="shapely")
+    topos = topo.topoquantize(1e2).to_dict()
+
+    assert "transform" in topos.keys()
+
+
+def test_prequantize_topoquantize_as_chaining():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Antarctica")]
+    topo = topojson.Topology(data, prequantize=1e6, topology=True)
+    topos = topo.topoquantize(1e5).to_dict()
+
+    assert "transform" in topos.keys()
+
+
+def test_topology_to_svg():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.name == "Antarctica")]
+    topo = topojson.Topology(data, prequantize=1e6, presimplify=50, topology=True)
+
+    assert topo.to_svg() == None
+
+
+def test_topology_with_arcs_without_linestrings():
+    data = [
+        {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+        {"type": "Polygon", "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
+    ]
+    topo = topojson.Topology(data, prequantize=False, topology=True).to_dict()
+
+    assert "linestrings" not in topo.keys()
+
+
+def test_topology_widget():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.continent == "Africa")]
+    topo = topojson.Topology(data, prequantize=1e6, topology=True)
+    widget = topo.to_widget()
+
+    assert len(widget.widget.children) == 4  # pylint: disable=no-member
+
+
+def test_topology_simplification_vw():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.continent == "South America")]
+    topo = topojson.Topology(
+        data,
+        prequantize=False,
+        topology=True,
+        toposimplify=1,
+        simplify_with="simplification",
+        simplify_algorithm="vw",
+    ).to_dict()
+
+    assert len(topo["arcs"][0]) == 4
+
+
+def test_topology_simplification_dp():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    data = data[(data.continent == "South America")]
+    topo = topojson.Topology(
+        data,
+        prequantize=False,
+        topology=True,
+        toposimplify=1,
+        simplify_with="simplification",
+        simplify_algorithm="dp",
+    ).to_dict()
+
+    assert len(topo["arcs"][0]) == 3

--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -1,7 +1,7 @@
 import itertools
-import numpy as np
 import pprint
 import copy
+import numpy as np
 from shapely import geometry
 from shapely.strtree import STRtree
 from .join import Join

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -1,12 +1,8 @@
-from shapely import geometry
-
-# from shapely.ops import split
-from shapely.ops import linemerge
-
-# import itertools
-import numpy as np
 import copy
 import pprint
+import numpy as np
+from shapely import geometry
+from shapely.ops import linemerge
 from .cut import Cut
 from ..ops import np_array_from_lists
 from ..ops import lists_from_np_array

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -1,11 +1,10 @@
 import json
 import copy
-from shapely import geometry
 import logging
 import pprint
+from shapely import geometry
 from ..utils import singledispatch_class
 from ..utils import serialize_as_svg
-
 from ..utils import TopoOptions
 from ..ops import winding_order
 

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -1,10 +1,6 @@
-import numpy as np
-
-# from itertools import compress
 import copy
 import pprint
-
-# import json
+import numpy as np
 from shapely import geometry
 from shapely.ops import linemerge
 from .dedup import Dedup

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -1,4 +1,6 @@
 # pylint: disable=unsubscriptable-object
+import copy
+import pprint
 from shapely import geometry
 from shapely.wkb import loads
 from shapely.ops import shared_paths
@@ -8,14 +10,6 @@ from ..ops import select_unique_combs
 from ..ops import simplify
 from ..ops import quantize
 from ..utils import serialize_as_svg
-
-# import numpy as np
-
-# import itertools
-import copy
-
-# import warnings
-import pprint
 from .extract import Extract
 
 if speedups.available:

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -1,6 +1,4 @@
 import pprint
-
-# import json
 import copy
 import numpy as np
 from .hashmap import Hashmap


### PR DESCRIPTION
Changed the `self.assertEqual()` and its variants `assertListEqual()`, `assertTrue()`, `assertSequenceEqual()`, `assertFalse()` etc to the pytest variant `assert x == y`

Some tests had different output, but upon inspecting the current generated output is right and so changed test assertions in a few cases. 