### PR TITLE
Use dicts and sets in to get junctions

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -587,3 +587,15 @@ def test_join_linemerge_multilinestring():
 
     assert len(topo["linestrings"]) == 2
     assert len(topo["junctions"]) == 7
+
+    # test the shared_paths_approach using dicts
+    def test_join_shared_paths_dict():
+        data = {
+            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+            "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+        }
+        topo = Join(data, options={"shared_paths": "dict"}).to_dict()
+
+        assert geometry.MultiPoint(topo["junctions"]).equals(
+            geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+        )

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -67,6 +67,9 @@ class Topology(Hashmap):
         between `CW_CCW` for clockwise orientation for outer rings and counter-clockwise
         for interior rings. Or `CCW_CW` for counter-clockwise for outer rings and 
         clockwise for interior rings. Default is `CW_CCW`.
+    shared_paths : str
+         Sets the shared paths strategy. Choose `coords` for speed or `shapely` for
+         correctness in case of topologically unprecise geometry.
     """
 
     def __init__(
@@ -80,6 +83,7 @@ class Topology(Hashmap):
         simplify_with="shapely",
         simplify_algorithm="dp",
         winding_order="CW_CCW",
+        shared_paths="shapely",
     ):
 
         options = TopoOptions(locals())

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -48,6 +48,7 @@ class TopoOptions(object):
         simplify_with="shapely",
         simplify_algorithm="dp",
         winding_order=None,
+        shared_paths="shapely",
     ):
         # get all arguments
         arguments = locals()
@@ -93,6 +94,11 @@ class TopoOptions(object):
             self.winding_order = arguments["winding_order"]
         else:
             self.winding_order = None
+
+        if "shared_paths" in arguments:
+            self.shared_paths = arguments["shared_paths"]
+        else:
+            self.shared_paths = "shapely"
 
     def __repr__(self):
         return "TopoOptions(\n  {}\n)".format(pprint.pformat(self.__dict__))


### PR DESCRIPTION
Hi,

I tried to implement similar algorithm `libpysal` is using, to determine contiguity to get junctions and it seems to be faster than numpy solution in #75. It is based on performant dict/set.

```py
gdf = gpd.read_file(gpd.datasets.get_path('nybb'))

%%timeit
topojson.Topology(gdf, shared_paths='dict')
# 1.77 s ± 10.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
topojson.Topology(gdf, shared_paths='shapely')
# 5.94 s ± 376 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
topojson.Topology(gdf, shared_paths='numpy')
# 3.72 s ± 133 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Using `naturalearth_lowres` all versions seems to be equal.

```
1.52 s ± 92.8 ms per loop,
1.64 s ± 112 ms per loop
1.45 s ± 47.9 ms per loop
```

I haven't tested the correctness of resulting junctions, but simplified gdf looks alright.

The whole diff is between lines 156-189. It is based on #75 to have a comparison.

_edit: it is wrong at the moment :) working on it_