### PR TITLE
Improve serialization of geopandas objects and code cleaning

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -176,19 +176,7 @@ def test_cut_super_function_cut():
     )
     topo = Cut(data).to_dict()
 
-    assert list(topo.keys()) == [
-        "type",
-        "linestrings",
-        "coordinates",
-        "bookkeeping_geoms",
-        "bookkeeping_coords",
-        "objects",
-        "options",
-        "bbox",
-        "junctions",
-        "bookkeeping_duplicates",
-        "bookkeeping_linestrings",
-    ]
+    assert len(list(topo.keys())) == 11
 
 
 # this geometry is added on several classes (extract and hashmap). Not yet clear in

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -144,20 +144,7 @@ def test_dedup_super_function():
     )
     topo = Dedup(data).to_dict()
 
-    assert list(topo.keys()) == [
-        "type",
-        "linestrings",
-        "coordinates",
-        "bookkeeping_geoms",
-        "bookkeeping_coords",
-        "objects",
-        "options",
-        "bbox",
-        "junctions",
-        "bookkeeping_duplicates",
-        "bookkeeping_arcs",
-        "bookkeeping_shared_arcs",
-    ]
+    assert len(list(topo.keys())) == 12
 
 
 # this test was added since there is an error stating the following during Dedup:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -325,3 +325,12 @@ def test_extract_single_multilinestring_list():
     topo = Extract(data).to_dict()
 
     assert len(topo["bookkeeping_geoms"]) == 2
+
+
+def test_extract_geopandas_geodataframe():
+    data = geopandas.read_file(
+        "tests/files_geojson/naturalearth_alb_grc.geojson", driver="GeoJSON"
+    )
+    topo = Extract(data).to_dict()
+
+    assert len(topo["bookkeeping_geoms"]) == 3

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -113,14 +113,7 @@ def test_hashmap_super_function():
     topo = Hashmap(data).to_dict()
     geoms = topo["objects"]["data"]["geometries"][0]["geometries"]
 
-    assert list(topo.keys()) == [
-        "type",
-        "linestrings",
-        "coordinates",
-        "objects",
-        "options",
-        "bbox",
-    ]
+    assert len(list(topo.keys())) == 6
     assert geoms[0]["arcs"] == [[-3, 0]]
     assert geoms[1]["arcs"] == [[1, 2]]
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -546,17 +546,7 @@ def test_join_super_function_extract():
     )
     topo = Join(data).to_dict()
 
-    assert list(topo.keys()) == [
-        "type",
-        "linestrings",
-        "coordinates",
-        "bookkeeping_geoms",
-        "bookkeeping_coords",
-        "objects",
-        "options",
-        "bbox",
-        "junctions",
-    ]
+    assert len(list(topo.keys())) == 9
 
 
 def test_join_point():

--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -55,11 +55,26 @@ class Cut(Join):
         return "Cut(\n{}\n)".format(pprint.pformat(self.output))
 
     def to_dict(self):
+        """
+        Convert the Cut object to a dictionary.
+        """
         topo_object = copy.copy(self.output)
-        topo_object["options"] = vars(topo_object["options"])
+        topo_object["options"] = vars(self.options)
         return topo_object
 
     def to_svg(self, separate=False, include_junctions=False):
+        """
+        Display the linestrings and junctions as SVG.
+
+        Parameters
+        ----------
+        separate : boolean
+            If `True`, each of the linestrings will be displayed separately. 
+            Default is `False`
+        include_junctions : boolean
+            If `True`, the detected junctions will be displayed as well. 
+            Default is `False`
+        """
         serialize_as_svg(self.output, separate, include_junctions)
 
     def cutter(self, data):

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -29,11 +29,26 @@ class Dedup(Cut):
         return "Dedup(\n{}\n)".format(pprint.pformat(self.output))
 
     def to_dict(self):
+        """
+        Convert the Dedup object to a dictionary.
+        """
         topo_object = copy.copy(self.output)
-        topo_object["options"] = vars(topo_object["options"])
+        topo_object["options"] = vars(self.options)
         return topo_object
 
     def to_svg(self, separate=False, include_junctions=False):
+        """
+        Display the linestrings and junctions as SVG.
+
+        Parameters
+        ----------
+        separate : boolean
+            If `True`, each of the linestrings will be displayed separately. 
+            Default is `False`
+        include_junctions : boolean
+            If `True`, the detected junctions will be displayed as well. 
+            Default is `False`
+        """
         serialize_as_svg(self.output, separate, include_junctions)
 
     def deduper(self, data):

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -29,17 +29,35 @@ class Hashmap(Dedup):
         return "Hashmap(\n{}\n)".format(pprint.pformat(self.output))
 
     def to_dict(self):
+        """
+        Convert the Hashmap object to a dictionary.
+        """
         topo_object = copy.copy(self.output)
-        topo_object["options"] = vars(topo_object["options"])
+        topo_object["options"] = vars(self.options)
         return topo_object
 
     def to_svg(self, separate=False, include_junctions=False):
+        """
+        Display the linestrings and junctions as SVG.
+
+        Parameters
+        ----------
+        separate : boolean
+            If `True`, each of the linestrings will be displayed separately. 
+            Default is `False`
+        include_junctions : boolean
+            If `True`, the detected junctions will be displayed as well. 
+            Default is `False`
+        """
         serialize_as_svg(self.output, separate, include_junctions)
 
-    def to_json(self, fp=None):
+    def to_json(self):
+        """
+        Convert the Hashmap object to a JSON object.
+        """
         topo_object = copy.copy(self.output)
-        topo_object["options"] = vars(topo_object["options"])
-        return serialize_as_json(topo_object, fp)
+        topo_object["options"] = vars(self.options)
+        return serialize_as_json(topo_object, fp=None)
 
     def to_alt(
         self,
@@ -49,8 +67,30 @@ class Hashmap(Dedup):
         projection="identity",
         objectname="data",
     ):
+        """
+        Display as Altair visualization.
+
+        Parameters
+        ----------
+        mesh : boolean
+            If `True`, render arcs only (mesh object). If `False` render as geoshape. 
+            Default is `True`
+        color : str
+            Assign an property attribute to be used for color encoding. Remember that
+            most of the time the wanted attribute is nested within properties. Moreover,
+            specific type declaration is required. Eg `color='properties.name:N'`. 
+            Default is `None`
+        tooltip : boolean
+            Option to include or exclude tooltips on geoshape objects
+            Default is `True`.
+        projection : str
+            Defines the projection of the visualization. Defaults to a non-geographic,
+            Cartesian projection (known by Altair as `identity`).
+        objectname : str
+            The name of the object within the Topology to display.
+            Default is `data` 
+        """
         topo_object = copy.copy(self.output)
-        del topo_object["options"]
         return serialize_as_altair(
             topo_object, mesh, color, tooltip, projection, objectname
         )

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -64,11 +64,26 @@ class Join(Extract):
         return "Join(\n{}\n)".format(pprint.pformat(self.output))
 
     def to_dict(self):
+        """
+        Convert the Join object to a dictionary.
+        """
         topo_object = copy.copy(self.output)
-        topo_object["options"] = vars(topo_object["options"])
+        topo_object["options"] = vars(self.options)
         return topo_object
 
     def to_svg(self, separate=False, include_junctions=False):
+        """
+        Display the linestrings and junctions as SVG.
+
+        Parameters
+        ----------
+        separate : boolean
+            If `True`, each of the linestrings will be displayed separately. 
+            Default is `False`
+        include_junctions : boolean
+            If `True`, the detected junctions will be displayed as well. 
+            Default is `False`
+        """
         serialize_as_svg(self.output, separate, include_junctions)
 
     def joiner(self, data):

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -463,7 +463,7 @@ def serialize_as_geojson(
     indent=4,
     maxlinelength=88,
     validate=False,
-    lyr_idx=0,
+    objectname="data",
 ):
     from shapely.geometry import asShape
 
@@ -483,8 +483,7 @@ def serialize_as_geojson(
             np_arcs = dequantize(np_arcs, scale, translate)
 
     # select object member from topology object
-    lyr_name = list(topo_object["objects"].keys())[lyr_idx]
-    features = topo_object["objects"][lyr_name]["geometries"]
+    features = topo_object["objects"][objectname]["geometries"]
 
     # prepare geojson featurecollection
     fc = {"type": "FeatureCollection", "features": []}
@@ -559,7 +558,7 @@ def serialize_as_ipywidgets(topo_object, toposimplify, topoquantize):
     tq = topoquantize
 
     # set to simplification package for speed
-    topo_object.output["options"].simplify_with = "simplification"
+    topo_object.options.simplify_with = "simplification"
 
     alg = widgets.RadioButtons(
         options=[("Douglas-Peucker", "dp"), ("Visvalingam-Whyatt", "vw")],


### PR DESCRIPTION
This PR mainly targets the `topojson.core.extract.py` file. 

It refactors the parsing of GeoDataFrames and GeoSeries. Now a GeoDataFrame is serialized from `gdf.to_dict(orient='records')` and a GeoSeries from `series.to_dict()`. No need to go through the much slower `__geo_interface__`.

Also this PR prepend non public attributes and functions in the `Extract` class with a `_`.
And because I removed the `options` object out of the `.options`, Ihad to change some other classes and tests as well. 

Also more docstrings are included.