### PR TITLE
include geojson serialization and geo_inferface

### DIFF
--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -12,6 +12,7 @@ from ..ops import delta_encoding
 from ..utils import TopoOptions
 from ..utils import serialize_as_svg
 from ..utils import serialize_as_json
+from ..utils import serialize_as_geojson
 
 
 class Topology(Hashmap):
@@ -91,6 +92,11 @@ class Topology(Hashmap):
     def __repr__(self):
         return "Topology(\n{}\n)".format(pprint.pformat(self.output))
 
+    @property
+    def __geo_interface__(self):
+        topo_object = copy.deepcopy(self.output)
+        return serialize_as_geojson(topo_object, validate=False, lyr_idx=0)
+
     def to_dict(self, options=False):
         topo_object = copy.deepcopy(self.output)
         topo_object = self.resolve_coords(topo_object)
@@ -103,7 +109,7 @@ class Topology(Hashmap):
     def to_svg(self, separate=False, include_junctions=False):
         serialize_as_svg(self.output, separate, include_junctions)
 
-    def to_json(self, fp=None, options=False, indent=4, maxlinelength=88):
+    def to_json(self, fp=None, options=False, pretty=True, indent=4, maxlinelength=88):
         topo_object = copy.deepcopy(self.output)
         topo_object = self.resolve_coords(topo_object)
         if options is False:
@@ -111,7 +117,16 @@ class Topology(Hashmap):
         elif options is True:
             topo_object["options"] = vars(topo_object["options"])
         return serialize_as_json(
-            topo_object, fp, indent=indent, maxlinelength=maxlinelength
+            topo_object, fp, pretty=pretty, indent=indent, maxlinelength=maxlinelength
+        )
+
+    def to_geojson(
+        self, fp=None, pretty=True, indent=4, maxlinelength=88, validate=True, lyr_idx=0
+    ):
+        topo_object = copy.deepcopy(self.output)
+        fc = serialize_as_geojson(topo_object, validate=validate, lyr_idx=lyr_idx)
+        return serialize_as_json(
+            fc, fp, pretty=pretty, indent=indent, maxlinelength=maxlinelength
         )
 
     def to_gdf(self):


### PR DESCRIPTION
This PR includes support for the `__geo_interface__` on the topology object. Since the `__geo_interface__` is build upon the `geojson` standard this also means there is now a `.to_geojson()` function.  

The `pretty` and `validate` parameter will probably change later to `False` and `False` instead of the current `True`, `True`.

---

With the `__geo_interface__` in place, visualization can be done directly using the `Topology` object in Altair:

Prepare a `Topology` object:
```python
import geopandas as gpd
import topojson

df = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
df = df[df.continent == 'Africa']

tp = topojson.Topology(df)
tp.toposimplify(1, inplace=True)
```

And then:
```python
import altair as alt

# from this PR forward: with the __geo_interface__ serialization in place
# the serialization from TopoJSON to GeoJSON can also be done on the Python side
# btw: this happens within Altair
alt.Chart(tp).mark_geoshape().encode(color='name:N')
```
  
![output_1_1](https://user-images.githubusercontent.com/5186265/79887172-98646380-83fa-11ea-8240-f382fc1d7635.png)

Compare this to the current approach (still and will be completely OK as well):

```python
# conventional the serialization from TopoJSON to GeoJSON happens on the Vega side:
tp.to_alt(color='properties.name:N')
```
![output_2_1](https://user-images.githubusercontent.com/5186265/79888846-859f5e00-83fd-11ea-8e35-2a0b22d00396.png)

---
This PR also means that there will be two approaches to create a `GeoDataFrame`:

```python
# conventional through fiona using the `TopoJSON` driver (under the hood)
tp.to_gdf().plot()
```

![output_3_1](https://user-images.githubusercontent.com/5186265/79887403-014bdb80-83fb-11ea-9567-2415007230a0.png)

And now:

```python
import json

# from this PR forward: using the .to_geojson() function
gpd.GeoDataFrame().from_features(
    json.loads(tp.to_geojson(validate=False))['features']
).plot()
```

![output_3_1](https://user-images.githubusercontent.com/5186265/79887403-014bdb80-83fb-11ea-9567-2415007230a0.png)

Maybe the `to_gdf()` function should get a `driver` parameter, that can be set to `TopoJSON` or `GeoJSON`?

I will not close the relevant issues, since tests are not written yet.
