### PR TITLE
Fix hashmap and topology errors

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -258,9 +258,9 @@ def test_topology_to_geojson_nested_geometrycollection():
             ],
         }
     }
-    topo = topojson.Topology(data).to_geojson()
+    topo = topojson.Topology(data).to_geojson(pretty=False)
 
-    assert len(topo["linestrings"]) == 2
+    assert "]]]}]}]}}]}" in topo
 
 
 def test_topology_to_geojson_polygon_geometrycollection():
@@ -275,7 +275,7 @@ def test_topology_to_geojson_polygon_geometrycollection():
     }
     topo = topojson.Topology(data).to_geojson()
 
-    assert len(topo["linestrings"]) == 2
+    assert "]]}}]}" in topo
 
 
 def test_topology_to_geojson_linestring_polygon():
@@ -294,7 +294,7 @@ def test_topology_to_geojson_linestring_polygon():
     }
     topo = topojson.Topology(data).to_geojson()
 
-    assert len(topo["linestrings"]) == 2
+    assert "]]}}]}" in topo
 
 
 def test_topology_to_geojson_polygon_point():
@@ -304,5 +304,6 @@ def test_topology_to_geojson_polygon_point():
     ]
     topo = topojson.Topology(data).to_geojson()
 
-    assert len(topo["linestrings"]) == 1
-    assert len(topo["coordinates"]) == 1
+    assert "]]]}}" in topo  # feat 1
+    assert "]}}]}" in topo  # feat 2
+

--- a/topojson/__init__.py
+++ b/topojson/__init__.py
@@ -20,7 +20,7 @@ Main Features
   - Optional support for UI controls to exploring the results of topoquantize
     and toposimplify interactively if ipywidgets is installed.
 """
-__version__ = "1.0rc8"
+__version__ = "1.0rc9"
 __all__ = ["Topology "]
 
 from .core.topology import Topology  # noqa

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -352,8 +352,12 @@ class Hashmap(Dedup):
         Function that resolves the arcs based on the type of the feature
         """
         if feat["type"] == "LineString":
-            f_arc = feat["arcs"][0]
+            if "geometries" in feat:
+                f_arc = feat["geometries"][0]["arcs"][0]
+            else:
+                f_arc = feat["arcs"][0]
             feat["arcs"] = f_arc
+            feat.pop("geometries", None)
 
         elif feat["type"] == "Polygon":
             if "geometries" in feat:

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -109,7 +109,7 @@ class Topology(Hashmap):
     def to_svg(self, separate=False, include_junctions=False):
         serialize_as_svg(self.output, separate, include_junctions)
 
-    def to_json(self, fp=None, options=False, pretty=True, indent=4, maxlinelength=88):
+    def to_json(self, fp=None, options=False, pretty=False, indent=4, maxlinelength=88):
         topo_object = copy.deepcopy(self.output)
         topo_object = self.resolve_coords(topo_object)
         if options is False:
@@ -121,9 +121,16 @@ class Topology(Hashmap):
         )
 
     def to_geojson(
-        self, fp=None, pretty=True, indent=4, maxlinelength=88, validate=True, lyr_idx=0
+        self,
+        fp=None,
+        pretty=False,
+        indent=4,
+        maxlinelength=88,
+        validate=False,
+        lyr_idx=0,
     ):
         topo_object = copy.deepcopy(self.output)
+        topo_object = self.resolve_coords(topo_object)
         fc = serialize_as_geojson(topo_object, validate=validate, lyr_idx=lyr_idx)
         return serialize_as_json(
             fc, fp, pretty=pretty, indent=indent, maxlinelength=maxlinelength


### PR DESCRIPTION
This PR fix 7 broken tests that were committed in https://github.com/mattijn/topojson/commit/1646ee79997581112f02f34ac8d8e1aaefbc8466. 

The tests regarding the `Hashmap` class, can now correctly parse nested geometry collections which could not parse `hashmapper` before .

The tests regarding the `.to_geojson()` also can now correctly parse nested geometry collections, and combinations of both points and polygons. This is quite cumbersome, since line strings and polygons are supported through a top-level `arcs` object, but coordinates of point and multipoint types are stored within the object itself (which can be quantized). 

Default the `pretty` and `validate` in the `.to_json()` and `to_geojson()` to `False`.

Last, bump version to `rc9`, which can be released now since all 136 tests pass.
