### PR TITLE
Complex shared paths with backward and forward parts with non-existing junctions

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -219,3 +219,27 @@ def test_cut_geomcol_multipolygon_polygon():
 
     assert topo["bookkeeping_linestrings"].size == 8
 
+
+# this test is added since its seems no extra junctions are placed at lines where other
+# linestrings have shared paths but no shared junctions.
+def test_cut_linemerge_multilinestring():
+    data = [
+        {"type": "LineString", "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)]},
+        {
+            "type": "LineString",
+            "coordinates": [
+                (5, 0),
+                (25, 0),
+                (25, 5),
+                (16, 5),
+                (16, 10),
+                (14, 10),
+                (14, 5),
+                (0, 5),
+            ],
+        },
+    ]
+    topo = Cut(data).to_dict()
+
+    assert len(topo["linestrings"]) == 12
+    assert len(topo["junctions"]) == 7

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -173,3 +173,25 @@ def test_s2_geometries():
     assert len(topo["junctions"]) == 6
     assert len(topo["bookkeeping_duplicates"]) == 0
 
+
+def test_dedup_linemerge_multilinestring():
+    data = [
+        {"type": "LineString", "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)]},
+        {
+            "type": "LineString",
+            "coordinates": [
+                (5, 0),
+                (25, 0),
+                (25, 5),
+                (16, 5),
+                (16, 10),
+                (14, 10),
+                (14, 5),
+                (0, 5),
+            ],
+        },
+    ]
+    topo = Dedup(data).to_dict()
+
+    assert len(topo["linestrings"]) == 9
+    assert len(topo["junctions"]) == 7

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -574,3 +574,19 @@ def test_join_prequantize_points():
     topo = Join(data, options={"prequantize": True}).to_dict()
 
     assert topo["bbox"] == (-0.5, 0.0, 1.0, 1.5)
+
+def test_join_linemerge_multilinestring():
+    data = [
+        {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        {
+            "type": "LineString",
+            "coordinates": [(5, 0), (25, 0), (25, 5), (16, 5), (16, 10), (14, 10), (14, 5), (0, 5)],
+        }
+    ]
+    topo = Join(data).to_dict()
+
+    assert len(topo["linestrings"]) == 2
+    assert len(topo["junctions"]) == 7

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -137,6 +137,7 @@ class Extract(object):
                     self.invalid_geoms, "" if self.invalid_geoms == 1 else "s"
                 )
             )
+            self.invalid_geoms = 0
 
         return data
 

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -195,6 +195,18 @@ class Join(Extract):
 
         return data
 
+    def validate_linemerge(self, merged_line):
+        """
+        Return list of linestrings. If the linemerge was a MultiLineString 
+        then returns a list of multiple single linestrings
+        """
+
+        if not isinstance(merged_line, geometry.LineString):
+            merged_line = [ls for ls in merged_line]
+        else:
+            merged_line = [merged_line]
+        return merged_line
+
     def shared_segs(self, g1, g2):
         """
         This function returns the segments that are shared with two input geometries.
@@ -235,9 +247,10 @@ class Join(Extract):
                 shared_segments = backward
             else:
                 # both backward and forward contains objects, so combine
-                shared_segments = geometry.MultiLineString(
-                    [linemerge(forward), linemerge(backward)]
-                )
+                forward = self.validate_linemerge(linemerge(forward))
+                backward = self.validate_linemerge(linemerge(backward))
+
+                shared_segments = geometry.MultiLineString(forward + backward)
 
             # add shared paths to segments
             self.segments.extend([list(shared_segments)])

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -91,6 +91,12 @@ def insert_coords_in_line(line, tree_splitter):
     )
     splitter_dist = splitter_dist[splitter_dist > 0]
 
+    # sort distance of non-existing junctions and apply sorting to the splitter distance
+    # and corresponing junction coordinates to be inserted.
+    sort_idx = splitter_dist.argsort()
+    splitter_dist = splitter_dist[sort_idx]
+    pts_xy_nonexst = pts_xy_nonexst[sort_idx]
+
     # get eucledian distance of all coords of line
     ls_xy_roll = np.roll(ls_xy, 1, axis=0)
     roll_min_ls = ls_xy_roll - ls_xy

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -154,7 +154,7 @@ def serialize_as_geodataframe(topo_object, url=False):
     return gdf
 
 
-def serialize_as_svg(topo_object, separate, include_junctions=False):
+def serialize_as_svg(topo_object, separate=False, include_junctions=False):
     from IPython.display import SVG, display
     from shapely import geometry
 
@@ -184,12 +184,21 @@ def serialize_as_svg(topo_object, separate, include_junctions=False):
     else:
         arcs = topo_object["linestrings"]
 
-    if separate:
+    if separate and not include_junctions:
         for ix, line in enumerate(arcs):
             svg = line._repr_svg_()
             print(ix, line.wkt)
             display(SVG(svg))
-    elif include_junctions:
+    elif separate and include_junctions:
+        pts = topo_object["junctions"]
+        for ix, line in enumerate(arcs):
+            svg = geometry.GeometryCollection(
+                [line, geometry.MultiPoint(pts)]
+            )._repr_svg_()
+            print(ix, line.wkt)
+            display(SVG(svg))
+
+    elif not separate and include_junctions:
         pts = topo_object["junctions"]
         display(
             geometry.GeometryCollection(


### PR DESCRIPTION
This PR fix https://github.com/mattijn/topojson/issues/63. 
The issue was twofold:
- Firstly, shared paths containing both forward and backward elements, where the forward or backward elements are non-contiguous could not be directly loaded as MultiLineString (this: `MultiLineString([LineString, MultiLineString])` doesn't work in shapely)
- Secondly, in the case a LineString has partially shared paths with non-existing junctions. Then these are inserted before splitting. These non-existing junctions are rightly detected, but were not sorted in the right order before insertion. Leading to problems in the `Dedup` phase. Fixed in `Cut` phase.

Last, the `.to_svg()` function was improved so one can use `.to_svg(separate=True, include_junctions=True)` during debugging.

Like:
```python
from topojson.core.cut import Cut
data = [
    {"type": "LineString", "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)]},
    {
        "type": "LineString",
        "coordinates": [
            (5, 0),
            (25, 0),
            (25, 5),
            (16, 5),
            (16, 10),
            (14, 10),
            (14, 5),
            (0, 5),
        ],
    },
]
c = Cut(data)
c.to_svg(separate=True, include_junctions=True)
```
<img width="284" alt="image" src="https://user-images.githubusercontent.com/5186265/69916356-745bb200-145a-11ea-9956-0ffd3a8a3442.png">

