### PR TITLE
WIP: include fast_shared_paths strategy

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -597,3 +597,16 @@ def test_join_linemerge_multilinestring():
 
     assert len(topo["linestrings"]) == 2
     assert len(topo["junctions"]) == 7
+
+
+# test the shared_paths_approach using numpy
+def test_join_shared_paths_numpy():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data, options={"shared_paths": "numpy"}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+    )

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -26,7 +26,7 @@ def test_topology_winding_order_TopoOptions():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 8
+    assert len(topo["options"]) == 9
 
 
 # test winding order using kwarg variables
@@ -37,7 +37,7 @@ def test_topology_winding_order_kwarg_vars():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 8
+    assert len(topo["options"]) == 9
 
 
 def test_topology_computing_topology():
@@ -306,4 +306,3 @@ def test_topology_to_geojson_polygon_point():
 
     assert "]]]}}" in topo  # feat 1
     assert "]}}]}" in topo  # feat 2
-

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -171,7 +171,7 @@ class Join(Extract):
                 s_coords_list.extend(s_coords)
 
             unique_s_coords = np.unique(np.array(s_coords_list), axis=0)
-            self.junctions = [geometry.asPoint(xy) for xy in unique_s_coords]
+            self.junctions = [geometry.Point(xy) for xy in unique_s_coords]
 
         elif self.options.shared_paths == "shapely":
 

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -67,6 +67,9 @@ class Topology(Hashmap):
         between `CW_CCW` for clockwise orientation for outer rings and counter-clockwise
         for interior rings. Or `CCW_CW` for counter-clockwise for outer rings and 
         clockwise for interior rings. Default is `CW_CCW`.
+    shared_paths : str
+        Sets the shared paths strategy. Choose `numpy` for speed or `shapely` for 
+        correctness 
     """
 
     def __init__(
@@ -80,6 +83,7 @@ class Topology(Hashmap):
         simplify_with="shapely",
         simplify_algorithm="dp",
         winding_order="CW_CCW",
+        shared_paths="shapely",
     ):
 
         options = TopoOptions(locals())

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -519,7 +519,7 @@ def select_unique(data):
     return sorted_data[row_mask]
 
 
-def select_unique_combs(linestrings, shared_paths="numpy"):
+def select_unique_combs(linestrings, shared_paths="shapely"):
     """
     Given a set of input linestrings will create unique couple combinations.
     Each combination created contains a couple of two linestrings where the enveloppe

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -48,6 +48,7 @@ class TopoOptions(object):
         simplify_with="shapely",
         simplify_algorithm="dp",
         winding_order=None,
+        shared_paths="shapely",
     ):
         # get all arguments
         arguments = locals()
@@ -93,6 +94,11 @@ class TopoOptions(object):
             self.winding_order = arguments["winding_order"]
         else:
             self.winding_order = None
+
+        if "shared_paths" in arguments:
+            self.shared_paths = arguments["shared_paths"]
+        else:
+            self.shared_paths = "shapely"
 
     def __repr__(self):
         return "TopoOptions(\n  {}\n)".format(pprint.pformat(self.__dict__))


### PR DESCRIPTION
_Work in progress_

Completely untested strategy to use NumPy as opt in for the current only route of a time-expensive (but topological correct) `shapely.ops.shared_paths` strategy.
