### PR TITLE
Prepare Cut for coords routine

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -231,3 +231,10 @@ def test_cut_linemerge_multilinestring():
 
     assert len(topo["linestrings"]) == 12
     assert len(topo["junctions"]) == 7
+
+
+def test_cut_junctions_coords():
+    data = geopandas.read_file("tests/files_geojson/naturalearth_alb_grc.geojson")
+    topo = Cut(data, options={"shared_paths": "coords"}).to_dict()
+
+    assert len(topo["linestrings"]) == 3

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -26,7 +26,7 @@ def test_topology_winding_order_TopoOptions():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 8
+    assert len(topo["options"]) == 9
 
 
 # test winding order using kwarg variables
@@ -37,7 +37,7 @@ def test_topology_winding_order_kwarg_vars():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 8
+    assert len(topo["options"]) == 9
 
 
 def test_topology_computing_topology():
@@ -306,4 +306,3 @@ def test_topology_to_geojson_polygon_point():
 
     assert "]]]}}" in topo  # feat 1
     assert "]}}]}" in topo  # feat 2
-


### PR DESCRIPTION
This PR is a start to make the Cut class ready for the `coords` routine. 
Currently it create some small changes to skip the step where coordinates were inserted in LineStrings that contain shared paths without shared junctions.

But while being in the class I realised that the real bottleneck is here: https://github.com/mattijn/topojson/blob/master/topojson/core/cut.py#L130. 

The `find_duplicates()` [function](https://github.com/mattijn/topojson/blob/master/topojson/core/cut.py#L184-L212) becomes really slow if the number of features are high (using eg. the sample.geojson test file)