### PR TITLE
Adopt numpy-hash approach to find duplicates

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -53,6 +53,8 @@ def test_cut_reversed_rings_ABCA_ACBA_no_cuts():
 
 
 # cut rotated duplicate rings BCAB & ABCA have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
 def test_cut_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
     data = {
         "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
@@ -61,7 +63,7 @@ def test_cut_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
     topo = Cut(data).to_dict()
 
     assert len(topo["junctions"]) == 0
-    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+    assert len(topo["bookkeeping_duplicates"]) == 0
 
 
 # cut ring ABCA & line ABCA have no cuts
@@ -83,6 +85,8 @@ def test_cut_ring_ABCA_line_ABCA_no_cuts():
 
 
 # cut ring BCAB & line ABCA have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
 def test_cut_ring_BCAB_line_ABCA_no_cuts():
     data = {
         "abcaLine": {
@@ -97,10 +101,12 @@ def test_cut_ring_BCAB_line_ABCA_no_cuts():
     topo = Cut(data).to_dict()
 
     assert len(topo["junctions"]) == 0
-    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+    assert len(topo["bookkeeping_duplicates"]) == 0
 
 
 # cut ring ABCA & line BCAB have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
 def test_cut_ring_ABCA_line_BCAB_no_cuts():
     data = {
         "bcabLine": {
@@ -115,7 +121,7 @@ def test_cut_ring_ABCA_line_BCAB_no_cuts():
     topo = Cut(data).to_dict()
 
     assert len(topo["junctions"]) == 0
-    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+    assert len(topo["bookkeeping_duplicates"]) == 0
 
 
 # overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -68,7 +68,7 @@ class Dedup(Cut):
         # create numpy array from bookkeeping_geoms variable for numerical computation
         array_bk = np_array_from_lists(data["bookkeeping_linestrings"])
         array_bk_sarcs = None
-        if data["bookkeeping_duplicates"].size != 0:
+        if len(data["bookkeeping_duplicates"]):
             array_bk_sarcs, dup_pair_list = self.deduplicate(
                 data["bookkeeping_duplicates"], data["linestrings"], array_bk
             )
@@ -97,7 +97,7 @@ class Dedup(Cut):
         # prepare to return object
         del data["bookkeeping_linestrings"]
         data["bookkeeping_arcs"] = lists_from_np_array(array_bk)
-        if data["bookkeeping_duplicates"].size != 0:
+        if len(data["bookkeeping_duplicates"]):
             data["bookkeeping_shared_arcs"] = array_bk_sarcs.astype(np.int64).tolist()
             data["bookkeeping_duplicates"] = lists_from_np_array(
                 data["bookkeeping_duplicates"][dup_pair_list != -99]


### PR DESCRIPTION
This PR implements the method as prototyped in https://github.com/mattijn/topojson/pull/78.

The method collects the hash identifiers of sorted linestring coordinates through tuples. With this approach every linestring can be represented as an equal length integer.

One side-effect are rotated rings. Using the shapely shared_paths function for junction detection these are not equal anymore as the hash is not the same. With a ring, the first and last coordinate are the same, but if the ring is rotated than these first and last coordinate are not the same anymore and so not the hash.

With the dictlist coords approach the first/last coordinated of a ring is seen as a junction so a rotated polygon is split in two duplicate segments. 

Eg. test https://github.com/mattijn/topojson/blob/master/tests/test_cut.py#L58:L66 and two more were changed to capture this new behavior.