### PR TITLE
Fix dequantization multipoint

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -353,3 +353,16 @@ def test_topology_to_json(tmp_path):
 
     with open(topo_file) as f:
         topo_reloaded = json.load(f)
+
+
+def test_topology_topoquantize():
+    data = [
+        {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},
+        {"type": "LineString", "coordinates": [[0, 2], [1, 1], [2, 2], [3, 1], [4, 2]]},
+    ]
+    tp = topojson.Topology(data, prequantize=1e4)
+    topo = tp.topoquantize(1e4).to_dict()
+
+    assert topo["transform"]["translate"] == [0.0, 0.0]
+    assert topo["arcs"][0] == [[9999, 0], [-4999, 9999]]
+

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -382,7 +382,7 @@ def np_array_from_arcs(arcs):
 
 
 def dequantize(np_arcs, scale, translate):
-    dequantized_arcs = np_arcs.cumsum(axis=0) * scale + translate
+    dequantized_arcs = np_arcs.cumsum(axis=1) * scale + translate
     return dequantized_arcs
 
 

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -172,7 +172,7 @@ def geometry(obj, tp_arcs, transform=None):
             scale = transform["scale"]
             translate = transform["translate"]
             coords = obj["coordinates"]
-            point_coords = dequantize(np.array(coords), scale, translate).tolist()
+            point_coords = dequantize(np.array(coords).T, scale, translate).T.tolist()
         else:
             point_coords = obj["coordinates"]
         return {"type": obj["type"], "coordinates": point_coords}


### PR DESCRIPTION
This PR fix #96. The dequantization function was incorrectly changed to the wrong axis for the `cumsum()` function. 

The function parameter of the `MultiPoint` _entrance_ into the `dequantize` function is transposed. Which solves the issue.