### PR TITLE
Using json.dump method to write json to file

### DIFF
--- a/tests/test_to_json.py
+++ b/tests/test_to_json.py
@@ -1,0 +1,18 @@
+import topojson
+import os
+import json
+import pytest
+
+def test_to_json(tmp_path):
+    topo_file = os.path.join(tmp_path, "topo.json")
+    data = [
+        {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
+        {"type": "LineString", "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]]},
+    ]
+    topo = topojson.Topology(data)
+    topo.to_json(topo_file)
+
+    with open(topo_file) as f:
+        topo_reloaded = json.load(f)
+
+

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 import numpy as np
 import pprint
 import json
-import types
 from .ops import dequantize
 from .ops import np_array_from_arcs
 
@@ -461,7 +460,7 @@ def serialize_as_json(topo_object, fp, pretty=False, indent=4, maxlinelength=88)
                     file=f,
                 )
             else:
-                print(topo_object, file=f)
+                json.dump(topo_object, fp=f)
     else:
         if pretty:
             return prettyjson(topo_object, indent=indent, maxlinelength=maxlinelength)


### PR DESCRIPTION
Current implementation of `to_json` method relies on built-in `print` command. This command uses single quotes. It produces valid Python string, but invalid JSON.

This bugfix uses `json.dump` function to write json to a file.