### PR TITLE
Fix invalid geoms

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -334,3 +334,14 @@ def test_extract_geopandas_geodataframe():
     topo = Extract(data).to_dict()
 
     assert len(topo["bookkeeping_geoms"]) == 3
+
+
+# dict shoud have a valued key:geom_object. Otherwise key:value is removed
+def test_extract_invalid_dict_item():
+    data = {
+        "type": "MultiPolygon",
+        "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+    }
+    topo = Extract(data).to_dict()
+
+    assert len(topo["bookkeeping_geoms"]) == 0

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -599,3 +599,19 @@ def test_join_linemerge_multilinestring():
         assert geometry.MultiPoint(topo["junctions"]).equals(
             geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
         )
+
+    # test a list of two invalid geometric objects with prequantize True
+    def test_join_invalid_prequantize():
+        data = [
+            {
+                "type": "MultiPolygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            {
+                "type": "MultiPolygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+        ]
+        topo = Join(data, options={"prequantize": True}).to_dict()
+
+        assert len(topo["junctions"]) == 0

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -26,7 +26,7 @@ def test_topology_winding_order_TopoOptions():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 8
+    assert len(topo["options"]) == 9
 
 
 # test winding order using kwarg variables
@@ -37,7 +37,7 @@ def test_topology_winding_order_kwarg_vars():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 8
+    assert len(topo["options"]) == 9
 
 
 def test_topology_computing_topology():
@@ -191,9 +191,11 @@ def test_topology_polygon_point():
 
 def test_topology_point():
     data = [{"type": "Point", "coordinates": [0.5, 0.5]}]
+    # topo = topojson.Topology(data, topoquantize=True).to_dict()
     with pytest.raises(SystemExit) as topo:
         topojson.Topology(data, topoquantize=True).to_dict()
 
+    # assert len(topo["arcs"]) == 0
     assert topo.type == SystemExit
     assert topo.value.code == "Cannot quantize when xmax-xmin OR ymax-ymin equals 0"
 
@@ -307,3 +309,14 @@ def test_topology_to_geojson_polygon_point():
     assert "]]]}}" in topo  # feat 1
     assert "]}}]}" in topo  # feat 2
 
+
+def test_topology_to_geojson_quantized_points_only():
+    data = [{"type": "MultiPoint", "coordinates": [[0.5, 0.5], [1.0, 1.0]]}]
+    topo = topojson.Topology(data, prequantize=True).to_dict()
+
+    assert len(topo["arcs"]) == 0
+    assert topo["objects"]["data"]["geometries"][0]["coordinates"] == [
+        [0, 0],
+        [999999, 999999],
+    ]
+    assert topo["transform"]["translate"] == [0.5, 0.5]

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -144,6 +144,10 @@ class Join(Extract):
         ptbs = geometry.asMultiPoint(data["coordinates"]).bounds
         data["bbox"] = compare_bounds(lsbs, ptbs)
 
+        if not data["linestrings"] and not data["coordinates"]:
+            data["junctions"] = self.junctions
+            return data
+
         # prequantize linestrings if required
         if self.options.prequantize > 0:
             # set default if not specifically given in the options
@@ -165,6 +169,7 @@ class Join(Extract):
             return data
 
         if self.options.shared_paths == "coords":
+
             def _get_verts(geom):
                 # get coords of each LineString
                 return [x for x in geom.coords]
@@ -176,7 +181,9 @@ class Join(Extract):
                 verts = _get_verts(ls)
                 for i, vert in enumerate(verts):
                     ran = geoms.pop(vert, None)
-                    neighs = sorted([verts[i - 1], verts[i + 1 if i < len(verts) - 1 else 0]])
+                    neighs = sorted(
+                        [verts[i - 1], verts[i + 1 if i < len(verts) - 1 else 0]]
+                    )
                     if ran and ran != neighs:
                         junctions.append(vert)
                     geoms[vert] = neighs

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -298,6 +298,8 @@ class Topology(Hashmap):
         result = copy.deepcopy(self)
         arcs = result.output["arcs"]
 
+        if not arcs:
+            return result
         # dequantize if quantization is applied
         if "transform" in result.output.keys():
             np_arcs = np_array_from_arcs(arcs)

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -400,22 +400,23 @@ def serialize_as_svg(topo_object, separate=False, include_junctions=False):
     keys = topo_object.keys()
     if "arcs" in keys:
         arcs = topo_object["arcs"]
-        # dequantize if quantization is applied
-        if "transform" in keys:
+        if arcs:
+            # dequantize if quantization is applied
+            if "transform" in keys:
 
-            np_arcs = np_array_from_arcs(arcs)
+                np_arcs = np_array_from_arcs(arcs)
 
-            transform = topo_object["transform"]
-            scale = transform["scale"]
-            translate = transform["translate"]
+                transform = topo_object["transform"]
+                scale = transform["scale"]
+                translate = transform["translate"]
 
-            np_arcs = dequantize(np_arcs, scale, translate)
-            l_arcs = []
-            for ls in np_arcs:
-                l_arcs.append(ls[~np.isnan(ls)[:, 0]].tolist())
-            arcs = l_arcs
+                np_arcs = dequantize(np_arcs, scale, translate)
+                l_arcs = []
+                for ls in np_arcs:
+                    l_arcs.append(ls[~np.isnan(ls)[:, 0]].tolist())
+                arcs = l_arcs
 
-        arcs = [geometry.LineString(arc) for arc in arcs]
+            arcs = [geometry.LineString(arc) for arc in arcs]
 
     else:
         arcs = topo_object["linestrings"]
@@ -475,18 +476,18 @@ def serialize_as_geojson(
 
     # prepare arcs from topology object
     arcs = topo_object["arcs"]
+    transform = None
+    if "transform" in topo_object.keys():
+        transform = topo_object["transform"]
+        scale = transform["scale"]
+        translate = transform["translate"]
+
     if arcs:
         np_arcs = np_array_from_arcs(arcs)
-
-        transform = None
         # dequantize if quantization is applied
-        if "transform" in topo_object.keys():
-
-            transform = topo_object["transform"]
-            scale = transform["scale"]
-            translate = transform["translate"]
-
-            np_arcs = dequantize(np_arcs, scale, translate)
+        np_arcs = dequantize(np_arcs, scale, translate)
+    else:
+        np_arcs = None
 
     # select object member from topology object
     features = topo_object["objects"][objectname]["geometries"]


### PR DESCRIPTION
This PR fix #79.

```python
geoms_bad = [
    {
        "type": "MultiPolygon",
        "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
    },
    {
        "type": "MultiPolygon",
        "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
    }
]

import topojson
tp = topojson.Topology(geoms_bad)
tp
```

> ```bash
> WARNING:root:removed 2 invalid geometric objects
> Topology(
> {'arcs': [],
>  'bbox': [],
>  'coordinates': [],
>  'objects': {'data': {'geometries': [], 'type': 'GeometryCollection'}},
>  'type': 'Topology'}
> )
> ```

Where the result still can be parsed to the `to_geojson()` function:
```python
tp.to_geojson()
```

> ```bash
> '{"type": "FeatureCollection", "features": []}'
> ```