### PR TITLE
Include prevent_oversimplify and change shared_paths to shared_coords

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -241,6 +241,6 @@ def test_cut_linemerge_multilinestring():
 
 def test_cut_junctions_coords():
     data = geopandas.read_file("tests/files_geojson/naturalearth_alb_grc.geojson")
-    topo = Cut(data, options={"shared_paths": "coords"}).to_dict()
+    topo = Cut(data, options={"shared_coords": True}).to_dict()
 
     assert len(topo["linestrings"]) == 3

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -594,7 +594,7 @@ def test_join_linemerge_multilinestring():
             "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
             "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
         }
-        topo = Join(data, options={"shared_paths": "dict"}).to_dict()
+        topo = Join(data, options={"shared_coords": True}).to_dict()
 
         assert geometry.MultiPoint(topo["junctions"]).equals(
             geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -26,7 +26,7 @@ def test_topology_winding_order_TopoOptions():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 9
+    assert len(topo["options"]) == 10
 
 
 # test winding order using kwarg variables
@@ -37,7 +37,7 @@ def test_topology_winding_order_kwarg_vars():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 9
+    assert len(topo["options"]) == 10
 
 
 def test_topology_computing_topology():

--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -76,7 +76,9 @@ class Cut(Join):
             If `True`, the detected junctions will be displayed as well. 
             Default is `False`
         """
-        serialize_as_svg(self.output, separate, include_junctions)
+        serialize_as_svg(
+            self.output, separate=separate, include_junctions=include_junctions
+        )
 
     def _cutter(self, data):
         """
@@ -115,7 +117,7 @@ class Cut(Join):
             tree_splitter = STRtree(mp)
             slist = []
             # junctions are only existing in coordinates of linestring
-            if self.options.shared_paths == "coords":
+            if self.options.shared_coords:
                 for ls in data["linestrings"]:
                     line, splitter = np_array_bbox_points_line(ls, tree_splitter)
                     # prev function returns None for splitter if there is nothing to split

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -137,6 +137,7 @@ class Join(Extract):
                 algorithm=self.options.simplify_algorithm,
                 package=self.options.simplify_with,
                 input_as="linestring",
+                prevent_oversimplify=self.options.prevent_oversimplify,
             )
 
         # compute the bounding box of input geometry
@@ -168,7 +169,7 @@ class Join(Extract):
             data["junctions"] = self._junctions
             return data
 
-        if self.options.shared_paths == "coords":
+        if self.options.shared_coords:
 
             def _get_verts(geom):
                 # get coords of each LineString

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -45,10 +45,11 @@ class TopoOptions(object):
         topoquantize=False,
         presimplify=False,
         toposimplify=False,
+        shared_coords=False,
+        prevent_oversimplify=True,
         simplify_with="shapely",
         simplify_algorithm="dp",
         winding_order=None,
-        shared_paths="shapely",
     ):
         # get all arguments
         arguments = locals()
@@ -80,6 +81,16 @@ class TopoOptions(object):
         else:
             self.toposimplify = False
 
+        if "shared_coords" in arguments:
+            self.shared_coords = arguments["shared_coords"]
+        else:
+            self.shared_coords = False
+
+        if "prevent_oversimplify" in arguments:
+            self.prevent_oversimplify = arguments["prevent_oversimplify"]
+        else:
+            self.prevent_oversimplify = True
+
         if "simplify_with" in arguments:
             self.simplify_with = arguments["simplify_with"]
         else:
@@ -94,11 +105,6 @@ class TopoOptions(object):
             self.winding_order = arguments["winding_order"]
         else:
             self.winding_order = None
-
-        if "shared_paths" in arguments:
-            self.shared_paths = arguments["shared_paths"]
-        else:
-            self.shared_paths = "shapely"
 
     def __repr__(self):
         return "TopoOptions(\n  {}\n)".format(pprint.pformat(self.__dict__))


### PR DESCRIPTION
This PR fix https://github.com/mattijn/topojson/issues/84 and close https://github.com/mattijn/topojson/pull/85:
- includes a `prevent_oversimplify` parameter. Use `True` for a, so-called, topology-preserving variant for linestring simplification.
- changed the name of the `shared_paths` parameter to `shared_coords`. It can be set to `True` for the dict/set introduced in https://github.com/mattijn/topojson/pull/76 or `False` to use the shapely `shared_paths()` function. 

In a follow-up PR this `shared_coords` parameter will default to `True` since this introduce numerous changes in the tests.
