### PR TITLE
Shared_coords defaults to True

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -28,102 +28,6 @@ def test_cut_reversed_duplicate_lines_ABC_CBA_no_cuts():
     assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
 
-# cut exact duplicate rings ABCA & ABCA have no cuts
-def test_cut_exact_duplicate_rings_ABCA_ABCA_no_cuts():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
-        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
-    }
-    topo = Cut(data).to_dict()
-
-    assert len(topo["junctions"]) == 0
-    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
-
-
-# cut reversed rings ABCA & ACBA have no cuts
-def test_cut_reversed_rings_ABCA_ACBA_no_cuts():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
-        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 1], [1, 0], [0, 0]]]},
-    }
-    topo = Cut(data).to_dict()
-
-    assert len(topo["junctions"]) == 0
-    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
-
-
-# cut rotated duplicate rings BCAB & ABCA have no cuts
-# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
-# not detected anymore in find_duplicate function when shapely is used for shared_paths.
-def test_cut_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
-        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]]},
-    }
-    topo = Cut(data).to_dict()
-
-    assert len(topo["junctions"]) == 0
-    assert len(topo["bookkeeping_duplicates"]) == 0
-
-
-# cut ring ABCA & line ABCA have no cuts
-def test_cut_ring_ABCA_line_ABCA_no_cuts():
-    data = {
-        "abcaLine": {
-            "type": "Linestring",
-            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
-        },
-        "abcaPolygon": {
-            "type": "Polygon",
-            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-        },
-    }
-    topo = Cut(data).to_dict()
-
-    assert len(topo["junctions"]) == 0
-    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
-
-
-# cut ring BCAB & line ABCA have no cuts
-# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
-# not detected anymore in find_duplicate function when shapely is used for shared_paths.
-def test_cut_ring_BCAB_line_ABCA_no_cuts():
-    data = {
-        "abcaLine": {
-            "type": "Linestring",
-            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
-        },
-        "bcabPolygon": {
-            "type": "Polygon",
-            "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]],
-        },
-    }
-    topo = Cut(data).to_dict()
-
-    assert len(topo["junctions"]) == 0
-    assert len(topo["bookkeeping_duplicates"]) == 0
-
-
-# cut ring ABCA & line BCAB have no cuts
-# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
-# not detected anymore in find_duplicate function when shapely is used for shared_paths.
-def test_cut_ring_ABCA_line_BCAB_no_cuts():
-    data = {
-        "bcabLine": {
-            "type": "Linestring",
-            "coordinates": [[1, 0], [2, 1], [0, 0], [1, 0]],
-        },
-        "abcaPolygon": {
-            "type": "Polygon",
-            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
-        },
-    }
-    topo = Cut(data).to_dict()
-
-    assert len(topo["junctions"]) == 0
-    assert len(topo["bookkeeping_duplicates"]) == 0
-
-
 # overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB
 def test_cut_overlapping_rings_are_cut():
     data = {
@@ -214,6 +118,13 @@ def test_cut_geomcol_multipolygon_polygon():
     assert topo["bookkeeping_linestrings"].size == 8
 
 
+def test_cut_junctions_coords():
+    data = geopandas.read_file("tests/files_geojson/naturalearth_alb_grc.geojson")
+    topo = Cut(data, options={"shared_coords": True}).to_dict()
+
+    assert len(topo["linestrings"]) == 3
+
+
 # this test is added since its seems no extra junctions are placed at lines where other
 # linestrings have shared paths but no shared junctions.
 def test_cut_linemerge_multilinestring():
@@ -235,12 +146,222 @@ def test_cut_linemerge_multilinestring():
     ]
     topo = Cut(data).to_dict()
 
+    assert len(topo["linestrings"]) == 2
+    assert len(topo["junctions"]) == 0
+
+
+# cut exact duplicate rings ABCA & ABCA have no cuts
+def test_cut_exact_duplicate_rings_ABCA_ABCA_no_cuts():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut reversed rings ABCA & ACBA have no cuts
+def test_cut_reversed_rings_ABCA_ACBA_no_cuts():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 1], [1, 0], [0, 0]]]},
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut rotated duplicate rings BCAB & ABCA have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
+def test_cut_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]]},
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+    assert len(topo["bookkeeping_duplicates"]) == 2
+
+
+# cut ring ABCA & line ABCA have no cuts
+def test_cut_ring_ABCA_line_ABCA_no_cuts():
+    data = {
+        "abcaLine": {
+            "type": "Linestring",
+            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut ring BCAB & line ABCA have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
+def test_cut_ring_BCAB_line_ABCA_no_cuts():
+    data = {
+        "abcaLine": {
+            "type": "Linestring",
+            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
+        },
+        "bcabPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+    assert len(topo["bookkeeping_duplicates"]) == 2
+
+
+# cut ring ABCA & line BCAB have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
+def test_cut_ring_ABCA_line_BCAB_no_cuts():
+    data = {
+        "bcabLine": {
+            "type": "Linestring",
+            "coordinates": [[1, 0], [2, 1], [0, 0], [1, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
+        },
+    }
+    topo = Cut(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+    assert len(topo["bookkeeping_duplicates"]) == 2
+
+
+# this test is added since its seems no extra junctions are placed at lines where other
+# linestrings have shared paths but no shared junctions.
+def test_cut_shared_paths_linemerge_multilinestring():
+    data = [
+        {"type": "LineString", "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)]},
+        {
+            "type": "LineString",
+            "coordinates": [
+                (5, 0),
+                (25, 0),
+                (25, 5),
+                (16, 5),
+                (16, 10),
+                (14, 10),
+                (14, 5),
+                (0, 5),
+            ],
+        },
+    ]
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
+
     assert len(topo["linestrings"]) == 12
     assert len(topo["junctions"]) == 7
 
 
-def test_cut_junctions_coords():
-    data = geopandas.read_file("tests/files_geojson/naturalearth_alb_grc.geojson")
-    topo = Cut(data, options={"shared_coords": True}).to_dict()
+# cut exact duplicate rings ABCA & ABCA have no cuts
+def test_cut_shared_paths_exact_duplicate_rings_ABCA_ABCA_no_cuts():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+    }
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
 
-    assert len(topo["linestrings"]) == 3
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut reversed rings ABCA & ACBA have no cuts
+def test_cut_shared_paths_reversed_rings_ABCA_ACBA_no_cuts():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 1], [1, 0], [0, 0]]]},
+    }
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut rotated duplicate rings BCAB & ABCA have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
+def test_cut_shared_paths_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]]},
+    }
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 0
+
+
+# cut ring ABCA & line ABCA have no cuts
+def test_cut_shared_paths_ring_ABCA_line_ABCA_no_cuts():
+    data = {
+        "abcaLine": {
+            "type": "Linestring",
+            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
+        },
+    }
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
+
+
+# cut ring BCAB & line ABCA have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
+def test_cut_shared_paths_ring_BCAB_line_ABCA_no_cuts():
+    data = {
+        "abcaLine": {
+            "type": "Linestring",
+            "coordinates": [[0, 0], [1, 0], [2, 1], [0, 0]],
+        },
+        "bcabPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 1], [0, 0], [1, 0]]],
+        },
+    }
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 0
+
+
+# cut ring ABCA & line BCAB have no cuts
+# changed the assertion of bookkeeping_duplicates, since the method rotated polyons are
+# not detected anymore in find_duplicate function when shapely is used for shared_paths.
+def test_cut_shared_paths_ring_ABCA_line_BCAB_no_cuts():
+    data = {
+        "bcabLine": {
+            "type": "Linestring",
+            "coordinates": [[1, 0], [2, 1], [0, 0], [1, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]],
+        },
+    }
+    topo = Cut(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 0

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -3,20 +3,6 @@ import topojson
 import geopandas
 from topojson.core.join import Join
 
-
-# the returned hashmap has true for junction points
-def test_join_true_for_junction_points():
-    data = {
-        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
-    )
-
-
 # the returned hashmap has undefined for non-junction points
 def test_join_undefined_for_non_junction_points():
     data = {
@@ -26,42 +12,6 @@ def test_join_undefined_for_non_junction_points():
     topo = Join(data).to_dict()
 
     assert geometry.Point(1.0, 0.0) not in geometry.MultiPoint(topo["junctions"])
-
-
-# forward backward lines
-def test_join_forward_backward_lines():
-    data = {
-        "foo": {
-            "type": "LineString",
-            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
-        },
-        "bar": {
-            "type": "LineString",
-            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
-        },
-    }
-    topo = Join(data).to_dict()
-
-    assert len(topo["junctions"]) == 5
-
-
-# more than two lines
-def test_join_more_than_two_lines():
-    data = {
-        "foo": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
-        "bar": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
-        "baz": {
-            "type": "LineString",
-            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
-        },
-        "qux": {
-            "type": "LineString",
-            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
-        },
-    }
-    topo = Join(data).to_dict()
-
-    assert len(topo["junctions"]) == 5
 
 
 # exact duplicate lines ABC & ABC have no junctions
@@ -80,72 +30,6 @@ def test_join_reversed_duplicate_lines_junction_endpoints():
     data = {
         "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
         "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# exact duplicate rings ABCA & ABCA have no junctions
-def test_join_exact_duplicate_rings():
-    data = {
-        "abca1": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
-        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# reversed duplicate rings ABCA & ACBA have no junctions
-def test_join_reversed_duplicate_rings():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
-        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# rotated duplicate rings BCAB & ABCA have no junctions
-def test_join_rotated_duplicate_rings():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
-        "bcab": {"type": "Polygon", "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]]},
-    }
-    topo = Join(data).to_dict()
-    assert topo["junctions"] == []
-
-
-# ring ABCA & line ABCA have no junction at A
-def test_join_equal_ring_and_line_no_junctions():
-    data = {
-        "abcaLine": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
-        },
-        "abcaPolygon": {
-            "type": "Polygon",
-            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
-        },
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# ring ABCA & line ABCA have no junctions
-def test_join_rotated_ring_and_line_no_junctions():
-    data = {
-        "abcaLine": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
-        },
-        "bcabPolygon": {
-            "type": "Polygon",
-            "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
-        },
     }
     topo = Join(data).to_dict()
 
@@ -176,45 +60,6 @@ def test_join_reversed_line_CBA_extends_new_line_AB():
     assert geometry.Point(1.0, 0.0) in geometry.MultiPoint(topo["junctions"])
 
 
-# when a new arc ADE shares its start with an old arc ABC, there is no junction at A
-def test_join_line_ADE_share_starts_with_ABC():
-    data = {
-        "ade": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# ring ABA has no junctions
-def test_join_single_ring_ABCA():
-    data = {
-        "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [1, 1], [0, 0]]}
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# ring AA is not a proper polygon geometry.
-def test_join_single_ring_AA():
-    data = {"aa": {"type": "Polygon", "coordinates": [[0, 0], [0, 0]]}}
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# when a new line DEC shares its end with an old line ABC, there is no junction at C
-def test_join_line_DEC_share_line_ABC():
-    data = {
-        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        "dec": {"type": "LineString", "coordinates": [[0, 1], [1, 1], [2, 0]]},
-    }
-    topo = Join(data).to_dict()
-    assert topo["junctions"] == []
-
-
 # when a new line ABC extends an old line AB, there is a junction at B
 def test_join_line_ABC_extends_line_AB():
     data = {
@@ -241,20 +86,6 @@ def test_join_line_ABC_extends_line_BA():
     )
 
 
-# when a new line starts BC in the middle of an old line ABC, there is a
-# junction at B
-def test_join_line_ABC_extends_line_BC():
-    data = {
-        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
-    )
-
-
 # when a new line BC starts in the middle of a reversed old line CBA, there is a
 # junction at B
 def test_join_line_BC_start_middle_reversed_line_CBA():
@@ -267,238 +98,6 @@ def test_join_line_BC_start_middle_reversed_line_CBA():
     assert geometry.MultiPoint(topo["junctions"]).equals(
         geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)])
     )
-
-
-# when a new line ABD deviates from an old line ABC, there is a junction at B
-def test_join_line_ABD_deviates_line_ABC():
-    data = {
-        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)])
-    )
-
-
-# when a new line ABD deviates from a reversed old line CBA, there is a
-# junction at B
-def test_join_line_ABD_deviates_line_CBA():
-    data = {
-        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
-    )
-
-
-# when a new line DBC merges into an old line ABC, there is a junction at B
-def test_join_line_DBC_merge_line_ABC():
-    data = {
-        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)])
-    )
-
-
-# when a new line DBC merges into a reversed old line CBA, there is a junction at B
-def test_join_line_DBC_merge_reversed_line_CBA():
-    data = {
-        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)])
-    )
-
-
-# when a new line DBE shares a single midpoint with an old line ABC, there is
-# no junction at B
-def test_join_line_DBE_share_singe_midpoint_line_ABC():
-    data = {
-        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
-        "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
-    }
-    topo = Join(data).to_dict()
-    assert topo["junctions"] == []
-
-
-# when a new line ABDE skips a point with an old line ABCDE, there is a no junction
-def test_join_line_ABDE_skips_point_line_ABCDE():
-    data = {
-        "abcde": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]],
-        },
-        "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
-    }
-    topo = Join(data).to_dict()
-    assert topo["junctions"] == []
-
-
-# when a new line ABDE skips a point with a reversed old line EDCBA, there is
-# no junction
-def test_join_line_ABDE_skips_point_reversed_line_EDCBA():
-    data = {
-        "edcba": {
-            "type": "LineString",
-            "coordinates": [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]],
-        },
-        "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
-    }
-    topo = Join(data).to_dict()
-    assert topo["junctions"] == []
-
-
-# when a line ABCDBE self-intersects with its middle, there are no junctions
-def test_join_line_ABCDBE_self_intersects_with_middle():
-    data = {
-        "abcdbe": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
-        }
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# when a line ABACD self-intersects with its start, there are no junctions
-def test_join_line_ABACD_self_intersects_with_middle():
-    data = {
-        "abacd": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]],
-        }
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# when a line ABCDBD self-intersects with its end, there are no junctions
-def test_join_line_ABCDBD_self_intersects_with_end():
-    data = {
-        "abcdbd": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]],
-        }
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# when an old line ABCDBE self-intersects and shares a point B, there is
-# no junction at B
-def test_join_line_ABCDB_self_intersects():
-    data = {
-        "abcdbe": {
-            "type": "LineString",
-            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
-        },
-        "fbg": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# when a line ABCA is closed, there is no junction at A
-def test_join_line_ABCA_is_closed():
-    data = {
-        "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [0, 1], [0, 0]]}
-    }
-    topo = Join(data).to_dict()
-    assert topo["junctions"] == []
-
-
-# when a ring ABCA is closed, there are no junctions
-def test_join_ring_ABCA_is_closed():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
-def test_join_exact_duplicate_rings_ABCA_ABCA_share_ABCA():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no juctions
-def test_join_exact_duplicate_rings_ABCA_ACBA_share_ABCA():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# coincident rings ABCA & BCAB share the arc BCAB, but contain no junctinos
-# this is a problem though as they are considered equal in a MultiPolygon geometry.
-# test will pass, but coincident rings should be rotated before dedup
-def test_join_coincident_rings_ABCA_BCAB_share_BCAB():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [0, 1], [0, 0], [1, 0]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# coincident rings ABCA & BACB share the arc BCAB, but contain no junctions
-def test_join_coincident_rings_ABCA_BACB_share_BCAB():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-        "bacb": {"type": "Polygon", "coordinates": [[[1, 0], [0, 0], [0, 1], [1, 0]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# coincident rings ABCA & DBED share the point B, but is no junction
-def test_join_coincident_rings_ABCA_DBED_share_B():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-        "dbed": {"type": "Polygon", "coordinates": [[[2, 1], [1, 0], [2, 2], [2, 1]]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
-
-
-# coincident ring ABCA & line DBE share the point B
-def test_join_coincident_ring_ABCA_and_line_DBE_share_B():
-    data = {
-        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-        "dbe": {"type": "LineString", "coordinates": [[2, 1], [1, 0], [2, 2]]},
-    }
-    topo = Join(data).to_dict()
-
-    assert topo["junctions"] == []
 
 
 # should keep junctions from partly shared paths
@@ -530,13 +129,6 @@ def test_join_shared_segment_partly_start_partly_end_segment():
     assert len(topo["junctions"]) == 6
 
 
-def test_join_non_noded_interesection():
-    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-    topo = Join(data).to_dict()  # , quant_factor=1e6)
-
-    assert len(topo["junctions"]) == 321
-
-
 def test_join_super_function_extract():
     data = geometry.GeometryCollection(
         [
@@ -566,6 +158,44 @@ def test_join_prequantize_points():
     assert topo["bbox"] == (-0.5, 0.0, 1.0, 1.5)
 
 
+# ring AA is not a proper polygon geometry.
+def test_join_single_ring_AA():
+    data = {"aa": {"type": "Polygon", "coordinates": [[0, 0], [0, 0]]}}
+    topo = Join(data).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# test the shared_paths_approach using dicts
+def test_join_shared_paths_dict():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": True}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
+    )
+
+
+# test a list of two invalid geometric objects with prequantize True
+def test_join_invalid_prequantize():
+    data = [
+        {
+            "type": "MultiPolygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+        {
+            "type": "MultiPolygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+    ]
+    topo = Join(data, options={"prequantize": True}).to_dict()
+
+    assert len(topo["junctions"]) == 0
+
+
 def test_join_linemerge_multilinestring():
     data = [
         {"type": "LineString", "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)]},
@@ -586,32 +216,826 @@ def test_join_linemerge_multilinestring():
     topo = Join(data).to_dict()
 
     assert len(topo["linestrings"]) == 2
+    assert len(topo["junctions"]) == 0
+
+
+# the returned hashmap has true for junction points
+def test_join_true_for_junction_points():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+# forward backward lines
+def test_join_forward_backward_lines():
+    data = {
+        "foo": {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        "bar": {
+            "type": "LineString",
+            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 0
+
+
+# more than two lines
+def test_join_more_than_two_lines():
+    data = {
+        "foo": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
+        "bar": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
+        "baz": {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        "qux": {
+            "type": "LineString",
+            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+# exact duplicate rings ABCA & ABCA have no junctions
+def test_join_exact_duplicate_rings():
+    data = {
+        "abca1": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# reversed duplicate rings ABCA & ACBA have no junctions
+def test_join_reversed_duplicate_rings():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# rotated duplicate rings BCAB & ABCA have no junctions
+def test_join_rotated_duplicate_rings():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]]},
+    }
+    topo = Join(data).to_dict()
+    assert len(topo["junctions"]) == 2
+
+
+# ring ABCA & line ABCA have no junction at A
+def test_join_equal_ring_and_line_no_junctions():
+    data = {
+        "abcaLine": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# ring ABCA & line ABCA have no junctions
+def test_join_rotated_ring_and_line_no_junctions():
+    data = {
+        "abcaLine": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
+        },
+        "bcabPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
+        },
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+# when a new arc ADE shares its start with an old arc ABC, there is no junction at A
+def test_join_line_ADE_share_starts_with_ABC():
+    data = {
+        "ade": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# ring ABA has no junctions
+def test_join_single_ring_ABCA():
+    data = {
+        "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [1, 1], [0, 0]]}
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# when a new line DEC shares its end with an old line ABC, there is no junction at C
+def test_join_line_DEC_share_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dec": {"type": "LineString", "coordinates": [[0, 1], [1, 1], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# when a new line starts BC in the middle of an old line ABC, there is a
+# junction at B
+def test_join_line_ABC_extends_line_BC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+# when a new line ABD deviates from an old line ABC, there is a junction at B
+def test_join_line_ABD_deviates_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])
+    )
+
+
+# when a new line ABD deviates from a reversed old line CBA, there is a
+# junction at B
+def test_join_line_ABD_deviates_line_CBA():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])
+    )
+
+
+# when a new line DBC merges into an old line ABC, there is a junction at B
+def test_join_line_DBC_merge_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)])
+    )
+
+
+# when a new line DBC merges into a reversed old line CBA, there is a junction at B
+def test_join_line_DBC_merge_reversed_line_CBA():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0)])
+    )
+
+
+# when a new line DBE shares a single midpoint with an old line ABC, there is
+# no junction at B
+def test_join_line_DBE_share_singe_midpoint_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
+    }
+    topo = Join(data).to_dict()
+    assert len(topo["junctions"]) == 1
+
+
+# when a new line ABDE skips a point with an old line ABCDE, there is a no junction
+def test_join_line_ABDE_skips_point_line_ABCDE():
+    data = {
+        "abcde": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]],
+        },
+        "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
+    }
+    topo = Join(data).to_dict()
+    assert len(topo["junctions"]) == 2
+
+
+# when a new line ABDE skips a point with a reversed old line EDCBA, there is
+# no junction
+def test_join_line_ABDE_skips_point_reversed_line_EDCBA():
+    data = {
+        "edcba": {
+            "type": "LineString",
+            "coordinates": [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]],
+        },
+        "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
+    }
+    topo = Join(data).to_dict()
+    assert len(topo["junctions"]) == 2
+
+
+# when a line ABCDBE self-intersects with its middle, there are no junctions
+def test_join_line_ABCDBE_self_intersects_with_middle():
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
+        }
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# when a line ABACD self-intersects with its start, there are no junctions
+def test_join_line_ABACD_self_intersects_with_middle():
+    data = {
+        "abacd": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]],
+        }
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# when a line ABCDBD self-intersects with its end, there are no junctions
+def test_join_line_ABCDBD_self_intersects_with_end():
+    data = {
+        "abcdbd": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]],
+        }
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# when an old line ABCDBE self-intersects and shares a point B, there is
+# no junction at B
+def test_join_line_ABCDB_self_intersects():
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
+        },
+        "fbg": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# when a line ABCA is closed, there is no junction at A
+def test_join_line_ABCA_is_closed():
+    data = {
+        "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [0, 1], [0, 0]]}
+    }
+    topo = Join(data).to_dict()
+    assert len(topo["junctions"]) == 1
+
+
+# when a ring ABCA is closed, there are no junctions
+def test_join_ring_ABCA_is_closed():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
+def test_join_exact_duplicate_rings_ABCA_ABCA_share_ABCA():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no juctions
+def test_join_exact_duplicate_rings_ABCA_ACBA_share_ABCA():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 1
+
+
+# coincident rings ABCA & BCAB share the arc BCAB, but contain no junctinos
+# this is a problem though as they are considered equal in a MultiPolygon geometry.
+# test will pass, but coincident rings should be rotated before dedup
+def test_join_coincident_rings_ABCA_BCAB_share_BCAB():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [0, 1], [0, 0], [1, 0]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+# coincident rings ABCA & BACB share the arc BCAB
+def test_join_coincident_rings_ABCA_BACB_share_BCAB():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "bacb": {"type": "Polygon", "coordinates": [[[1, 0], [0, 0], [0, 1], [1, 0]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+# coincident rings ABCA & DBED share the point B, but is no junction
+def test_join_coincident_rings_ABCA_DBED_share_B():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "dbed": {"type": "Polygon", "coordinates": [[[2, 1], [1, 0], [2, 2], [2, 1]]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 3
+
+
+# coincident ring ABCA & line DBE share the point B
+def test_join_coincident_ring_ABCA_and_line_DBE_share_B():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "dbe": {"type": "LineString", "coordinates": [[2, 1], [1, 0], [2, 2]]},
+    }
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 2
+
+
+def test_join_non_noded_interesection():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    topo = Join(data).to_dict()
+
+    assert len(topo["junctions"]) == 440
+
+
+################## shared_coords:False ##################
+
+
+def test_join_shared_paths_linemerge_multilinestring():
+    data = [
+        {"type": "LineString", "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)]},
+        {
+            "type": "LineString",
+            "coordinates": [
+                (5, 0),
+                (25, 0),
+                (25, 5),
+                (16, 5),
+                (16, 10),
+                (14, 10),
+                (14, 5),
+                (0, 5),
+            ],
+        },
+    ]
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["linestrings"]) == 2
     assert len(topo["junctions"]) == 7
 
-    # test the shared_paths_approach using dicts
-    def test_join_shared_paths_dict():
-        data = {
-            "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
-            "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+
+# the returned hashmap has true for junction points
+def test_join_shared_paths_true_for_junction_points():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "ab": {"type": "LineString", "coordinates": [[0, 0], [1, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
+    )
+
+
+# forward backward lines
+def test_join_shared_paths_forward_backward_lines():
+    data = {
+        "foo": {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        "bar": {
+            "type": "LineString",
+            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
+        },
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 5
+
+
+# more than two lines
+def test_join_shared_paths_more_than_two_lines():
+    data = {
+        "foo": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
+        "bar": {"type": "LineString", "coordinates": [(0, 0), (15, 2.5), (30, 5)]},
+        "baz": {
+            "type": "LineString",
+            "coordinates": [(0, 0), (10, 0), (10, 5), (20, 5)],
+        },
+        "qux": {
+            "type": "LineString",
+            "coordinates": [(5, 0), (30, 0), (30, 5), (0, 5)],
+        },
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 5
+
+
+# exact duplicate rings ABCA & ABCA have no junctions
+def test_join_shared_paths_exact_duplicate_rings():
+    data = {
+        "abca1": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# reversed duplicate rings ABCA & ACBA have no junctions
+def test_join_shared_paths_reversed_duplicate_rings():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [1, 1], [0, 0]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# rotated duplicate rings BCAB & ABCA have no junctions
+def test_join_shared_paths_rotated_duplicate_rings():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+    assert topo["junctions"] == []
+
+
+# ring ABCA & line ABCA have no junction at A
+def test_join_shared_paths_equal_ring_and_line_no_junctions():
+    data = {
+        "abcaLine": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
+        },
+        "abcaPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+        },
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# ring ABCA & line ABCA have no junctions
+def test_join_shared_paths_rotated_ring_and_line_no_junctions():
+    data = {
+        "abcaLine": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [2, 0], [0, 0]],
+        },
+        "bcabPolygon": {
+            "type": "Polygon",
+            "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]],
+        },
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# when a new arc ADE shares its start with an old arc ABC, there is no junction at A
+def test_join_shared_paths_line_ADE_share_starts_with_ABC():
+    data = {
+        "ade": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# ring ABA has no junctions
+def test_join_shared_paths_single_ring_ABCA():
+    data = {
+        "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [1, 1], [0, 0]]}
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# when a new line DEC shares its end with an old line ABC, there is no junction at C
+def test_join_shared_paths_line_DEC_share_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dec": {"type": "LineString", "coordinates": [[0, 1], [1, 1], [2, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+    assert topo["junctions"] == []
+
+
+# when a new line starts BC in the middle of an old line ABC, there is a
+# junction at B
+def test_join_shared_paths_line_ABC_extends_line_BC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "bc": {"type": "LineString", "coordinates": [[1, 0], [2, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
+    )
+
+
+# when a new line ABD deviates from an old line ABC, there is a junction at B
+def test_join_shared_paths_line_ABD_deviates_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)])
+    )
+
+
+# when a new line ABD deviates from a reversed old line CBA, there is a
+# junction at B
+def test_join_shared_paths_line_ABD_deviates_line_CBA():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "abd": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
+    )
+
+
+# when a new line DBC merges into an old line ABC, there is a junction at B
+def test_join_shared_paths_line_DBC_merge_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)])
+    )
+
+
+# when a new line DBC merges into a reversed old line CBA, there is a junction at B
+def test_join_shared_paths_line_DBC_merge_reversed_line_CBA():
+    data = {
+        "cba": {"type": "LineString", "coordinates": [[2, 0], [1, 0], [0, 0]]},
+        "dbc": {"type": "LineString", "coordinates": [[3, 0], [1, 0], [2, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert geometry.MultiPoint(topo["junctions"]).equals(
+        geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)])
+    )
+
+
+# when a new line DBE shares a single midpoint with an old line ABC, there is
+# no junction at B
+def test_join_shared_paths_line_DBE_share_singe_midpoint_line_ABC():
+    data = {
+        "abc": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+    assert topo["junctions"] == []
+
+
+# when a new line ABDE skips a point with an old line ABCDE, there is a no junction
+def test_join_shared_paths_line_ABDE_skips_point_line_ABCDE():
+    data = {
+        "abcde": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]],
+        },
+        "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+    assert topo["junctions"] == []
+
+
+# when a new line ABDE skips a point with a reversed old line EDCBA, there is
+# no junction
+def test_join_shared_paths_line_ABDE_skips_point_reversed_line_EDCBA():
+    data = {
+        "edcba": {
+            "type": "LineString",
+            "coordinates": [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]],
+        },
+        "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+    assert topo["junctions"] == []
+
+
+# when a line ABCDBE self-intersects with its middle, there are no junctions
+def test_join_shared_paths_line_ABCDBE_self_intersects_with_middle():
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
         }
-        topo = Join(data, options={"shared_coords": True}).to_dict()
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
 
-        assert geometry.MultiPoint(topo["junctions"]).equals(
-            geometry.MultiPoint([(0.0, 0.0), (1.0, 0.0)])
-        )
+    assert topo["junctions"] == []
 
-    # test a list of two invalid geometric objects with prequantize True
-    def test_join_invalid_prequantize():
-        data = [
-            {
-                "type": "MultiPolygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },
-            {
-                "type": "MultiPolygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },
-        ]
-        topo = Join(data, options={"prequantize": True}).to_dict()
 
-        assert len(topo["junctions"]) == 0
+# when a line ABACD self-intersects with its start, there are no junctions
+def test_join_shared_paths_line_ABACD_self_intersects_with_middle():
+    data = {
+        "abacd": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]],
+        }
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# when a line ABCDBD self-intersects with its end, there are no junctions
+def test_join_shared_paths_line_ABCDBD_self_intersects_with_end():
+    data = {
+        "abcdbd": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]],
+        }
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# when an old line ABCDBE self-intersects and shares a point B, there is
+# no junction at B
+def test_join_shared_paths_line_ABCDB_self_intersects():
+    data = {
+        "abcdbe": {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]],
+        },
+        "fbg": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# when a line ABCA is closed, there is no junction at A
+def test_join_shared_paths_line_ABCA_is_closed():
+    data = {
+        "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [0, 1], [0, 0]]}
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# when a ring ABCA is closed, there are no junctions
+def test_join_shared_paths_ring_ABCA_is_closed():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
+def test_join_shared_paths_exact_duplicate_rings_ABCA_ABCA_share_ABCA():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "abca2": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no juctions
+def test_join_shared_paths_exact_duplicate_rings_ABCA_ACBA_share_ABCA():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "acba": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 0], [0, 0]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# coincident rings ABCA & BCAB share the arc BCAB, but contain no junctinos
+# this is a problem though as they are considered equal in a MultiPolygon geometry.
+# test will pass, but coincident rings should be rotated before dedup
+def test_join_shared_paths_coincident_rings_ABCA_BCAB_share_BCAB():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "bcab": {"type": "Polygon", "coordinates": [[[1, 0], [0, 1], [0, 0], [1, 0]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# coincident rings ABCA & BACB share the arc BCAB, but contain no junctions
+def test_join_shared_paths_coincident_rings_ABCA_BACB_share_BCAB():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "bacb": {"type": "Polygon", "coordinates": [[[1, 0], [0, 0], [0, 1], [1, 0]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# coincident rings ABCA & DBED share the point B, but is no junction
+def test_join_shared_paths_coincident_rings_ABCA_DBED_share_B():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "dbed": {"type": "Polygon", "coordinates": [[[2, 1], [1, 0], [2, 2], [2, 1]]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+# coincident ring ABCA & line DBE share the point B
+def test_join_shared_paths_coincident_ring_ABCA_and_line_DBE_share_B():
+    data = {
+        "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+        "dbe": {"type": "LineString", "coordinates": [[2, 1], [1, 0], [2, 2]]},
+    }
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert topo["junctions"] == []
+
+
+def test_join_shared_paths_non_noded_interesection():
+    data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 321

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -49,7 +49,7 @@ def test_topology_computing_topology():
     no_topo = topojson.Topology(data, topology=False, prequantize=False).to_dict()
     topo = topojson.Topology(data, topology=True, prequantize=False).to_dict()
 
-    assert len(topo["arcs"]) == 5
+    assert len(topo["arcs"]) == 4
     assert len(no_topo["arcs"]) == 2
 
 

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -55,7 +55,7 @@ class Topology(Hashmap):
         considered shared when all coordinates appear in both paths 
         (`coords-connected`). When set to `False` a path is considered shared when 
         coordinates are the same path (`path-connected`). The path-connected strategy 
-        is more 'correct', but slower. Default is `False`.
+        is more 'correct', but slower. Default is `True`.
     prevent_oversimplify: boolean
         If this setting is set to `True`, the simplification is slower, but the 
         likelihood of producing valid geometries is higher as it prevents 
@@ -89,7 +89,7 @@ class Topology(Hashmap):
         topoquantize=False,
         presimplify=False,
         toposimplify=False,
-        shared_coords=False,
+        shared_coords=True,
         prevent_oversimplify=True,
         simplify_with="shapely",
         simplify_algorithm="dp",

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -44,7 +44,7 @@ class TopoOptions(object):
         topoquantize=False,
         presimplify=False,
         toposimplify=False,
-        shared_coords=False,
+        shared_coords=True,
         prevent_oversimplify=True,
         simplify_with="shapely",
         simplify_algorithm="dp",
@@ -83,7 +83,7 @@ class TopoOptions(object):
         if "shared_coords" in arguments:
             self.shared_coords = arguments["shared_coords"]
         else:
-            self.shared_coords = False
+            self.shared_coords = True
 
         if "prevent_oversimplify" in arguments:
             self.prevent_oversimplify = arguments["prevent_oversimplify"]


### PR DESCRIPTION
This PR change the default from settings from `"shared_coords":False` to `"shared_coords":True`. 

Before this PR the default was that a path can be shared without having shared coordinates. 

From this PR onwards the default is that paths are shared when overlapping coordinates exist.