### PR TITLE
Fix dedup merged linestrings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,12 @@
       "program": "${workspaceFolder}/topojson/__init__.py",
       "console": "integratedTerminal",
       "justMyCode": false
+    },
+    {
+      "name": "Debug Tests",
+      "type": "python",
+      "request": "test",
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,410 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topojson as tp\n",
+    "import geopandas as gpd\n",
+    "import altair as alt\n",
+    "\n",
+    "gdf_basins = gpd.read_file(r\"C:\\Users\\lilei\\Documents\\china_floods\\main_basins.json\")\n",
+    "gdf_rivers = gpd.read_file(r\"C:\\Users\\lilei\\Documents\\china_floods\\main_rivers.json\")\n",
+    "\n",
+    "basins = alt.Chart(gdf_basins).mark_geoshape(filled=False, stroke='gray')\n",
+    "rivers = alt.Chart(gdf_rivers).mark_geoshape(filled=False, strokeWidth=1)\n",
+    "\n",
+    "basins + rivers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapely.wkt import loads\n",
+    "from topojson.core.extract import Extract\n",
+    "from topojson.core.cut import Cut\n",
+    "from topojson.core.dedup import Dedup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-286513854da04015b5c5527eb8d28587\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-286513854da04015b5c5527eb8d28587\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-286513854da04015b5c5527eb8d28587\");\n",
+       "    }\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.8.1?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function loadScript(lib) {\n",
+       "      return new Promise(function(resolve, reject) {\n",
+       "        var s = document.createElement('script');\n",
+       "        s.src = paths[lib];\n",
+       "        s.async = true;\n",
+       "        s.onload = () => resolve(paths[lib]);\n",
+       "        s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "        document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "      });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else if (typeof vegaEmbed === \"function\") {\n",
+       "      displayChart(vegaEmbed);\n",
+       "    } else {\n",
+       "      loadScript(\"vega\")\n",
+       "        .then(() => loadScript(\"vega-lite\"))\n",
+       "        .then(() => loadScript(\"vega-embed\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-337501cc7cbad23d8aa7c8257c789fbe\", \"format\": {\"mesh\": \"data\", \"type\": \"topojson\"}}, \"mark\": {\"type\": \"geoshape\", \"filled\": false}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-337501cc7cbad23d8aa7c8257c789fbe\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"type\": \"Polygon\", \"arcs\": [[0, 1, -1]]}, {\"type\": \"Polygon\", \"arcs\": [[1, 2]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [0.0, 0.0, 2.0, 1.0], \"transform\": {\"scale\": [2.000002000002e-06, 1.000001000001e-06], \"translate\": [0.0, 0.0]}, \"arcs\": [[[500000, 0], [-500000, 0], [0, 999999], [500000, 0]], [[500000, 0], [0, 999999]], [[500000, 999999], [499999, 0], [0, -999999], [-499999, 0]]]}}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.Chart(...)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from shapely.wkt import loads\n",
+    "import topojson\n",
+    "from topojson.core.extract import Extract\n",
+    "from topojson.core.cut import Cut\n",
+    "from topojson.core.dedup import Dedup\n",
+    "\n",
+    "# data = [\n",
+    "#     {\"type\": \"LineString\", \"coordinates\": [(1,0),(2,0),(3,0),(4,0),(5,0)]},\n",
+    "#     {\"type\": \"LineString\", \"coordinates\": [(5,0),(4,-1),(4,0),(4,1),(3,1),(3,0),(2,1),(2,0),(1,0),(1,1)]},\n",
+    "# ]\n",
+    "\n",
+    "data = {\n",
+    "    \"abcda\": {\n",
+    "        \"type\": \"Polygon\",\n",
+    "        \"coordinates\": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],\n",
+    "    },  # rotated to BCDAB, cut BC-CDAB\n",
+    "    \"befcb\": {\n",
+    "        \"type\": \"Polygon\",\n",
+    "        \"coordinates\": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "\n",
+    "\n",
+    "# topojson.Topology(data, shared_coords=False)  # this works (in this case)\n",
+    "topojson.Topology(data, shared_coords=True).to_alt()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e = Extract(data, options={'prequantize':False})\n",
+    "e.to_svg(separate=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = Cut(data, options={'prequantize':False})\n",
+    "c.to_svg(include_junctions=True, separate=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = Dedup(data, options={'prequantize':False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.to_svg(include_junctions=True, separate=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import SVG, display\n",
+    "from shapely.ops import linemerge\n",
+    "\n",
+    "def svg_split_view(geom):\n",
+    "    svg_custom = geom._repr_svg_()\n",
+    "    for c in ['green','blue', 'orange', 'red']:    \n",
+    "        svg_custom = svg_custom.replace('stroke=\"#66cc99\"', f'stroke=\"{c}\"', 1)\n",
+    "    display(SVG(svg_custom))\n",
+    "    \n",
+    "in_geoms = loads('MULTILINESTRING ((5 0, 4 -1, 4 0), (4 0, 4 1, 3 1, 3 0), (3 0, 2 1, 2 0), (1 0, 1 1))')\n",
+    "svg_split_view(in_geoms) # 4 non shared arcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topojson as tp\n",
+    "import geopandas as gpd\n",
+    "import json\n",
+    "\n",
+    "# Load JSON geometry\n",
+    "json_string = '{\"type\": \"FeatureCollection\", \"features\": [{\"id\": \"0\", \"type\": \"Feature\", \"properties\": {\"certainty\": 4}, \"geometry\": {\"type\": \"Polygon\", \"coordinates\": [[[556395.0, -2289375.0], [556485.0, -2289375.0], [556485.0, -2289735.0], [556455.0, -2289735.0], [556455.0, -2289705.0], [556395.0, -2289705.0], [556395.0, -2289735.0], [556335.0, -2289735.0], [556335.0, -2289705.0], [556365.0, -2289705.0], [556365.0, -2289675.0], [556395.0, -2289675.0], [556395.0, -2289615.0], [556365.0, -2289615.0], [556365.0, -2289555.0], [556335.0, -2289555.0], [556335.0, -2289465.0], [556365.0, -2289465.0], [556365.0, -2289435.0], [556395.0, -2289435.0], [556395.0, -2289375.0]]]}}, {\"id\": \"1\", \"type\": \"Feature\", \"properties\": {\"certainty\": 4}, \"geometry\": {\"type\": \"Polygon\", \"coordinates\": [[[556065.0, -2289075.0], [556155.0, -2289075.0], [556155.0, -2289135.0], [556125.0, -2289135.0], [556125.0, -2289195.0], [556095.0, -2289195.0], [556095.0, -2289225.0], [556065.0, -2289225.0], [556065.0, -2289375.0], [556095.0, -2289375.0], [556095.0, -2289465.0], [556125.0, -2289465.0], [556125.0, -2289525.0], [556155.0, -2289525.0], [556155.0, -2289615.0], [556125.0, -2289615.0], [556125.0, -2289645.0], [556155.0, -2289645.0], [556155.0, -2289675.0], [556125.0, -2289675.0], [556125.0, -2289735.0], [556155.0, -2289735.0], [556155.0, -2289765.0], [556185.0, -2289765.0], [556185.0, -2289795.0], [556215.0, -2289795.0], [556215.0, -2289825.0], [556245.0, -2289825.0], [556245.0, -2289855.0], [556305.0, -2289855.0], [556305.0, -2289825.0], [556335.0, -2289825.0], [556335.0, -2289795.0], [556365.0, -2289795.0], [556365.0, -2289825.0], [556395.0, -2289825.0], [556395.0, -2289855.0], [556455.0, -2289855.0], [556455.0, -2289825.0], [556485.0, -2289825.0], [556485.0, -2289885.0], [556455.0, -2289885.0], [556455.0, -2289915.0], [556425.0, -2289915.0], [556395.0, -2289915.0], [556395.0, -2289945.0], [556365.0, -2289945.0], [556305.0, -2289945.0], [556305.0, -2289975.0], [556275.0, -2289975.0], [556245.0, -2289975.0], [556245.0, -2290005.0], [556215.0, -2290005.0], [556155.0, -2290005.0], [556155.0, -2290035.0], [556125.0, -2290035.0], [556095.0, -2290035.0], [556095.0, -2290065.0], [556065.0, -2290065.0], [556035.0, -2290065.0], [556035.0, -2290095.0], [556005.0, -2290095.0], [556000.0, -2290095.0], [556000.0, -2289135.0], [556005.0, -2289135.0], [556035.0, -2289135.0], [556035.0, -2289105.0], [556065.0, -2289105.0], [556065.0, -2289075.0]]]}}, {\"id\": \"2\", \"type\": \"Feature\", \"properties\": {\"certainty\": 0}, \"geometry\": {\"type\": \"MultiPolygon\", \"coordinates\": [[[[556000.0, -2290095.0], [556005.0, -2290095.0], [556035.0, -2290095.0], [556035.0, -2290065.0], [556065.0, -2290065.0], [556095.0, -2290065.0], [556095.0, -2290035.0], [556125.0, -2290035.0], [556155.0, -2290035.0], [556155.0, -2290005.0], [556215.0, -2290005.0], [556245.0, -2290005.0], [556245.0, -2289975.0], [556275.0, -2289975.0], [556305.0, -2289975.0], [556305.0, -2289945.0], [556365.0, -2289945.0], [556395.0, -2289945.0], [556395.0, -2289915.0], [556425.0, -2289915.0], [556455.0, -2289915.0], [556455.0, -2289885.0], [556485.0, -2289885.0], [556485.0, -2290250.0], [556000.0, -2290250.0], [556000.0, -2290095.0]]], [[[556485.0, -2289000.0], [556485.0, -2289375.0], [556455.0, -2289375.0], [556395.0, -2289375.0], [556395.0, -2289435.0], [556365.0, -2289435.0], [556365.0, -2289465.0], [556335.0, -2289465.0], [556335.0, -2289555.0], [556365.0, -2289555.0], [556365.0, -2289615.0], [556395.0, -2289615.0], [556395.0, -2289675.0], [556365.0, -2289675.0], [556365.0, -2289705.0], [556335.0, -2289705.0], [556335.0, -2289735.0], [556395.0, -2289735.0], [556395.0, -2289705.0], [556455.0, -2289705.0], [556455.0, -2289735.0], [556485.0, -2289735.0], [556485.0, -2289825.0], [556455.0, -2289825.0], [556455.0, -2289855.0], [556395.0, -2289855.0], [556395.0, -2289825.0], [556365.0, -2289825.0], [556365.0, -2289795.0], [556335.0, -2289795.0], [556335.0, -2289825.0], [556305.0, -2289825.0], [556305.0, -2289855.0], [556245.0, -2289855.0], [556245.0, -2289825.0], [556215.0, -2289825.0], [556215.0, -2289795.0], [556185.0, -2289795.0], [556185.0, -2289765.0], [556155.0, -2289765.0], [556155.0, -2289735.0], [556125.0, -2289735.0], [556125.0, -2289675.0], [556155.0, -2289675.0], [556155.0, -2289645.0], [556125.0, -2289645.0], [556125.0, -2289615.0], [556155.0, -2289615.0], [556155.0, -2289525.0], [556125.0, -2289525.0], [556125.0, -2289465.0], [556095.0, -2289465.0], [556095.0, -2289375.0], [556065.0, -2289375.0], [556065.0, -2289225.0], [556095.0, -2289225.0], [556095.0, -2289195.0], [556125.0, -2289195.0], [556125.0, -2289135.0], [556155.0, -2289135.0], [556155.0, -2289075.0], [556065.0, -2289075.0], [556065.0, -2289105.0], [556035.0, -2289105.0], [556035.0, -2289135.0], [556005.0, -2289135.0], [556000.0, -2289135.0], [556000.0, -2289000.0], [556485.0, -2289000.0]]]]}}]}'\n",
+    "json_data = json.loads(json_string)\n",
+    "\n",
+    "# Convert to GeoDataFrame\n",
+    "gdf = gpd.GeoDataFrame.from_features(json_data[\"features\"])\n",
+    "\n",
+    "# Construct topology and simplify (with shared_coords=False)\n",
+    "topo = tp.Topology(gdf, shared_coords=False, prequantize=False)\n",
+    "simplified_gdf = topo.toposimplify(30).to_gdf() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simplified_gdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo.toposimplify(30).to_alt(color='properties.certainty:Q')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_geoms = linemerge(in_geoms)\n",
+    "svg_split_view(out_geoms) # 3 out of 4 can be merged"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "import geopandas\n",
+    "import topojson as tp\n",
+    "from shapely.wkt import loads\n",
+    "\n",
+    "df = pandas.DataFrame({\n",
+    "    \"name\": [\"P1\", \"P2\", \"P3\"],\n",
+    "    \"geometry\": [\n",
+    "        \"POLYGON ((60.05 88.85, 60.3 86.9, 61.9 73.4, 51.85 72.1, 50.8 80.5, 57.95 81.4, 57.5 85.05, 59.05 85.25, 58.85 87.15, 60.05 88.85))\",\n",
+    "        \"POLYGON ((66.35 90.55, 65.75 86.8, 64.5 81.1, 63.7 77, 63 73.55, 61.9 73.4, 60.3 86.9, 64.15 87.45, 64.85 90.8, 66.35 90.55))\",\n",
+    "        \"POLYGON ((65.75 86.8, 70.5 87.45, 71.45 79, 69.85 78.85, 70.3 74.5, 64.15 73.75, 63.7 77, 64.5 81.1, 66.45 81.35, 65.75 86.8))\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "df['geometry'] = df['geometry'].apply(loads)\n",
+    "gdf = geopandas.GeoDataFrame(df, geometry='geometry', crs='EPSG:27700')\n",
+    "topo = tp.Topology(gdf, prequantize=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo.to_gdf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo.to_alt(color='properties.name:N')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "The issue is in the process when the remaining non-shared arcs are tried to be merged again. \n",
+    "In this process are currently two options covered \n",
+    "(1) the first and last non-shared arc can be merged and \n",
+    "(2) all arcs can be merged. Until know this were the two situations \n",
+    "\n",
+    "It seems the assumption that this logic works for all cases has been proven wrong.\n",
+    "Somehow need to find a better method to detect which segment-indices where merged"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "The shared segments of a linestring are collected from all geometries. \n",
+    "The remaining non-shared segments of each linestring are then tried to be merged. These merged contigious \n",
+    "segment replaces the"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "import geopandas\n",
+    "import topojson as tp\n",
+    "from shapely.wkt import loads\n",
+    "\n",
+    "df = pandas.DataFrame({\n",
+    "    \"name\": [\"P1\", \"P2\", \"P3\"],\n",
+    "    \"geometry\": [\n",
+    "        \"POLYGON ((60.05 88.85, 60.3 86.9, 61.9 73.4, 51.85 72.1, 50.8 80.5, 57.95 81.4, 57.5 85.05, 59.05 85.25, 58.85 87.15, 60.05 88.85))\",\n",
+    "        \"POLYGON ((66.35 90.55, 65.75 86.8, 64.5 81.1, 63.7 77, 63 73.55, 61.9 73.4, 60.3 86.9, 64.15 87.45, 64.85 90.8, 66.35 90.55))\",\n",
+    "        \"POLYGON ((65.75 86.8, 70.5 87.45, 71.45 79, 69.85 78.85, 70.3 74.5, 64.15 73.75, 63.7 77, 64.5 81.1, 66.45 81.35, 65.75 86.8))\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "df['geometry'] = df['geometry'].apply(loads)\n",
+    "gdf = geopandas.GeoDataFrame(df, geometry='geometry', crs='EPSG:27700')\n",
+    "topo = Dedup(gdf, options={'prequantize':False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topojson as tp\n",
+    "import geopandas as gpd\n",
+    "\n",
+    "# Read file\n",
+    "gdf = gpd.read_file(r\"C:\\Users\\lilei\\Downloads\\polygons\\polygons.json\")\n",
+    "\n",
+    "# Construct topology and simplify\n",
+    "topo = tp.Topology(gdf, prequantize=False)\n",
+    "simplified_gdf = topo.toposimplify(30).to_gdf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -2,19 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-96f19616fba14059b5e76ca06dcaa296\"></div>\n",
+       "<div id=\"altair-viz-3b1b2cd61e564f738ef9081f5a0d78b6\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-96f19616fba14059b5e76ca06dcaa296\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-96f19616fba14059b5e76ca06dcaa296\");\n",
+       "    if (outputDiv.id !== \"altair-viz-3b1b2cd61e564f738ef9081f5a0d78b6\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-3b1b2cd61e564f738ef9081f5a0d78b6\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -63,7 +63,7 @@
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -99,339 +99,119 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "import geopandas\n",
     "from topojson.core.hashmap import Hashmap\n",
     "\n",
-    "# data = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
-    "# data = data[\n",
-    "#     (data.name == \"Botswana\")\n",
-    "#     | (data.name == \"South Africa\")\n",
-    "#     | (data.name == \"Zimbabwe\")\n",
-    "#     | (data.name == \"Mozambique\")\n",
-    "#     | (data.name == \"Zambia\")\n",
-    "# ]\n",
-    "\n",
     "data = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
     "data = data[\n",
-    "    (data.name == \"Togo\") | (data.name == \"Benin\") | (data.name == \"Burkina Faso\")\n",
+    "    (data.name == \"Botswana\")\n",
+    "    | (data.name == \"South Africa\")\n",
+    "    | (data.name == \"Zimbabwe\")\n",
+    "    | (data.name == \"Mozambique\")\n",
+    "    | (data.name == \"Zambia\")\n",
     "]\n",
+    "\n",
+    "# data = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "# data = data[\n",
+    "#     (data.name == \"Togo\") | (data.name == \"Benin\") | (data.name == \"Burkina Faso\")\n",
+    "# ]\n",
     "#topo = Hashmap(data)\n",
     "topo = topojson.Topology(data)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Topology(\n",
-       "{'arcs': [[[880723, 35917], [-89176, -12698]],\n",
-       "          [[822755, 654305],\n",
-       "           [36222, 31881],\n",
-       "           [38680, 281],\n",
-       "           [82280, -62637],\n",
-       "           [-4205, -36162],\n",
-       "           [24267, -64566],\n",
-       "           [-21261, -43817],\n",
-       "           [11369, -29277],\n",
-       "           [-52342, -67382],\n",
-       "           [-33238, -33366],\n",
-       "           [-20341, -68655],\n",
-       "           [2727, -69238],\n",
-       "           [-6190, -175450],\n",
-       "           [-89176, -12698]],\n",
-       "          [[687348, 551684],\n",
-       "           [-13728, -57311],\n",
-       "           [32960, -32131],\n",
-       "           [37470, -38119],\n",
-       "           [4099, -53418],\n",
-       "           [21735, -22426],\n",
-       "           [-4913, -249970],\n",
-       "           [26576, -75090]],\n",
-       "          [[791547, 23219],\n",
-       "           [-86874, -23219],\n",
-       "           [-24083, 38220],\n",
-       "           [-28761, 69050],\n",
-       "           [-8570, 54138],\n",
-       "           [23854, 98039],\n",
-       "           [-27066, 39703],\n",
-       "           [-10282, 85746],\n",
-       "           [181, 79045],\n",
-       "           [-45034, 56132],\n",
-       "           [7940, 33934]],\n",
-       "          [[822755, 654305],\n",
-       "           [-23575, -32545],\n",
-       "           [-52743, -10170],\n",
-       "           [-21981, -47588],\n",
-       "           [-37108, -12318]],\n",
-       "          [[687348, 551684], [-94496, 2323]],\n",
-       "          [[592852, 554007],\n",
-       "           [-49905, 8670],\n",
-       "           [-34839, -17568],\n",
-       "           [-47669, 7933],\n",
-       "           [-187431, -5129],\n",
-       "           [-2534, -61755],\n",
-       "           [14718, -81947],\n",
-       "           [-73848, 28068],\n",
-       "           [-50558, -4134],\n",
-       "           [-37744, -27376],\n",
-       "           [-48516, 22983],\n",
-       "           [-18858, 35998],\n",
-       "           [-48522, 23731],\n",
-       "           [-7146, 63188],\n",
-       "           [29427, 46137],\n",
-       "           [-2492, 36868],\n",
-       "           [85650, 90210],\n",
-       "           [15835, 74646],\n",
-       "           [29567, 26563],\n",
-       "           [52180, -14675],\n",
-       "           [45221, 22161],\n",
-       "           [14676, 27961],\n",
-       "           [83718, 48792],\n",
-       "           [20586, 34024],\n",
-       "           [100853, 45150],\n",
-       "           [59401, 15493],\n",
-       "           [26932, -20882],\n",
-       "           [69181, 501],\n",
-       "           [-8550, -52755],\n",
-       "           [14489, -49579],\n",
-       "           [60761, -71075],\n",
-       "           [3351, -52672],\n",
-       "           [124412, -24688],\n",
-       "           [-2443, -74544]]],\n",
-       " 'bbox': (-5.470564947929006,\n",
-       "          5.928837388528876,\n",
-       "          3.7971122575117136,\n",
-       "          15.116157741755728),\n",
-       " 'coordinates': [],\n",
-       " 'objects': {'data': {'geometries': [{'arcs': [[0, -3, -5, 1]],\n",
-       "                                      'properties': {'continent': 'Africa',\n",
-       "                                                     'gdp_md_est': 24310.0,\n",
-       "                                                     'iso_a3': 'BEN',\n",
-       "                                                     'name': 'Benin',\n",
-       "                                                     'pop_est': 11038805},\n",
-       "                                      'type': 'Polygon'},\n",
-       "                                     {'arcs': [[2, 3, -6]],\n",
-       "                                      'properties': {'continent': 'Africa',\n",
-       "                                                     'gdp_md_est': 11610.0,\n",
-       "                                                     'iso_a3': 'TGO',\n",
-       "                                                     'name': 'Togo',\n",
-       "                                                     'pop_est': 7965055},\n",
-       "                                      'type': 'Polygon'},\n",
-       "                                     {'arcs': [[4, 5, 6]],\n",
-       "                                      'properties': {'continent': 'Africa',\n",
-       "                                                     'gdp_md_est': 32990.0,\n",
-       "                                                     'iso_a3': 'BFA',\n",
-       "                                                     'name': 'Burkina Faso',\n",
-       "                                                     'pop_est': 20107509},\n",
-       "                                      'type': 'Polygon'}],\n",
-       "                      'type': 'GeometryCollection'}},\n",
-       " 'transform': {'scale': [9.267686473127193e-06, 9.187329540556393e-06],\n",
-       "               'translate': [-5.470564947929006, 5.928837388528876]},\n",
-       " 'type': 'Topology'}\n",
-       ")"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x24fd770ccc8>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPIAAAD4CAYAAADW87vCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO2dd3icxbX/P2eLVr1Zki2ruzdcZRvTIRCawbQQeksA55Lc5OamERISCNxUkvtLSOgQEpIQUx3gEkICNgGCbblhyw3ZsqxiWbLV20q7O78/tCbC3pVW2953V/N5Hj1e7b47c/R6vzszZ86cI0opNBpNbGMx2gCNRhM6WsgaTRyghazRxAFayBpNHKCFrNHEATajDRhKTk6OKi0tNdoMjcaUbNy48bBSKtfXa6YScmlpKRUVFUabodGYEhGp8feanlprNHGAFrJGEwdoIWs0cYAWskYTB2ghazRxgBayRhMHaCFrNHGAFrJGEweYKiBEEzu4PYqGtl7qWnupbe2hrrWXutYeWrr7mVuQwbLJOSwsycRhsxpt6phAC1kzIq3d/bywqY5djZ3UtfZQ29LLoY4+XB7fSSnW7G7ml29VkZOawJ3nz+TyRYVRtnjsoYWsGZZnPqjhvtd20DfgGfV7D3f189/PbWVVRS0/uGQO08anRcBCDeg1smYY+gbc/OLNPUGJeCjrqls493/f4cYn1/PWrkN4/IzkmuDRI7LGLy9uqudId39Y2lIK1u5pZu2eZgoykzh1ag4nTxn8yU5JCEsfYxktZI1PlFI8+V51RNqub+vl2Q21PLuhFhGYOSGdC+fmc/PJpSQn6I9kMOi7pvHJmt3NVDV1RbwfpWDHwQ52HOzgqff286WzpnDN0mLsVr3qGw36bml8crjLaUif3/tLJWc9sIY3Khuj3n8so4Ws8cmlCwooGZdsSN+1Lb2sfGYjz3zg9xy95hi0kDU+sVktfOmsqYb1rxR85+XtPLx2r2E2xBIhCVlEPiMilSLiEZHyY167U0SqRGS3iJwbmpkaI7h0QQGJdmO/63/0+i5++sYuQ22IBUL9X9oOXAa8M/RJEZkFXAXMBs4DfiMiOlYvxujsGwh5Dzkc/PrtvextjrzjLZYJSchKqZ1Kqd0+XloBPKuUciqlqoEqYEkofWmiz77D3Uab8DH/2HnIaBNMTaTmTQVA7ZDf67zPHYeI3CYiFSJS0dzcHCFzNMGwr9lMQm4y2gRTM6KQReTvIrLdx8+K4d7m4zmfcXlKqUeVUuVKqfLcXJ8pezUGUX3YPNPZjTWttPcMGG2GaRkxIEQpdXYQ7dYBRUN+LwQagmhHYyBmGpFdHsWaPU2smO9zYhdztHb3kxXG0NRITa3/AlwlIg4RKQOmAusj1JcmQlSbaI0M8TG9Vkrx+D/3cc4v3sHpcoet3VC3ny4VkTpgGfCaiLwBoJSqBFYBO4C/AncopcJntSbiKKXYf8RcQu7pj+2P0JEuJ7f8dgP3vbaTw11O3t4Vvi+mkGKtlVIvAS/5ee1+4P5Q2tcYR31brym2no6SaLdw9/JZRpsRNO9VHea//ryFps5/h76+uKme8+bkh6V9fWhC45MDR3qMNuETXLW4mGKDQkZDweX28PM39/Dw2r0cewx7z6HOsPWjhWwyao50c88rO8hMtnPbaZOYMSHdEDtqW80l5JOn5BhtwqjY0dDB6q31vLKlgYb2Pp/XJNrDFyOlhWwyirOT2XWwg4b2Pmblpxsm5PrWXkP69YVFYElpttFmjEhdaw+rtzSweks9ew6NvHWXnKCFHLeICKdNy+XZDbX886PDFGcn093vosvpJsEqlIxLoSwnhfHpiRG1o85EQp4xIZ2MZLvRZgCwvb4diwgJNgsO26CveO2eZlZvqaeiphU1iixGSVrI8c3R/dujqXF8kZxgpSwnhYevW0RRdvjXjmYS8omTxhltAn0Dbr7+/Ie8sjV84RBJ9vDJTwvZZPS7PGytaxvxup5+N5UNHXzpT5t5buWysGfUqG8zj5CXTgpsWt3W08/qLQ00dvTR2O796eijs8/FnIJ0FpdmU16SxbyizFGtT5s7ndz6uwq21I78/zIa9Igcx2yrb8fpCnzbZ0ttGz97Yzd3XjBzxGs7+wb43b9q+NwpZcN+kF1uD40dvh00RlCUFdiM47mKOu7/v50+X1uzu5k1uwdnNwlWy8fCXlyaTXlpFikOGy9srOPPFbV09A6e+uobcNM74KZvwH2cxzkcJGtnV/ziGc0iy8uj/9zH+PRETpw0jil5qSTYPjk69/a7eer9ah59Zx9tPQPkpjm4srzIT2vQ0efCbhXcJklbu7WujVkTR3b6vbCpLqD2+t0eNh1oY9OBNh55Zx8ikOqw0dnnCtXUUWGx+DqSEBxayCajvCSLouwkalsCn9oqBfe+ugMAm0UozUlh+oQ0po9Pw2YVnnx3/ydycD39/v5hhZydksDrXz6Nbzy/lQ37W4P/Y8JExf5Wrl5SPOw1Oxo62NUY3L6sUkRdxBDe5YsWsskQES5bUMj/+8dHQb3f5VFUNXVR1dTFaxz0eU1lQwcb9reweJgtnbKcFFbdvoyXNtfzszd2+90LjQYba1pGvCbQ0dhM1IQxBFbn7DIhF5wQnrC94fjKs1v4+nNbeeLdat7fe5i2nuMT0YsIly0s5K2vncHXz51OquPf3/v5GYmkhNFZMxz7j/TQ3Ok/q6fbo1i9JfYO19W39uJyhycMVo/IJmR99ZGI91Hf1stzGz85ik1IT2Tl6ZO46eSyTzyfaLdyx5lT+OziIn7x5h7cHsVdF87k8ofeDyjwIRxsrGnxG5d8oKXHkPS9oeLyKOpaeynNSQm5LS1kE/Kn9bUjXxQBGjv6uOfVHeSlJ/qcFeSkOrj/0hM+/j0rOXqlXtp7/ScVKMlOJtVho8sZ/XVuqOw/0h0WIeuptclo6uhjx8EOw/pXCv7rz1vYdGBkJ1e0ajZdvaSIzy727+yyWIQTCjKiYku4qQnT4RQtZJORl55ITqrDUBucLg+3Pl1Bwwhe1XBmuPDHp2eN575LThjxuvnFmRG3JRKEq0ieFnKEaOroo6mzj8NdTo50OWnt7qetp5/23gE6+gbocrrodrro7R8MOHC63Ay4PbjcHpaUZRltPke6+/nPP20e1hmTHeGptc0i/PjyuVgD2G+dXxSbQh7Qzi7z0tvvZsn//MNoM0KmoqaVB97cwzfPm+Hz9UiPyCdOGhdwHwtidEQeGEUU33DoETkCuIOIzjIrD6/dy5rdvlPSZEX4RNL5J0wI+Nq8tEQKMpMiaE1k6Ncjsnlxu+NHyErBV1dt5aaTSrFaBBGwimC1SETLrloEzp0duJBhcHptpsMegaCn1ibG5TFPrqtw0NLdz8/f3BPVPheXZo/a6Te/KJPXtvmOZjMrozkgMxxayBEgnqbWRhFMdNvCkkzSEm0kJ1hxujy0xUBC+4Ewzd60kCOAWU4NxSoicN6c0U2rARaVZLPt+4OFP9t7Bvjc0xuoqDH+0MdwaGeXiXHF0RrZCJSC//jDJr9OtkDISLbzzOeXcu7s8WG0LPyEy9mlhRwB9IgcOhtrWrnpqQ2s+PV7rAkykXui3cpD1y7i5CnGpwryR7icXVrIEUCvkUNDgCl5KSwty6bf5ebW31fw3Ze3B3VSyGIRvn/RbGxhPMQfTvr11Nq86BF59IxPd7C4NIsFxZmkJ9mpaupmXXULOw92MuBW/P6DGm56asOwhyf8MXV8GtedWBIBq0MnXAc9tJAjgF4jj0xKgpV5hRksKc2mMCuJQx1ONuxvZfOBNr9ifbfqMJf+5r2Pi8v19LtoCTBW+b/OnhbxAJZg2HGwY8SY9kDQXusIoEfk47EITM5NJTslgfbeAaqautha1z7qdvY1d3PJr99j2aRxrN3TjN0qfPuCmVw1QiqgjGQ7Xz1nGt9dXRnsnxARlILVWxr4whmTQ2on1GqMnxGRShHxiEj5kOdLRaRXRLZ4fx4OycoYQ6+RB8nPGJwuzy/KJMVh46OmLtZVt7CrsRNXCF927b0D/LWykd4BNx19Lr714jaufvQDOvuGn3Zfs7SEsjCc/Q03L2+uD7mNUEfk7cBlwCM+XturlJofYvsxiTvOIrsCJdVhZUpeKnarlYa2Hurb+jjYHp3MHf/ad4QdDR0sHSaZvdUiTM5NMV3d54PtvQy4PSHlJg+1rOpOGMztpPk3Y3WNPH1COhsNDMDYf6R7WCEDpCeZb518xaKikAsMRNLZVSYim0VkrYicGsF+TMdYnVobvcXTGMDon55oLiGLwPXLQveojzgii8jfAV/xcncppVb7edtBoFgpdUREFgEvi8hspdRxOWxE5DbgNoDi4uEdFrHCWHV2Gfl3i8CFc0cO68ww2Yh8ypScsKzbRxSyUurs0TaqlHICTu/jjSKyF5gGVPi49lHgUYDy8vK4UEAojpxYxsjkd2dOz2NKXtqI15lNyDcsKw1LOxGZWotIrohYvY8nAVOBfZHoy4zE03nk0RDonm4kuPXUSQFdZyYhF2cn86kZeWFpKyRnl4hcCvwKyAVeE5EtSqlzgdOAe0XEBbiBlUqpkcsFxAljaY2clmijMCuJNIcNpRQdfYMF0KJNoKl+zCTkb5w3PWz1n0L1Wr8EvOTj+ReAF0JpO5aJ9zVyfkYi+RmJ1LX20tTpZOfBf9dcmpKbSlVzdJLWD6Wpw0nxuJGrNpqlYPrC4kyWz50YtvZ0iGYEiOc1cnlJFh29A2w60EaTjzIuxwrFZhGS7FaSI1xeJtAysGYZke+6cFZY29MhmhHAE4dCzkyyU5qTMuJB/e31bSTbLQy4FQMehcujcHncAMwrzMDp8gRdNXE4AhHy/sPdPLRmb9j7Hi0XnpDPopLwpjzWQo4AZvnWDxd2q+CwW9hS2zbitU6XAnx/kR2NrZ6al8qA28P+MFVZADg0TLXI+rZefvLXXbz64UHDlz3JCVa/6YVDQU+tI8CZM/JGrOcbS8zKT+dQR/hCLT9q6qKn301uWvgqary9uwmny+3ztf95bSertzQYLuI0h43f3bIkoLX8aNFCjhD3rpjN0jL/9YdjBZtFwuZZHUpTpxOHzcLSsmwWl2Yxc0JaSOvo9/ce4XO/raCn/5N72fVtvfy1sjFUc0MmPdHG7z+/lPJhalKHghZyhLBbLTx03SKKsmMvaTrAkrJsZk5Iw2qBzQdGnlIHQ11rL+uqW9iwv5WdjZ0k2iwhrR3frTrMDU+sp2PIKain399v+EiclWznj7eeGNGyNlrIESQ7JYHHbiiPWkHwcLG0LJv11S3sbOz0rnmjQ0vPABtrWpmdn05hVnBfgBU1rVzz2Ae0dPfT7XTx7PoDYbZydIxLSeCPt57InAhXi9RCjjAzJqTzi8/OJxYOiFkEFpdmsa7a2NidyoMdHOroIzfIqpTb6zu48pF/8Zs1VXT0GRM2mmCzcNmCAp7/wknMzE+PeH/aax0FPj17At88bwY/en2X0ab4xWYR5hZmsGG/OfJAD7gVNmvw335VTV0RLWnjj8KsJK5dWsJnFxdFrX40aCFHjZWnD6ZyMaOYE2wWZk5IY1OE1sLBEgOTGGDw5NXp03K5/sQSzpyeFxHn4EhoIUeRladPJslu5fuvVGKWcOykBCuTclKCyp811klz2PhMeRE3nlRCyThjUwhpIUeZG08qJclu5VsvfogvZ2pemoOlk8bR73JzuKvfWyi9PyJHBJMSrBRlJVHZcNwxcVNgVr/CpNwUblxWyhWLCklxmENC5rBijHHl4iISE6x89c9bsFiExaVZnDY1l9On5zJjgm/HSF1rDz/+625e2doQFhssAtPyUk09Eptk0gL8e/p800mlnD4t13TprUSZZY7HYGKBiorjcg/ELVVNXRRkJpE0iu2pjTUtfHXVVmpCDG9c4t1iMjMTMxNpaAvsMESksFmEa5cWc+NJpUzKTTXUFhHZqJQq9/WaHpENZEre6D4YLreH5s5+po9PI8lu5UBLDz39vsMShyMWRAwgBru7EqwWfnXNglEXXDcCLWSDUErRO+AmOWHk/4Lalh6e3XCA5yrqPj46mJRgxWGzgFJkpzpIdQzWBT6ajdHtUTR29FHX+skqBnMLM6jYb34RG02S3coj1y/itGm5RpsSEFrIUaLb6WJLbRsba1rZWNPK5gOtZKck8NzKk447PFDb0sPdq7ezdk+zT4cYQG+/m3kFGXxQ3UJPq/+SI1PyUhiXMti+UorKhg6/bZoNo5Z9aQ4bT9y0mCUxFCuvhRwhalt62HSg9WPh7mrsPC7mt6PPxQ1PrufZ204kI8lOv8vDo+/s5cG3qwJKl1PZ0EGqw0qX0//0uqqpmyrMlZA9ELKT7RwMMFlAOMlMtvO7W5YwtzBycdGRQAs5SLbXt7P/SDc9Tjc9/S56Btz09rvZ29zFxprWgI/97TzYwed+u4E7zprCfa/uYG9z4KLrdLpYWpZteEhlJCjLTaUlysnuc9McPPO5pUyfMHI2TrOhhRwkj/1zH6u3hGcrqKKmlZuf2hDUe3cf6iTJbqHXgIR3ESXKs+qCzCSe+fxSU9aGCgR9aCJIzLLObOsZiLlp4EgIsPdw9OKky3JSWLVyWcyKGLSQg8Zjov33jTWtlIc5B5SRTM5Loa1n9AXNg2FeYQZ/vv1ECjJj89z4UfTUOkjMFEjj8igqalo5oSCDbfXmjdQKlLQo1GdaVJLFHWdO5qwZ4yPeVzTQQg4So7NO+KLTOYBgrtDGYIh0Mbh7Lp7NjSeVRrSPaKOn1kFiQh2z/3BP2NOsGoElgnHM37toVtyJGLSQg8ZMU+uh1Lb2kBDCgfx45jsXzuTmk8uMNiMiaCEHiRlHZIBDHU4WFMf2qByJW/ut82fw+QALvcUiWshBYiav9bGsq27hxBgKLzyWcH8ov/bpaR9naIlXtJCDxKwj8lE+qG6J2bzaOxs7SA3Dgf30RBs/WDGbL541NQxWmZuQhCwiPxWRXSLyoYi8JCKZQ167U0SqRGS3iJwbuqnmwqxr5KGsq26JqcD/o7T3upg9MfjMkzaLcNNJpaz9+plcH6ZC4mYn1BH5TWCOUmousAe4E0BEZgFXAbOB84DfHC18Hi+YeWo9lPXVLSwujb01cyj39wtnTOb7F88mK4pZLI0mJCErpf6mlDqaTOoDoND7eAXwrFLKqZSqBqqAJaH0ZTY8MRTavGH/YORXLPmyQ4nsKsoKf20lsxPONfItwOvexwVA7ZDX6rzPHYeI3CYiFSJS0dzcHEZzIos7Rkbko1TUtLKwJAsDMrWOGqvAgZbgUxlNjPFwy2AYUcgi8ncR2e7jZ8WQa+4CXMAfjj7loymfn3yl1KNKqXKlVHlubmxkY4DYWCMfy8aaVuYVZWIzuYuzKDsZpyv4KU9BkOVmYpkRXYNKqbOHe11EbgSWA59S//501wFFQy4rBMJz5s8kmN1r7Y/NB9qYW5hBT7+bfc1dpvs7puSm0jsw+jxkRxGB/IzEMFoUG4TqtT4P+CZwsVJq6FzoL8BVIuIQkTJgKrA+lL7MRqw4u3zxYV07VU1dJCVYOaEgw1QjdLLDSn2b/9RFI2G3WHDG29nsAAj1v/BBIA14U0S2iMjDAEqpSmAVsAP4K3CHUir4r1kTYraRLBi6nW621bdjs5hDyVnJdnaEmCy/3+3hh6/vDJNFsUNIu+5KqSnDvHY/cH8o7ZuZWFwj+8MsDrCp49PCkqb3zxW1XL6okMURKipuRszxVRyDxPLU+ljKDE68fpSW7v6wtKMUfPvFbfSH4DCLNbSQgySW9pFHwgwDcnF2cljLoH7U1MUja/eGrT2zo4UcJPE0Im9v6GBSrnH5qhw2IWUUZXMC5cG3q9h/OPZSAQeDFnKQxJOQATKTIp9exxc2C0yfkM7Oxs6wt+10eXjknbExKmshB0k8eK2HsrWunRkT0qK6FSXA3MJMPoxgRcg3Kg/hcsfROsgPOmdXkMTbiOz2KHY1dpJgszA1J5nM5MERuqW7f1RJ80fD4tIs1u+PbBL6lu5+3t97JGZqOAWLFnKQxJmOP6bf5eGjY5xOcyam09jRx+Gu8HiVgahWyHj1wwYt5LFKU0cfD6/dR5/LTV+/e/DfAQ99A276BtwhRR/FGtsbOshMsjO/KJMttW0htxftMjdr98TOYZxg0UL2Q3OXkyffqzbaDNPQ1jvAlto2Fpdmsb2+PegSNeUlWayPclnX9t7oJLs3Ei1kzag40NLDvKJMup1uRMBmsWC1wO7GTjr6XB9fV5SVhMUi1LX2fpwDfF5RBptr26K+LHG6PDzwt92cNSMv5hMT+kMLWRMQ41ISmJybwuYDbT4rTdotwrzCDBLtVpo7nezz7t8mWIWyvBRyUx1sPNBmSGJ/peBXb1WxMA5yfvtDC1kzLBlJdmZMSGNrbduwHuYBj2Krj22kfrcarNHc1E3JuGRqjgSfMCBUHGY65hVm4vcv04REisPK0rJs3B4P66pb6AtD3HJ+urHnhLWQNWMGh83C0rJs7FYL66pb6HKG7/RpncGefoctrvI/fgItZA0wmFljcWkWaYk21lW3RKSsaV1rL5MMrEGcoEdkTTyTaLewoCiTDftbwxr04YvcNEdE2x+OeJ5aa2fXGCc3zUFGop1NB0IP9AiEAy3GnUaKRt1lo4jfryjNiEzNS8XjUVQ1h+8c8EgcbHcyNS/6iQwWFmeSHccJ6/WIPEZZWJzJ9vp2+t3R39c1QlAXz5sY9T6jiR6Rxxgig7HOmw60GSJigOrD3USwlvlxWC3ChXO1kDVxxJLS6B5Y8EVTp5Pp49Oi1p/bo/jNmqq4zuGlhTyGyE11sPlAZM//Bkp6YnRXdU+9t58H3/ooqn1GEy3kMURZboph0+lj2XWoE7s1umn/zpyRF9X+ookW8hghN9XBFpOMxgAdIdZAHi2l45Lj9uQTaCGPGcw0Gn9MlMyxWYSvnD0tOp0ZhN5+GgNMykkx1Wh8lEpv5pG2CB78T3PYePDahZyuU/1oYpmMJDu9Ay7zjcYMHn2cmJkUMSEXZiXx5E2LmRZFD7lRaCHHMVaLUJSVxPYQC6NFkubO45MUhMrsielcu7SESxZMJDlhbHzEQ/orReSnwEVAP7AXuFkp1SYipcBOYLf30g+UUitD6UszMnlpDspyUnB7FJ19Lpo6+0wt4tQEK81d4RGyw2Zh+dyJXHdicVw7tfwR6tfVm8CdSimXiPwYuJPBeskAe5VS80Ns3zD6XR5vBFQrAyaclvqiLCfF8GCP0ZCfmXRc6t3RUpCZxE0nlfKZ8kIyk+M3lnokQi2r+rchv34AXBGaOebgyXerqWzoYF11C4VZSbT1DNDldI38RgOxWiSsRdCiQUYIZWrmFWVy66llnD8nH6tZ6sIaSDi3n24BXh/ye5mIbBaRtSJyqr83ichtIlIhIhXNzcbnH35hYx33vrrj49/rWnuZFcX9zmCZmZ/GkTCVJY0WoxWgReCcWeNZdfsyVt9xMsvnTtQi9jLiiCwifwcm+HjpLqXUau81dwEu4A/e1w4CxUqpIyKyCHhZRGYrpY5bsCmlHgUeBSgvLzd0Dvu3yka+8cKHxz2/obqFqXmpIU8DfZFgs4QlBjgW09j0BZgbO9Fu4fKFhXzulDImmaSWs9kYUchKqbOHe11EbgSWA59SajBjsVLKCTi9jzeKyF5gGlARssUR4v2qw3zxj5t9pmtVDAbeWy0StnSucwsz6Hd52NvUxaz8dNISbRxo6eFge9+o27JbhT2N5nVq+eNI9/COLqtF+MLpk7nllLK4PkscDkL1Wp/HoHPrdKVUz5Dnc4EWpZRbRCYBU4F9IVkaQbbUtvH531XQP0zVvn2Hu8NS6mTGhDT6XZ5PVCDccXBQhHaLsLQsm2317fT0B5b0Lj3Rxsz89Jhych3l8DAe61SHjV9dvSCu46PDSahr5AeBNOBNEdkiIg97nz8N+FBEtgLPAyuVUqb8pO051MlNT60PSDgf1rUxPj34nFNWi9DldH2cvP1YBjyKddUtJCdYWVSSRXZKgs+DBXarMK8ok/lFGfT2u2NGxHlpjk8kwCvJ9p2IryAziee/sEyLeBSE6rWe4uf5F4AXQmk7GtS29HD9E+sCzhjZO+Bh2vhEn5UWAmFBUSYVNSOHSh7u6v9EErwEq5CWaCcpwUqS3cqhzj62hqGYWrQ4ZUoO910yh9KcFNp7B/i/bQd5aVM9/vxUD123kBkTzO9gNBNjI+zFB00dfVz7+LpRi3JrXTvF2ckcaBldxQSbRWhoDy6vc79bDXqkjctbFxKfXVxEqTcNbkaSnauXFHP1kmLe3tXEBz5mE/uP9DC3MDPaZsY0Y/L0U1tPPzc8uX7UYjxKyyi3ebJTEphbmEFD2+gdWbHOuJQEzvIzRT51ao5PJ9a2utiZbZiFMSfkbqeLm3+7gV2NnUG9f1xKwqiCQ8pLs3B5PFFLN2smROBnn5lHisP3xM9mtXDOzPHHPf/mjkO8uKmOps6x98UXLGNKyE6Xm5XPbGRzCKIKNMF6RpKdORPTqdjfSkevuaPCIsVNJ5WO6LA6d87xQt5/pIevrtrKY++YdqPDdIyZNbLL7eErz27hnx8dDqmdND+jy1AmpCdit4qpDyxEg2+dP2PEa4ZbC0/Ni//jh+FiTIzISim+/dI2Xt/eGPB7/KVrrWnpIcXhP4pqUk4KA24Pta3GFiwzA9YAct7mpDqY4KdK42QDEtnHKnE/IiuluP+1nayqqBvV+/x9BJs6nccFhlhkcMpdkJnEnsZOugIM5oh3egfcpFlHHitOnjKOrbXteJTCg0J5wKMUU8drIQdK3Av5129X8fi71WFtc311C0tKs3C6PLT2DHCwvZdDHc6g95fjlS/+cTMPXbdw2MP9vf1u3trVROsxe/kLijNJj+NaTeEmrqfWv/vXfn72tz1hb1cB6/e3srWunQMtPTFzXjnarN3TzDWPraN1mO26VRW1x4kYYHmcV4YIN3Er5Jc313P36kqjzRjzbKlt44qH36feR5Fzt0fx+LvHe6YtAsvn5kfDvLghLqfW/9h5iP9+bqvRZmi87G3u5oqH3uf/XbWALucAOw92suNgB5X17dS2HC/wxaXZjPVS/4sAAA02SURBVPfjANP4Ju6E/MG+I/zHHzaF7bihJjwcbO/jykf+FdC1F8V55cRIEFdT62117Xz+6QqccVysayygTz2NnrgRclVTFzc+td70ubU0w5NotzAxQ0+rR0tcCLmudfA44mgPM2jMR0l2ChLN4slxQswLubnTyfVPrA8qRY7GfJTmJBttQkwS00IecHu4/fcVVPvJuKGJPUrH+c4aohmemBWyx6O455VKZuSnc+7s40/QaGKTEi3koIjZ7ae7/7KdZz44AAweGXzrv0/nrAfWGmyVJlTmFmYYbUJMEpMj8nde3vaxiAHaewc464G1nD/HV/rt4Fhcmh22tjSBsXxuPnMKtJCDIeaE/Kf1Bz4h4qF8d/mskNuflZ/OqtuXcedL20JuSxM4DpuFOy+YabQZMUvMCfmcWeNJ9XO4/7on1pGSEFzFhTSHje33nMvhLidXPvKvMRsZJgKnTcvlqZsX88SN5eSkRicx/BfOmExBZlJU+opHxFscwhSUl5erioqRi1E8+NZHfk81Tc1L5fw5Ezj/hHyUgnteqRwx7/Mvr17As+sP8P7eI0HZHS9cPG8i//mpKUwZkpnjcJeTbzz/IW/taopInwk2C3ddMJMbTyqNSPvxhIhsVEqV+3wtFoXcN+DmjJ+uobEjsL3ji+ZN5IeXncD/vrmHN3ce4qTJOZw2NYdTp+Xy8Jq9PPh2VaimxzRpDhv3XTqHFfML/F7z+D/38T//t5NwTlTKclL41dUL9Lo4QOJOyADPVdTy9eePL7imGR0LijP55VULKMoeORDjjcpGvvzs5oCLrw3HpQsKuO+SOX4zbGqOZzghx9wa+SiXLyxkZr6uRhAK1ywt5rnblwUkYoBzZ0/gwasXhtRnkt3KT66Yyy8+O1+LOIzErJAtFuHbF4ycpVHjm7Nm5HHfijnYAsipNZSXttQH3WfpuGRe+dLJXFleFHQbGt/ErJABTp2ay2nTco02I+aYMSGNX169AMsoi4S/vauJ1z48GFSfGUl2nrxp8SccaZrwEZKQReQHIvKhtxLj30Rk4pDX7hSRKhHZLSLnhm6qb759wQy/xcA0x5OTmsDjN5b73cLzR0+/i++8vD2oPm0W4dfXLNRFyiNIqCPyT5VSc5VS84FXgbsBRGQWcBUwGzgP+I2IBLfBOwIzJqRzxaLCSDQddzhsFh65vpzCrNGfMHpozV6febcC4e6LZnHK1Jyg3qsJjJCErJQaWkohhcEEkwArgGeVUk6lVDVQBSwJpa/h+Nqnp496hBmLZKckMDFz9If2D3c5eTLIlMKXLijghmWlQb1XEzghr5FF5H4RqQWuxTsiAwVA7ZDL6rzP+Xr/bSJSISIVzc3NQdmQl57Il87yWapZM4SD7X1c+9g6mgLcfwfY29zFPa/soDuIpPuJdgvfPE87JKPBiEIWkb+LyHYfPysAlFJ3KaWKgD8AXzz6Nh9N+dywVko9qpQqV0qV5+YG77i65ZQyJufqI3Ajse9wN9c8vo7DXf6T6a/d08y3X9rGKT9+i089sJZXtjYE1dfNJ5cxQaftiQojClkpdbZSao6Pn9XHXPpH4HLv4zpg6B5DIRDcpyFA7FYL3794diS7iBuqmrq47nHfieMrG9q5+an1/HHdAepCqF+VlWznC2dMDsVMzSgI1Ws9dcivFwO7vI//AlwlIg4RKQOmAutD6SsQTp2aq5MMBMiuxk6ue2Id7cdUebjnlR1hCcP8zoWzdMmXKBKqh+hHIjId8AA1wEoApVSliKwCdgAu4A6lVFQqm313+SzW7mkOSxhhvFPZ0MH1T67ju8tnsW7fEdbsbqaipjXkdq8/sYTL9U5CVInZWOvh+PXbVfz0jd1hsEgzWspLsvjTbSdiH2XEmGZk4jLWejhWnj6ZhcX+C2hrIkNemoPfXLtQi9gA4vKOWy0yGJQfZJIBzeixW4WHrltInq7ZZAhxKWQYzMZ490Whp/7RjIwI/GDFHBaV6DxnRhG3Qgb47OJizpmlvdiRxG4VfnHlfK5aUmy0KWOauBYywI8vn0tumsNoM+KSJLuVx24o55IF/jOLaKJD3As5OyWBn1w+12gz4o7MZDt/uHUpZ0zXlRPNQNwLGQbLdJ49U0+xw8XEjESeX7mMhcVZRpui8TJmjgzp6XV4mJKXyu9uWcJEnbrWVIwZISfax8TkI6LML8rkqZsWk5USnVzXmsAZM0J22PSeciicPi2Xh65bSHLCmPnIxBRj5n9Fj8jBc8WiQn542Qk6YsvEjBkh6xF59IgMZl+540ydtMHsjAkhv191mBc31RltRkyRaLfw8yvnc8EJ+UabogmAuBfyva/s4Mn3gss3NVbJTXPw2A3lzC/SB09ihbgXsi6cPTpOKMjg4esX6cqIMUbcey8umjeR0nGjT/861khPtHHPxbN5+Y6TtYhjkLgXstUi/McZ2lnjD5HBOlpvfe0MbjypFKvO9h+TxL2QAS5dWKBHGR/MmJDGqtuX8cCV88hJ1ZFvsUzcr5FhMMPmNUuLdfofBguLnzNzPJcvKuD0aXl6BI4TxoSQYfDI3VhmQXEmly8s5KK5E8lI1tkt440xI2SPiZIMRouCzCRWzJ/I5YsKmawLqMU1WshxxHUnFrN87kTGpycyPt2h46LHEPp/OkocdSYNLdVSMi6ZOQUZzC3IYEJGInubu9l1sIPdhzo50NKDr++e8ekOLl9YyISMRNZVt7C+uoXmTidpDhvfOG+GTgo/RhkzQj575nge+NsenK7oJa5PsFo4Z9Z4PlNeyGlTc7FYhL4BN3WtveSmOoZdq3Y7Xew51Mmuxk52N3bS1tPPxfMnfsJBdbTK4b7mLo5092sRj2HiMkG9P97adYiPDnXxw9d3jXxxCMzMT+fK8kIumV+gz+5qwsZwCerHzIgMcNaM8Zw1Yzx9Ax5+8fc9YWvXIoPpd0+dmsOV5UXMKdBhoZroMqaEfJQvnz2VPpebh9bsHfV7HTYLsyamMzM/nVn5g//OzE/TjiWNoYzZT983z5vBleVFdPYNUN/ay3dXVw5bMxjgwhPy+e7yWbrmr8Z0hCRkEfkBsILBaoxNwE1KqQYRKQV2AkdDqT5QSq0Mpa9IUJYzWBh9bmEmJxRm8PmnK9jV2HncdSXjkrl3xRxOnxZ8IXaNJpKE5OwSkXSlVIf38X8Cs5RSK71CflUpNWc07UXa2TUSXU4XX/3zFiobOkhLtJHisHHq1BxWnj6ZxDEeGaYxnog5u46K2EsKYB4XeBCkOmw8eoPP+6TRmJqQTz+JyP0iUgtcC9w95KUyEdksImtF5NRh3n+biFSISEVzc3Oo5mg0Y5IRp9Yi8ndggo+X7lJKrR5y3Z1AolLqeyLiAFKVUkdEZBHwMjD7mBH8OIyeWms0ZiakqbVS6uwA+/kj8BrwPaWUE3B6379RRPYC0wCtUo0mAoQ0tRaRqUN+vRjY5X0+V0Ss3seTgKnAvlD60mg0/gl1H/lHIjKdwe2nGuDoFtNpwL0i4gLcwEqlVEuIfWk0Gj+E6rW+3M/zLwAvhNK2RqMJnDGRs0ujiXe0kDWaOEALWaOJA0x1HllEmhl0mpmJHOCw0UYcg7YpMOLNphKllM+Af1MJ2YyISIW/TXij0DYFxliySU+tNZo4QAtZo4kDtJBH5lGjDfCBtikwxoxNeo2s0cQBekTWaOIALWSNJg7QQvYiIkUi8raI7BSRShH5svf5bBF5U0Q+8v6bZQKbvi8i9SKyxftzQRRtShSR9SKy1WvTPd7njbxP/mwy7D4Nsc3qTbDxqvf3iNwnvUb2IiL5QL5SapOIpAEbgUuAm4AWpdSPRORbQJZS6psG23Ql0KWU+lk07DjGJgFSlFJdImIH3gW+DFyGcffJn03nYdB9GmLbV4FyIF0ptVxEfkIE7pMekb0opQ4qpTZ5H3cymAW0gMEsoU97L3uaQSEZbZNhqEG6vL/avT8KY++TP5sMRUQKgQuBx4c8HZH7pIXsA28W0AXAOmC8UuogDAoLyDOBTQBfFJEPReTJaE5jvbZYRWQLgymQ31RKGX6f/NgEBt4n4H+BbzB4Xv8oEblPWsjHICKpDJ6l/spIOcaihQ+bHgImA/OBg8AD0bRHKeVWSs0HCoElIjKqtMdRtMmw+yQiy4EmpdTGaPSnhTwE7/rqBeAPSqkXvU8f8q5Vj65Zm4y2SSl1yPvB9QCPAUuiadNRlFJtwBoG16KG3idfNhl8n04GLhaR/cCzwFki8gwRuk9ayF68DpMngJ1KqZ8PeekvwI3exzcCq499b7RtOvpB8HIpsD2KNuWKSKb3cRJwNoO52oy8Tz5tMvI+KaXuVEoVKqVKgauAt5RS1xGh+6S91l5E5BTgn8A2/r2m+TaDa9JVQDFwAPhMtPKPDWPT1QxOFxWwH7j96LorCjbNZdBJY2VwIFillLpXRMZh3H3yZ9PvMeg+HWPfGcDXvF7riNwnLWSNJg7QU2uNJg7QQtZo4gAtZI0mDtBC1mjiAC1kjSYO0ELWaOIALWSNJg74/3hyiNeku1dIAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "topo"
+    "import json\n",
+    "geopandas.GeoDataFrame().from_features(json.loads(topo.to_geojson())['features']).plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 LINESTRING (2.691699685742995 6.25881870363704, 1.865244476815404 6.142157993131055)\n"
-     ]
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x24fd7754688>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
     },
     {
      "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"1.8321862684583001 6.109099784773951 0.8925716256417981 0.18277712722019235\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,12.400976696768094)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"2.6916996857429947,6.25881870363704 1.8652444768154037,6.142157993131055\" stroke=\"#66cc99\" stroke-width=\"0.01785143251283596\"/></g></svg>"
-      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPIAAAD4CAYAAADW87vCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO2dd3ydZd3/398zcrJ32qTZ3XumLWWWoZS9N1JQZKiP+qiPCCiKyu9x4PgpAjJERBAreygIQquCtE266CadSZpmNHufcT1/JIG0PSc5Oeu+z8n1fr3y6sm573Pd39y9P+da3yFKKTQaTXRjMdoAjUYTPFrIGk0MoIWs0cQAWsgaTQyghazRxAA2ow0YSnZ2tiopKTHaDI3GlFRUVDQqpXK8HTOVkEtKSigvLzfaDI3GlIjIAV/H9NBao4kBtJA1mhhAC1mjiQG0kDWaGEALWaOJAbSQNZoYQAtZo4kBtJA1mhjAVA4hmujB5fZQ29pDVXMX1c3dAz9dHOnoY15BGssmZbOgKJ14u9VoU8cEWsiaEWnq7OP5imp21bVT1dQv3MNtPbg93pNSrNndwK/eqSQrKY67zp3BpQvzEZEIWz220ELWDMtTHxzgh69tp9flGfVnj3T28fW/bObP5VX84KLZTMtNCYOFGtBzZM0w9Djd/OKt3QGJeCjr9jVx9i//ycrfreMfO+p89uSawNE9ssYnL2yooamzL2TtrdndwJrdDUxIi+fUqTmcNDmbEydlkZXsCNk1xipayBqveDyKx/+9NyxtH2rt4dn1VTy7vgqAGXmpnD83jxtPLCHJoR/JQNB3TeOVNbsb2NPQGZFr7ahtY0dtG0+8t4//OmMK1ywpIs6mZ32jQd8tjVcaOnojfs3Gjj6++8o2zvjZat7Yejji149mtJA1XrlkQT5FmYmGXLu6uZvb/ljBUx/4jKPXHIMWssYrdquFL585xVAbvvPSVh5avcdQG6KFoIQsIleIyDYR8YhI2THH7hSRShHZJSJnB2emxggunj8Bh8Fz1R+/sZOfvLETXRFleIL9X9oKXAr8c+ibIjITuBqYBawAHhQR7asXZbT3uILeQw4FD67eE7GFt2glKCErpXYopXZ5OXQR8KxSqlcptQ+oBJYEcy1N5NnbaB7xvLOzzmgTTE24xk35QNWQ36sH3jsOEblFRMpFpLyhoSFM5mgCYZ+JhPz2jnqjTTA1IwpZRN4Wka1efi4a7mNe3vM6yVFKPaKUKlNKleXkeE3ZqzGIvQ0dRpvwMRUHmmnpCp2XWawxokOIUuqsANqtBgqH/F4AHAqgHY2BmKlHdnsUa3Y3cNF8rwO7qKOps4/MpLiQtReuofUrwNUi4hCRUmAKsC5M19KECTMJGWJjeO3xKB77114+/Ys19DjdIWs32O2nS0SkGlgGvC4ibwIopbYBq4DtwBvAF5VSobNaE3Y8HmU6IXf3uYw2ISgaO3r57JPr+eHrO2js6OPdnaH7YgrK11op9SLwoo9j9wH3BdO+xjgOtXabYutpEIfNwnfOn2m0GQHz748a+e9Vm2ho/8T19cWNNZwzJy8k7eugCY1XDhzpMtqEo7hmSRHFWUlGmzFqnG4PP39rNw+v2cOxPi276tpDdh0tZJOxv7GTe1/dRkZiHJ8/dSIz8lINsaO62VxCPnFSltEm+I1Sih217by8qYZXNh+itrXH63kJIcxnpoVsMooyE9l5uJ3a1h5m5KUaKORuQ67rDRFYUppptBkjUtXUxSubD/HSxho+qh956y4hTgs5ZrFYhFOn5PDn8ir+VdlIUVYinb0uOvvc2C1CcVYSpdlJjE91hDWhXY2JhDwjN5X0xNBt1QSKUoqtNW1YLP1z9jirFRFYvbuBlzfWUH6geVTtJWohxzaDq8X/3N3AP3d793ZLsFspzU7i4esXUZQV+nBDM/XISyca3xv3ON184y+beW1Lbcja1EPrGKbX5WZTdcuI53U73WyvbeO/nt3IX25dFvKMGmaaI58w0b/5cXNn38dz0rq2Hmpbu6lr66W9x8ns/DQWl2RSVpzBvMLR5duub+/h83+oYHPVyP8voyEhLnTy00I2GVtr2ugbxbbP5qoW7v/7Lu46d8aI57b1OHnqPwf43Mmlwz7ITreHw23eF2iMoCAjwa/znquo5r6/7vB6bPWuBlbv6h/d2K3CnEFhD4g7yWHjhQ3VPLu+irYeJ71OD91ONz1ON91O93ErzqEgwR66L18tZJMRSKrYR/65l/Gp8SybmMWkcUk4bEeLtKvPxe/f389v1+yltdtJToqDK8sKfbQGbd1O7FaLafaRt1S3MmtC2ojnPb+h2q/2nG7FhoMtbDjYwm//2Z9gMMVho703sg4nVkvo1ji0kE1GWXEGBRkJo56j/uC17UD/w1GancS08SlMy03BahGeeG8fjR2fBBz8/r39XLGowOdiWVayg7995RS++dyWUS/ghIP1+5u4ZknRsOdsO9TKzsOB78tGWsQANS2hG/XoVD8mw2IRLltYEPDn3R5FZX0Hr39Yy8/f2s1P39x1lIgBtte2jSjQiTnJrLp1GT+/ch55afEB2xMKKvz4MnlhQ00ELAktB46EzgVWC9mEnDMnN+zX+Oqzm/jGXzbz+L/38X5lI81eEtFbLMKlCwt45+vL+Z+zp5E0ZLskNzU+pNsnw3HgSBf17b57L5fbw8ubok/I1c3dON2hmb7oobUJWb+vKezXqGnp5rmKo+eUuanx3HraRG46qfSo9xPirHzx9MlcWVbIL9/ejcutuPv8GVz+0PvsrotMzHLF/maffskHm7qOG3VEA26Poqa5m5Ls4F1PtZBNhlKKZ9ZVjXxiGDjc1sO9r25nXEo85809XjQ5KQ7uu2TOx79nRNBJo7Xb6fNYcVYSSXFWOvuiL8Bu/5HOkAhZD61NRn17Lztq2wy14b9XbfJrXhrKwPjhuHpxIVct9r3KbrUIcwpGXtU2I/tDFCqqhWwyxqU4yE421h2xz+Xh838op6Zl+JXzjAgI+VMzx/PDi2eP6I46vzAj7LaEg6Yu3yON0aCFHAaUUtS19VDf3kNDey9HOnpp6uyjpauP1i4nbT1O2nucdPa66O7rdzrodbnpc3lwexSLS4x3SWzq7OPLf9o47GJMZpiH1laL8OPL5mKzjvyYLihKD6st4UIvdpmYHqeHpf/vH0abETQVB5r52d93861zpns9np5oD+v1l03M8nv4vqAwOoU8Gi++4dA9chhweczhERUKHl6zh3d3eU9JE+458mi24calxjPB4P3uQNA9somJIR0D8LU/b+LGE0uxWvr3li0iWEWo9CPmNlBE4NMzR7efPr8onUMfRlcVx1D1yFrIYSCWemSA5i4nv3h7d0SvuaQkk5wUx6g+M78wnb9Gm5B1j2xeAgl80BzNObNH7922sCiDFIeNhDgrvS7PsHvPZsHpDs2zooUcBty6cmDQrJg9+uySZSWZfHhvf+HPlq4+PvdkuV/74UbS5wqNE4te7AoDrhB9y45lvvB0Bat31QdcTjU9MY6nb17Kp2eOD7FloSVUPbIWchjQQ+vg2XCwhRufWM/Fv3kv4ETu8XYrD12/yNQZOEO1aq2FHAZcWshBM3lcEktKM+lze7jlqXK+89LWgB56q0X43oWzQhrEH0pClbxBz5HDgEfPkUfNuBQHRZmJuJViT30HlfWdwCd+yE99cIC9jR08eO0i0kbpiDJ1fAqfOaGY37+/P7RGh4COntAkNNA9chjQc+SRSbRbmFuQxpKSTPIzEqhv76X8QDMbD7bQ5uPhfq/yCJc8+N7H5V47e10c6ej1eu6xfPWsKWH3RAuE7bVtI/q0+4PukcOAniMfjwCTxyWTmRRHS7eTyvoOtlS3jrqdvY2dXPyb91g2KYs1uxuwWy3cfe4MrlpcOGxgRXpiHF//1FS+8/K2IP6K8PDKpkPcvnxSUG0EW43xChHZJiIeESkb8n6JiHSLyKaBn4eDsjLKiDWHkEDJTXVQVpLB/MJ0kh02PqrvYO2+JnYdbg/qy66tx8Wb2+rocXpo73HxrRc+5JpHP6CtZ/h942uWFFEShhzgwfLixuqAV+cHCbZH3gpcCvzWy7E9Sqn5QbYflYzVOXJynJVJ45KJs1mpae7iUGsPh9v8G/oGywd7m9h+qG3YHNg2q4VJOcnsN1mButrWHpxuRZwt8AW5YMuq7gDCWrokGhmrc+SpuSlsOBjaJO6jYX9j54jJ7NMSzDdPvnxRQdAFBsK52FUqIhtFZI2InBLG65iOsTpHtvsRNxxO/Emqn2pCIX/mhOKg2xixRxaRtwFvjq93K6Ve9vGxWqBIKXVERBYBL4nILKXUcTlsROQW4BaAoqLhcxdHC2PVRdPoL7Dz/CgabjYhnzIlm4k5yUG3M6KQlVJnjbZRpVQv0DvwukJE9gBTgXIv5z4CPAJQVlYWEwoYqw4hHQYkeR/kjOnjmDI+ZcTzzDa0DkVvDGEaWotIjohYB15PBKYAe8NxLTPiHqNz5CYvubEjxedPmejXeWYScmFmAmfOCI0veFCLXSJyCfBrIAd4XUQ2KaXOBk4Fvi8iLsAN3KaUCn+yZpMwlnrkFIeNgswEUhw2PB5Fa7fTkJpR/ubsMpOQv3n29JC5jga7av0i8KKX958Hng+m7Wgm1refclPjyUtzUNPSM5C+95OaS5NyktjTELpSKP5S19ZDcdbI+aHNIuQFRemc7yV3eKBoF80wEMs98qLiDNq6+9hY1Up9+/F7xOnHZNa0WYQEu5WEMJeXOdzqX0E0swj52+fNCOm2rXbRDAPuGPTsSkuwU5KdOGKg/ofVLSTaLTjdCqdH4fIoXJ7+4Pm5+Wn0uT1BVU30hT9bT/saO3lodWXIrz1azp2Ty6Li0KY81kIOA2b51g8VNovgsFnYXDWyb3SfW9HnY7FvS03/5yfnJOH0KA6E0MOqbhghVzd38ZM3dvHalkMYPVhKsFu5Y4X39MLBoIfWYeD0aeO4ZonvEifRxsy8VK/D6ECpbOikq9cd0ooa7+5soMfpPW3O//51J69sNl7EyQ4bf/jcEr/m8qNFCzkMiAj3XjibJaXGV4wIFqtFsIQhKL+hoxeHzcKS0gzKijOYnpsS1Dz6P3uP8Lkn19N5zF52dXMXf9taG6y5QZMSb+Opzy0JWxURLeQwEWez8NB1CynISDDalIBYXJLB9NxkrAKbqsLjP13T0sO6fc2UH2hm5+F24m0WFgZR+uW9yiPc8Lt1R2XPfPL9/Yb3xOmJdp65+QQWFIWvPpUWchjJSnbw6A1lESsIHiqWlGSyfn8zOw93+JzvhoPmLicbDrYwMy+V/AC/ACsONHPtox9wpKOXjl4Xz643pkTtIJlJcTxz8wlhrxaphRxmZuSl8ouroiOaUwTKijNYt99Y353ttW3Ut/YEPIfedqiNK3/7Hx58t5L2EKXSGS1xVguXLMjnuduWMXNCativp1etI8DZs3K5Y8V0fvzGTqNN8YnVIswtSKPcJHmgnR4VVDTVnoZOHly9J4QW+Ud+egLXn1DMlWUFZCWPrlJGMGghR4jBVC5mFLPdKszIS2WjgbHE0c5pU3O4YVkxy6eNMyRjpxZyBLl9+SQS7Ba+9+p2o035mAS7ldLsxIDyZ4Ubs6erSHbYuKKsgJXLSijJDv2W0mjQQo4wN55USkKclW+98CHeXLJzUhwsLc2kz+WhsaOXI519NLb30tkXmtIiQ0mwWynITGB7beg9rWKZidlJrDyxhMsWFZDsMIeEzGHFGOOqxUXE2618bdVmrCKUlWRw2tQcTp2aw/TcFK8+uFVNXfzkzV28uvlQSGwQgSnjkj/2tjIlJuuSl0/L4cYTSzh1Sk5Y9taDQYLN3hdKysrKVHn5cbkHYpbK+nYmpCeQGOf/92n5/ia+tmozB5uCc29cXJLB+v3mWNjyxYT0eA61+BcMES6sFuG6pUWsPLGESSHI5BEMIlKhlCrzdkz3yAYyedzIGS2G4nR7aOzoY1puCgl2Kwebu+gOYMgdDSI2A3ar8OtrFrIigBKvkUYL2SA8HkW3002SH3OsqqYunl1/kFXl1TQM+Dwn2K396VPtFjKT4kiJt5MQZ8VuERDB7VYcbu+hpvnoKgZz8lMpjxIRi4Fj63i7hd9+pozTpuYYZsNo0EKOEB29LjZXtVBxoJmKA81sONhMZlIcf7ltGeNS4o869+CRLu55ZStrdjd4XRAD6Ha6mVuQydp9TdS09ADeh6CTcpI+3s9USrGtphXzTKaGx6gEDckOG4+vLGPpCKl1zYQWchhQSlHd3M2Gg/2iLd/fzM7Dbcf5/Lb3uLjh8XX8+ZZlpCXa6XW5eWTNXh54t9KvdDnbDrWRHGelY5jh9Z6GTkMydgRLRqKdWj+TBYSStAQ7f/jsEuYVBu7zbQRayAGytaaVfY2ddPe56exz0dXnprvPzZ6GDioONPsd9rfzcDuffXI9Xzp9Mj94fTt7RyG6jl4XS0v7e+VYY2JO8ohJDEJNdrKDP968hOm54XepDDVayAHy6L/28vKm0GwFVRxo5qbfrw/os4NRQz0GJLwLKxEeVU9Ii+ePNy8NSY5pI9BBEwFidGjcIK3dTuYWhjeyxggqB0qnRoKSrERW3bYsakUMWsgBY6ZMmRUHWlhUHL5Y10gzKSfpqJjicDK3II1Vty6jIMN8VRpHgx5aB4jHLF0y/aVaKg40Mzs/la01x1XliToiUdZlYVE6Xzx9MmdMHxcTRQi1kAPETD3yIB0Gxd6GGmuYhfW9C2ay8sSSmBDwIHpoHSAm6pA/Zv+RLhYVR9e2iTcsYXwq7zl/JjeeVBpTIgYt5IAxk4/6UKqaurFbo/shDZdH193nzuCzJ5eGpW2j0UIOEDP2yAD17b1hTfIWCcLxHXnHiul8/lT/Cr1FI1rIAWLGOfIg6/Y1sTSKU/GGetT79U9N/ThDS6yihRwgZu2RB1m7rylq82rvONxGUggyj6bE2/j+RbP4rzOnhMAqcxOUkEXkpyKyU0S2iMiLIpI+5NidIlIpIrtE5OzgTTUXZp0jD2XdviaWhCkhejhp63YxKz9wJxerRbjxxBLW/M/p3LCsJHSGmZhge+S3gNlKqbnAbuBOABGZCVwNzAJWAA8OFj6PFcw8tB7Kuv1NlJVE35w5mC/K20+bxPcunEVmUuhK0pidoISslPq7Umpw8/IDoGDg9UXAs0qpXqXUPqASWBLMtcyG2+xj6yGU72+OOs+v5q7APbuKMqPbSysQQjlH/izwt4HX+cDQFP/VA+8dh4jcIiLlIlLe0NAQQnPCSxTpGOgPzFhYlG62NFhesQhBpTKakB6dZXqCYUQhi8jbIrLVy89FQ865G3ABTw++5aUpr4++UuoRpVSZUqosJyc6sjFAdMyRj2XDwRbmFaZj9m3mwowE+oKI5pqQHj/ySTHGiC6aSqmzhjsuIiuB84Ez1SdPdzUwtK5oARCamD+TEG098iCbqlqYk59Gt9PNnvoO02ULmZSTRLeP8qj+onvkUSIiK4A7gAuVUkPHQq8AV4uIQ0RKgSnAumCuZTaiZbHLGx/WtFJZ30FCnJU5+Wmm6qGTHLagMmfareKzTnIsE+wc+QEgBXhLRDaJyMMASqltwCpgO/AG8EWlVEzd3WjtkYfS1efmw5rWoGoshZL0RDvbDgUXveV0K370N/OV5Qk3QUU/KaUmD3PsPuC+YNo3M9E4R/aFWeIHpo5PYV0I0hY9u76KSxcWRK1DTCCY46s4ConmofWxlBpct2iQIx3+5Tnzh7te/JBeV0wNAodFCzlAPDGUIstigi65MCMhpNk+K+s7eGTN3pC1Z3a0kAMklnrkrYfaDO2V46ziV6L+0fLrdyvZ1xh9qYADQQs5QGJJyNC/0GQEVoFpuSnsPBz6ipB9Lg+/XRP5YudGoIUcILGwaj2UzVUtTM9NifhW1LzCdD4MY56xN7cdxumOoXmQD3TOrgCJtR7Zo/pzZNutQmlWEhmJdpSCps4+9oZpeBqJYnLNXU7e33Mkamo4BYoWcoDEmI4/xulWVNYfnVN61oRUDrf2cKSzL2TXiWSFjNe3HNJCHqvUtfXw8Jo99Dg99DrddDvd9Djd9Dg99Ljcx1U5jGW2HWojLcHOvMI0NlcFXxh9SUlky9ys3hU9wTiBooXsg8aOXp54b7/RZpiG1m4nm6taKSvOYGtNa8AlahYVZ7Buf2RrVbX1RCbZvZFoIWtGxcGmLuYVptPZ58IiglUEm1XYebid9iF5tQsyErBahKqmro8XBucWpLHxYORrM/c4Pdz/5i7OmDGOhVGemNAXWsgav8hMimNSThIbD3qvNGmzwNz8NBLirDS09368QGa3ChOzEslOclBxsNmw1f4H3q1kURRmSvEXLWTNsKTG25iel8rmquZhV5hdHthSc/z8uX/xrJNKOinKTAwqYUCwOEwSHBIOYvcv0wRFYpyVpaWZeDyKdfua6HUF35XmpRkb8O+wx+7jHrt/mSYg4mwWlpRmYLcKa/c10dEXusCDaoNX+uOsMZX/8Si0kDUfU1aSQYrDxrp9zbR2h74gXE1Lt6E+3bpH1sQ0DpuFBYVplO9vDqnThzfGpTjC2v5wxMXwHFkvdo1xspPjSEuwszEEjh7+cOCIcdFIKfGx+7jH7leUZkQmj0vGowhpHPBIHG7rZfK45Ihdb5AFRelkJRs3Ggg3sfsVpRmWBUXpbK1pxemO/MZuZmLkK0BcOG9CxK8ZSXSPPAZZWprJxoMthogYiHiwv0XgvLl5Eb1mpNFCHmNEMurIFw0dvUwbnxKx63kUPPjunpjO4aWFPIbITo5jgwG+zt5ITYjsrO737+/ngXcqI3rNSKKFPIaYmJNs2HD6WAaTGESS06ePi+j1IokW8hghOznOkMgjX7T3uJg1ITVi1yvOSmRBYfrIJ0YpWshjBDP1xoNEKsuK1SJ89awpiAnS/oYLvf00BijNTjRVbzzItkOtpCXYae0OX+B/ssPGA9cuYPm02B1WgxZyzJMab6O7z2263hj6Qx8npMeHTcj56Qn87sbFTMuN3Aq5UWghxzAWgcLMBLYdCn3O6FDR4CVJQbDMzEvl+hOKuWj+hLAkvjcjQf2VIvJT4AKgD9gD3KSUahGREmAHsGvg1A+UUrcFcy3NyOSkOCjNTsLjUbT3uKhr7zG1iJPirDR2hCZII85m4fy5eVx/QjELCtNjej7sjWC/rt4C7lRKuUTkx8Cd9NdLBtijlJofZPuG4XR7WFqayYaDzaYclnpjYnaS4c4eoyEvPeG41LujJT89gZUnFnPFokIykiLv+mkWgi2r+vchv34AXB6cOebgiff2se1QG2v3NZGfHk9Ll5POEAbYhwOLwEdBiiLSpCUEXqZmXkEaN58ykXNm52KL4fBEfwnlHfgs8Lchv5eKyEYRWSMip/j6kIjcIiLlIlLe0GB8/uEXNlTz/de2f7w1UtPSw8wI7ncGyswJqTSFOZY41Ngsoxv+isBZM8bz51tO4KUvnsQF8yZoEQ8wYo8sIm8DuV4O3a2UenngnLsBF/D0wLFaoEgpdUREFgEvicgspdRxRX6UUo8AjwCUlZUZOoZ9a3sd33xuy3H7m+v3NzN5XHLQw0Bv2K0SkqF7NCaW63b6N8px2CxctqiAz51cyqScyIdARgMjClkpddZwx0VkJXA+cKZS/RJQSvUCvQOvK0RkDzAVKA/a4jDx/p5GvvjMBlw+8rW6PQqLhK5425z8VPpcHvY0dDAzL5XkeCsHj3RzuK1n1G3ZLMKuOvMuavniyAgLXRaB25dP4rMnlcZ0LHEoCHbVegX9i1unKaW6hryfAzQppdwiMhGYApi26vTmqhY+/2Q5fcNUT9jX2BmSyKFp41Poc3uOqkC4vbb/tc3SH520paaVbj/n5CnxNmbkpbIuiha5Bmns8L31lBRn5dfXLuCM6eMjaFH0Eux47AEgBXhLRDaJyMMD758KbBGRzcBzwG1KKVM+aR/VtXPjE+v8WszaXNUSVM4pi0Bnr8tnPK7LA2v3NZFot7KwKJ2MRLvXwAK7VZhXmM68gjS6+1xRI+KcFMdRebOKsxK9npefnsBzt5+oRTwKgl21nuzj/eeB54NpOxJUNXXxmcfX0dzln2dRj8vD1NR4r5UW/GFBUQYVB0Z2lTzS2XdUErw4q5DssJPosBJvt1LX1sPmqpaAbDCCkyZncd/FcyjOSqSt28XrH9by4sZqLD72eh+8biEz8sy/wGgmxobbixfq23u4/vG1o56TbqlppTAjgapR5mi2WoRDLYHlde5zK5q6+jCwSENQXLW4iJKBNLhpiXauXVrEtUuL+MeOOq9TlQMD9aU0/hN9S50hoLXLyQ2Pr+PAkcCUMdptnoxEO3PzU6ltHf1CVrSTmRTHGT7igE+dmkNG4vF7yVuiaLRhFsackLv6XNz0+3XsPBzYKm9mYtyonEPKijNweVTE0s2ajfuvmEuyD39nu9XCp2cev7P51o46nq+opj6AFfyxypgScp/Lw61PVbDhYODf+ONS/VvsSo23MWtCCuUHmo8qNzqWuOmkkhEXrD496/jjB4508fW/bObRf5l2o8N0jJk5stuj+OqfN/KvjxqDasdX7zKU8akO7FaLqQMWIsEdK6aPeM7cAt9zYSPyX0crY6ZHvuuFD/nrh4f9Pt9X8MyBI10kxvkuBlaanYTTrQwvWGYGrH64YOakOMhN9V6lcfK42I8jDhVjoke+7/Xt/Lm8alSf8fUINnT0sqQkg3VDagWL9Nc0mpCewO7D7aYPsIgU3U43dj9cR0+cnMXmqhY8CpRSH/87Oce4gm/RRswL+TfvVvLov/aFtM11+5tZXJJBr8tDS5eT2pZu6tp6qWsLfZB8NPOlZzby0HULhw3u7+pz8c7OelqO2cufX5hOmgEVKaKVmB5aP/Wf/fz0zV0jnhcI6/c3s6W6lYNNXThD5YAdY/xzdwPXPrZ22O26VeurjhMxwAUxXuIl1MSskF/eVMM9r2wz2owxz+aqFi5/+H2qm4/fs3e5PTz27+NHSyJw3pzYLvESamJyaP3Ozjq+vmpzxNKtaoZnb0Mnlz/0H/7/1fPp7HOx/VAbO2rb2Xqo1eui4JKSTMUOiUQAAA1YSURBVHLTvC+AabwTc0Jeu/cIX3jadziixhgOt/Vw1SMf+HWuHlaPnpgaWm+taeXmJ8vpcfoOR9SYn+XTcow2IeqIGSHvaehg5e/W0d47Nr2oYgWHzcKEtASjzYg6YkLINS3dfOaxtUeF/mmik5KsJCyjzOWliQEhN3b08pnH1nJoDEYWxSK+kg1ohieqhexy9wdB7PWRcUMTfZRma2+uQIhaISul+O4r25g6PoUVs7wl+dREI8VZWsiBEJXbT0opvv3SVp5eexDoDxl89xvLOf3+1cYapgmauQVpRpsQlURdj3ysiAHaelycfv9qzp0Tup55cWlmyNrS+Md5c/OYna+FHAhRJ+Q/ras6SsRD+fZ5M4Nuf9aEVFbduoxvPb8l6LY0/hNns3DnOSPHL2u8E3VC/tTM8ST5iAe+/rG1fgX+eyMl3sbWe8+mvr2XK3/7n5Aloo9GTpmSzRM3LeaxG8rIilBhtNtPm0RBhl6xDpSomyPnpDi47bRJ/Oyt3ccd29vYyeRxyZw7O5dzBpzu7311Gx/sHT7v86+uWcCf1h5k9nffDIvN0cIF8ybw5TMmM2X8JwH9bxSeyjef28y7u8JTlyvOauGuc6ez8sSSsLQ/VhBlosiCsrIyVV4+clWZ7j43y+9/1+/43wvmTeB/L53DL9/azds76lg2KZtTp2RzytQcHlpdyW/e3ROs6VFNssPGDy+ezcUL8r0eV0rx+L/3cd9fd4Q0EKUkK5EHrl2o58V+IiIVSqkyr8eiUcgAq8qr+OZzeh4bLPML0/nV1Qso8sMR442th/nKsxvpHaa0jr9cPH8CP7xkTsBTobHIcEKOujnyIJctLGB6rs7pFAzXLCniL7ct80vEACtm5/LAtQuDuma83cJPLpvLL66ar0UcQqJWyFaLcNe5M4w2I2o5fVoOP7x4tl85tYby0qaagK9ZnJXIq186mSsXFyK+shtqAiJqhQz9lQpOmZJttBlRx7TxKfzqmgV+Zbkcyjs763h9S21A10yNt/G7GxcftZCmCR1BCVlEfiAiWwYqMf5dRCYMOXaniFSKyC4ROTt4U71z17kzfKau1RxPVlIcj60sIyX++FItw9HZ6+I7LwWWOslqEX5z3UJdpDyMBNsj/1QpNVcpNR94DbgHQERmAlcDs4AVwIMi4jsZdBDMyEvl8oUF4Wg65oizWXjkhkUUZo5+v/ah1XuoCbAI3T3nz+SUKTpZQDgJSshKqbYhvyYBg0vgFwHPKqV6lVL7gEpgSTDXGo5vnD3Np5OI5hMyE+PICyBov6G9l9+9F1hK4YvnT+CGZcUBfVbjP0HPkUXkPhGpAq5joEcG8oGhGeGrB97z9vlbRKRcRMobGgJzOhifGs+Xz5wS0GfHEofberjusbXU+VkcTSlFZX0H9766ja4Aku47bBbuOGe6XtiKACMKWUTeFpGtXn4uAlBK3a2UKgSeBr40+DEvTXndsFZKPaKUKlNKleXkBD78uumkUibqygQjsq+xk2sf/YCGYYq1r95Vz10vfsjJP36Xs36+htcCXOC66aTSgEYAmtEzopCVUmcppWZ7+Xn5mFOfAS4beF0NFA45VgAcCo3J3omzWfjeBbPCeYmYYU9DJ9f7SBy/taaVm36/nmfWHgx4TgyQnmjn9uWTgjFTMwqCXbUeOp69ENg58PoV4GoRcYhIKTAFWBfMtfzh1Kk5nO2lTKfmeHbVtXP9Y2tp6fpEzEopvv/q9pC4YX77vJmkJYxuZVwTOMG61vxIRKYBHuAAcBuAUmqbiKwCtgMu4ItKqYhUNvv2eTNZvashJG6Esc722jY+8/g6vnP+TNbuPcLq3Q1UHGge+YMjcP0JRVy+SO8kRJKo9bUejgfe+Yj7/358dJQm/CwqzuBPnz+BOFtU+xqZkpj0tR6O206bxIIi3wW0NeEhJ8XBg9ct1CI2gJi84zarhV9eNX/YguSa0GKzCA9dt5DxPoqWa8JLTAoZ+rMx3nN+8Kl/NP7xg4tnU1ai85wZRcwKGeCqxYWcNUOvYocTm0X4xVXzuGZJkdGmjGliWsgiwo8vm0N2ssNoU2KSeLuFR1eWcckCvUJtNDEtZICsZAc/uXyO0WbEHGkJdp6++QROnzbOaFM0jAEhA5wxfTxnzdAPXKjIS4vnuduWsag4w2hTNAOMmVwrOSl6eB0KJuUk8YfPLSU/XftQm4kxI2SHTW9FBcu8wnSeuHExmRHKda3xnzEj5Hi7FnIwnDo1h4euW0iSTphnSsbM/4pDexsFzGULC/jfS+dojy0TM2aErHvkwPifs6fxheWTdHIAkzMmhPxeZSPPb6g22oyowmGz8PMr53Pe3DyjTdH4QcwL+d5Xt/HEe/uNNiOqyE528OgNi1hQpLeXooWYF/K8Ah0FNRpm56fy8PWLdGXEKCPmVy/On5tHsZ8lUcYyKfE27r1wFi994SQt4igk5oVss1r4gs4dNSyXLSzgna8vZ+WJJdhGWUJGYw7GxP/aJQsKtCeSF6bnprDq1mX87Mp52vMtyon5OTL0Z9i8ZkmhTv9Df2Hxs2aO47KFBZw2NUf3wDHCmBAyQGLcmPlTvTK/MJ3LFhVwwdw80hO1i2WsMWaebo+JkgxGiglp8Vy8IJ9LFxYweZwuoBbLaCHHENctLeKCeRMYnxrPuBSH9oseQ4yZ/2mjdZyd3D+cbez4JCF8UWYicwrSmJOfRl5aPHvqO9h5uJ2dh9s52NTltZ1xKQ4uW1RAbmo86/Y1sXZfE40dvSQ7bHxzxXSdFH6MMmaEfNbM8fzsrd30RTBxvd0qfHpmLleUFXDKlBysFqG7z01NSxfZyY5h56odvS5217Wz63A7O2vbaOl2cuG8CUctUK08sQSlFPsaO2ns6NMiHsPEZIJ6X/xjRx0f1Xfwo7/tHPnkIJiem8JViwu5aH6+jt3VhIzhEtSPmR4Z4MwZ4zlzxnh6nG5++fZHIWtXBEqykjh5cjZXlhUyOz9VRwtpIsqYEvIgXzlzCj1ODw+v2TPqz8bZLMzMS2XmhFRm5KUyMy+V6bkpemFJYyhj8ukTEe5YMY0rywro6HVR3dzNPS9vPWohyhvnzsnlO+fP1DV/NaYjKCGLyA+Ai+ivxlgP3KiUOiQiJcAOYNfAqR8opW4L5lqhRkSYmNO/tzq3IJ05+Wnc/GQ5u+rajzu3KDOR7180i+U69avGpAS12CUiqUqptoHXXwZmKqVuGxDya0qp2aNpL9yLXSPR3uPka6s2s/1QG8kOG8nxNk6enM3tyyfpDCMawwnbYtegiAdIAsyzBB4AKfF2Hr3B633SaExN0B7zInKfiFQB1wH3DDlUKiIbRWSNiJwyzOdvEZFyESlvaGgI1hyNZkwy4tBaRN4Gcr0culsp9fKQ8+4E4pVS3xURB5CslDoiIouAl4BZx/Tgx2H00FqjMTNBDa2VUmf5eZ1ngNeB7yqleoHegc9XiMgeYCqgVarRhIGghtYiMmXIrxcCOwfezxER68DricAUYG8w19JoNL4Jdh/5RyIyjf7tpwPA4BbTqcD3RcQFuIHblFJNQV5Lo9H4INhV68t8vP888HwwbWs0Gv/ReV40mhhAC1mjiQG0kDWaGMBU8cgi0kD/opmZyAYajTbiGLRN/hFrNhUrpXK8HTCVkM2IiJT72oQ3Cm2Tf4wlm/TQWqOJAbSQNZoYQAt5ZB4x2gAvaJv8Y8zYpOfIGk0MoHtkjSYG0ELWaGIALeQBRKRQRN4VkR0isk1EvjLwfqaIvCUiHw38m2ECm74nIjUismng59wI2hQvIutEZPOATfcOvG/kffJlk2H3aYht1oEEG68N/B6W+6TnyAOISB6Qp5TaICIpQAVwMXAj0KSU+pGIfAvIUErdYbBNVwIdSqn7I2HHMTYJkKSU6hARO/Bv4CvApRh3n3zZtAKD7tMQ274GlAGpSqnzReQnhOE+6R55AKVUrVJqw8DrdvqzgObTnyX0yYHTnqRfSEbbZBiqn46BX+0DPwpj75MvmwxFRAqA84DHhrwdlvukheyFgSygC4C1wHilVC30CwswJCfuMTYBfElEtojI7yI5jB2wxSoim+hPgfyWUsrw++TDJjDwPgG/BL5Jf7z+IGG5T1rIxyAiyfTHUn91pBxjkcKLTQ8Bk4D5QC3ws0jao5RyK6XmAwXAEhEZVdrjCNpk2H0SkfOBeqVURSSup4U8hIH51fPA00qpFwberhuYqw7OWeuNtkkpVTfw4HqAR4ElkbRpEKVUC7Ca/rmooffJm00G36eTgAtFZD/wLHCGiPyRMN0nLeQBBhZMHgd2KKV+PuTQK8DKgdcrgZeP/WykbRp8EAa4BNgaQZtyRCR94HUCcBb9udqMvE9ebTLyPiml7lRKFSilSoCrgXeUUtcTpvukV60HEJGTgX8BH/LJnOYu+uekq4Ai4CBwRaTyjw1j0zX0DxcVsB+4dXDeFQGb5tK/SGOlvyNYpZT6vohkYdx98mXTUxh0n46xbznwjYFV67DcJy1kjSYG0ENrjSYG0ELWaGIALWSNJgbQQtZoYgAtZI0mBtBC1mhiAC1kjSYG+D9i1HUQF/QGUAAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<IPython.core.display.SVG object>"
+       "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 LINESTRING (2.154470436268758 11.94015304356263, 2.490164575698371 12.23305429664511, 2.84863868847893 12.235635936246, 3.611183931487837 11.66016917581417, 3.572213309868337 11.32793696496857, 3.797112257511714 10.73474784585301, 3.600071975406557 10.33218662737445, 3.705436302919539 10.06320918041558, 3.220347057543115 9.444148541313806, 2.912307694549314 9.137604103863602, 2.723793683999434 8.506847994256702, 2.749066665011652 7.87073567152766, 2.691699685742995 6.25881870363704, 1.865244476815404 6.142157993131055)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"1.621505359090806 5.898418875406457 2.4193460161455054 6.580956178564143\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,18.377793929377056)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"2.154470436268758,11.940153043562628 2.490164575698371,12.233054296645106 2.84863868847893,12.235635936246002 3.6111839314878367,11.660169175814172 3.572213309868337,11.327936964968572 3.7971122575117136,10.734747845853008 3.600071975406557,10.332186627374448 3.705436302919539,10.063209180415578 3.2203470575431155,9.444148541313806 2.9123076945493143,9.137604103863602 2.7237936839994337,8.506847994256702 2.749066665011652,7.87073567152766 2.6916996857429947,6.25881870363704 1.8652444768154037,6.142157993131055\" stroke=\"#66cc99\" stroke-width=\"0.13161912357128286\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
+     "metadata": {
+      "needs_background": "light"
      },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 LINESTRING (0.8995608140020241 10.99734009878119, 0.7723340140989334 10.47080505548236, 1.077796960253206 10.17560697001474, 1.425057172401281 9.825395155258276, 1.46304541925463 9.334626385860833, 1.66447858474805 9.128591333584316, 1.618946441105575 6.832034568331435, 1.865244476815404 6.142157993131055)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"0.578126729872928 5.947950708905049 1.4813250311684811 5.243596674102147\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,17.139498091912245)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"0.8995608140020241,10.99734009878119 0.7723340140989334,10.470805055482362 1.077796960253206,10.175606970014744 1.4250571724012815,9.825395155258276 1.4630454192546303,9.334626385860833 1.6644785847480499,9.128591333584316 1.6189464411055754,6.8320345683314345 1.8652444768154037,6.142157993131055\" stroke=\"#66cc99\" stroke-width=\"0.10487193348204293\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 LINESTRING (1.865244476815404 6.142157993131055, 1.060123482148953 5.928837388528876, 0.8369297888166303 6.279977123568941, 0.5703818581630191 6.914362228344361, 0.4909577850883187 7.411745875011002, 0.7120291782182946 8.312462475837611, 0.4611899761366347 8.677227020586322, 0.3658996238199403 9.465003779370869, 0.3675770750715763 10.19121624290415, -0.04978391755923361 10.70691942467466, 0.0238015130373963 11.0186822653039)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"-0.2533777126302346 5.725243593457876 2.3222159845166397 5.497032466917027\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,16.947519653832778)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"1.8652444768154037,6.142157993131055 1.0601234821489527,5.928837388528876 0.8369297888166303,6.279977123568941 0.5703818581630191,6.914362228344361 0.49095778508831867,7.411745875011002 0.7120291782182946,8.312462475837611 0.4611899761366347,8.677227020586322 0.36589962381994035,9.46500377937087 0.36757707507157633,10.19121624290415 -0.049783917559233615,10.706919424674663 0.023801513037396305,11.018682265303902\" stroke=\"#66cc99\" stroke-width=\"0.10994064933834054\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 LINESTRING (2.154470436268758 11.94015304356263, 1.935984727664784 11.64115140366522, 1.447179140012636 11.54771626223776, 1.243466123646828 11.11050962406176, 0.8995608140020241 10.99734009878119)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"0.8493644291113548 10.94714371389052 1.3553023920480722 1.0432057145627773\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,22.93749314234382)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"2.154470436268758,11.940153043562628 1.935984727664784,11.64115140366522 1.4471791400126364,11.54771626223776 1.2434661236468276,11.110509624061763 0.8995608140020241,10.99734009878119\" stroke=\"#66cc99\" stroke-width=\"0.027106047840961444\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 LINESTRING (0.8995608140020241 10.99734009878119, 0.0238015130373963 11.0186822653039)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"-0.011228859001188807 10.962309726742605 0.9458200450417982 0.09140291059988215\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,22.016022364085092)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"0.8995608140020241,10.99734009878119 0.023801513037396305,11.018682265303902\" stroke=\"#66cc99\" stroke-width=\"0.018916400900835965\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 LINESTRING (0.0238015130373963 11.0186822653039, -0.438702380404016 11.09833641242053, -0.7615793094412941 10.93693340705203, -1.203360655928795 11.00981649229727, -2.940412399273497 10.96269467908375, -2.963896716796401 10.39533114330669, -2.827494907284915 9.642457049446717, -3.511895017952412 9.900327014991053, -3.980450710660777 9.862346594670393, -4.33025026890249 9.610834261168122, -4.779881345832729 9.821986655998728, -4.954651377342961 10.15271214479968, -5.404338060392039 10.37073666212662, -5.470564947929006 10.9512656411353, -5.197844738084292 11.37514146414795, -5.220939812775325 11.71385992964918, -4.427162466351981 12.54264892750277, -4.280408651050012 13.22844632838715, -4.00639096509906 13.47248936297295, -3.522803084931283 13.33766530196528, -3.103709034929998 13.54126571191355, -2.967696468250384 13.79815263319705, -2.191824292093121 14.24642081613988, -2.001039698357325 14.55901051642777, -1.066365714483029 14.97381844518389, -0.5158558702927998 15.11615774175573, -0.2662585381985387 14.92430792628983, 0.3748892796988743 14.92891077838965, 0.2956505603536366 14.4442332084776, 0.4299300696627766 13.98873459718635, 0.9930439674564582 13.33574515009131, 1.024099984827907 12.85183012853112, 2.177111394322607 12.62501333683386, 2.154470436268758 11.94015304356263)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"-5.77647200161907 9.304927207478057 8.259490449631741 6.117137587967736\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,24.72699200292385)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"0.023801513037396305,11.018682265303902 -0.438702380404016,11.098336412420526 -0.7615793094412941,10.936933407052031 -1.2033606559287948,11.009816492297265 -2.940412399273497,10.96269467908375 -2.9638967167964014,10.395331143306692 -2.8274949072849154,9.642457049446717 -3.5118950179524124,9.900327014991053 -3.980450710660777,9.862346594670393 -4.33025026890249,9.610834261168122 -4.779881345832729,9.821986655998728 -4.9546513773429615,10.152712144799679 -5.404338060392039,10.370736662126621 -5.470564947929006,10.951265641135299 -5.197844738084292,11.37514146414795 -5.220939812775325,11.713859929649182 -4.427162466351981,12.542648927502775 -4.280408651050012,13.228446328387147 -4.00639096509906,13.472489362972947 -3.522803084931283,13.33766530196528 -3.1037090349299983,13.541265711913553 -2.967696468250384,13.798152633197049 -2.1918242920931212,14.246420816139876 -2.001039698357325,14.559010516427767 -1.0663657144830285,14.97381844518389 -0.5158558702927998,15.116157741755728 -0.26625853819853873,14.92430792628983 0.3748892796988743,14.92891077838965 0.29565056035363657,14.444233208477597 0.4299300696627766,13.988734597186351 0.9930439674564582,13.335745150091306 1.0240999848279069,12.85183012853112 2.1771113943226075,12.625013336833863 2.154470436268758,11.940153043562628\" stroke=\"#66cc99\" stroke-width=\"0.16518980899263483\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
-    "topo.to_svg(separate=True)"
+    "topo.to_gdf().plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas\n",
-    "import geopandas\n",
-    "import topojson as tp\n",
-    "from shapely.wkt import loads\n",
-    "\n",
-    "df = pandas.DataFrame({\n",
-    "    \"name\": [\"P1\", \"P2\", \"P3\"],\n",
-    "    \"geometry\": [\n",
-    "        \"POLYGON ((60.05 88.85, 60.3 86.9, 61.9 73.4, 51.85 72.1, 50.8 80.5, 57.95 81.4, 57.5 85.05, 59.05 85.25, 58.85 87.15, 60.05 88.85))\",\n",
-    "        \"POLYGON ((66.35 90.55, 65.75 86.8, 64.5 81.1, 63.7 77, 63 73.55, 61.9 73.4, 60.3 86.9, 64.15 87.45, 64.85 90.8, 66.35 90.55))\",\n",
-    "        \"POLYGON ((65.75 86.8, 70.5 87.45, 71.45 79, 69.85 78.85, 70.3 74.5, 64.15 73.75, 63.7 77, 64.5 81.1, 66.45 81.35, 65.75 86.8))\"\n",
-    "    ]\n",
-    "})\n",
-    "\n",
-    "df['geometry'] = df['geometry'].apply(loads)\n",
-    "gdf = geopandas.GeoDataFrame(df, geometry='geometry', crs='EPSG:27700')\n",
-    "topo = tp.Topology(gdf, shared_coords=True)\n",
-    "#topo = tp.Topology(gdf, prequantize=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-ef7ac57a9df244fc99a36020e825864b\"></div>\n",
+       "<div id=\"altair-viz-da213561796344f68d78e8933d5cde7c\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-ef7ac57a9df244fc99a36020e825864b\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-ef7ac57a9df244fc99a36020e825864b\");\n",
+       "    if (outputDiv.id !== \"altair-viz-da213561796344f68d78e8933d5cde7c\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-da213561796344f68d78e8933d5cde7c\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -473,14 +253,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-39eac94c17de9e71257464246046ce6d\", \"format\": {\"feature\": \"data\", \"type\": \"topojson\"}}, \"mark\": \"geoshape\", \"encoding\": {\"color\": {\"type\": \"nominal\", \"field\": \"properties.name\", \"legend\": {\"columns\": 2}}, \"tooltip\": [{\"type\": \"nominal\", \"field\": \"properties.name\"}]}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-39eac94c17de9e71257464246046ce6d\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"properties\": {\"name\": \"P1\"}, \"type\": \"Polygon\", \"arcs\": [[0, -4, 1]]}, {\"properties\": {\"name\": \"P2\"}, \"type\": \"Polygon\", \"arcs\": [[-7, 2, 3, 4]]}, {\"properties\": {\"name\": \"P3\"}, \"type\": \"Polygon\", \"arcs\": [[5, 6, 7]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [50.8, 72.1, 71.45, 90.8], \"transform\": {\"scale\": [2.0650020650020655e-05, 1.8700018700018704e-05], \"translate\": [50.8, 72.1]}, \"arcs\": [[[447941, 895721], [12107, -104278]], [[537530, 69519], [-486683, -69519], [-50847, 449197], [346247, 48129], [-21792, 195187], [75060, 10695], [-9685, 101604], [58111, 90909]], [[624697, 262032], [-33899, -184492], [-53268, -8021]], [[537530, 69519], [-77482, 721924]], [[460048, 791443], [186440, 29412], [33899, 179144], [72639, -13369], [-29056, -200535], [-60532, -304812]], [[723970, 786095], [230024, 34760], [46005, -451871], [-77482, -8022], [21792, -232620], [-297821, -40107], [-21791, 173797]], [[624697, 262032], [38741, 219251]], [[663438, 481283], [94430, 13369], [-33898, 291443]]]}}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-e4fdaaa1ba119db35f7650622ecb3459\", \"format\": {\"feature\": \"data\", \"type\": \"topojson\"}}, \"mark\": \"geoshape\", \"encoding\": {\"color\": {\"type\": \"nominal\", \"field\": \"properties.name\", \"legend\": {\"columns\": 2}}, \"tooltip\": [{\"type\": \"nominal\", \"field\": \"properties.name\"}]}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-e4fdaaa1ba119db35f7650622ecb3459\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"properties\": {\"pop_est\": 54841552, \"continent\": \"Africa\", \"name\": \"South Africa\", \"iso_a3\": \"ZAF\", \"gdp_md_est\": 739100.0}, \"type\": \"Polygon\", \"arcs\": [[0, -6, -5, -15, 1, -13, 2], [3]]}, {\"properties\": {\"pop_est\": 13805084, \"continent\": \"Africa\", \"name\": \"Zimbabwe\", \"iso_a3\": \"ZWE\", \"gdp_md_est\": 28330.0}, \"type\": \"Polygon\", \"arcs\": [[4, -8, -10, -16]]}, {\"properties\": {\"pop_est\": 2214858, \"continent\": \"Africa\", \"name\": \"Botswana\", \"iso_a3\": \"BWA\", \"gdp_md_est\": 35900.0}, \"type\": \"Polygon\", \"arcs\": [[5, 6, -11, 7]]}, {\"properties\": {\"pop_est\": 15972000, \"continent\": \"Africa\", \"name\": \"Zambia\", \"iso_a3\": \"ZMB\", \"gdp_md_est\": 65170.0}, \"type\": \"Polygon\", \"arcs\": [[8, -17, 9, 10, 11]]}, {\"properties\": {\"pop_est\": 26573706, \"continent\": \"Africa\", \"name\": \"Mozambique\", \"iso_a3\": \"MOZ\", \"gdp_md_est\": 35010.0}, \"type\": \"Polygon\", \"arcs\": [[12, 13, 14, 15, 16, 17]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [16.344976840895242, -34.81916635512371, 40.775475294768995, -8.238256524288218], \"transform\": {\"scale\": [2.4430522884396637e-05, 2.6580936411771908e-05], \"translate\": [16.344976840895242, -34.81916635512371]}, \"arcs\": [[[0, 234847], [19608, 18606], [16165, -10300], [6900, -16086], [18364, -2741], [25737, -7114], [21990, 2747], [36536, 19237], [42, 138946]], [[634158, 337679], [-20656, 6890], [-11832, -2681], [-3865, -10955], [-11177, -14124], [383, -13008], [24429, -20392], [23957, 4062], [8334, 16707]], [[674777, 303863], [-10228, -27386], [-4835, -31258], [-10591, -16982], [-27932, -18998], [-8000, -5439], [-17347, -19111], [-11418, -19330], [-23212, -26955], [-46261, -38817], [-28890, -22569], [-30910, -17118], [-42781, -14596], [-20866, -1960], [-5282, -10444], [-24877, 5560], [-20262, -7160], [-44363, 7250], [-24799, -4588], [-16948, 1969], [-42216, -14851], [-34946, -5957], [-25287, -14219], [-18619, -904], [-17319, 13414], [-13834, 689], [-17628, 16795], [-1934, -5216], [-5440, 10111], [228, 22058], [-13298, 25211], [13210, 6853], [-1071, 28874], [-26804, 35210], [-20569, 31868], [-61, 101], [-29387, 48879], [19608, 18606], [16165, -10300], [6900, -16086], [18364, -2741], [25737, -7114], [21990, 2747], [36536, 19237], [42, 138946]], [[517111, 220593], [-17870, 11591], [-19130, -7674], [-22178, -14718], [-21828, -23824], [30705, -28936], [14646, 3739], [7526, 12020], [22813, 5875], [6959, 12275], [12556, 18298], [-14199, 11354]], [[607700, 472807], [-21757, 3760], [-13794, -4516], [-19805, 6373], [-16653, 410]], [[535691, 478834], [-57917, -27706], [-36751, -28086], [-13630, -25070], [-12307, -14132], [-22271, -3011], [-7196, -18001], [-4142, -11736], [-26176, -8760], [-33315, 1860], [-19553, 10537], [-17252, 4569], [-19968, -8719], [-10018, -18020], [-19384, -11317], [-20469, -16789], [-29319, -3838], [-9134, 13208], [3772, 22923], [-24269, 35747], [-11050, 5649]], [[145342, 378142], [-12, 109802], [40346, 1310], [1208, 134010], [30470, 1244], [63110, 13172], [15642, -15508], [26130, 14744], [12416, 83], [23075, 8477]], [[365086, 642665], [15757, -30078], [8236, -6711], [12870, -21770], [46323, -41324], [17529, -4046], [102, -13271], [12040, -23858], [31652, -5774], [26096, -16999]], [[589223, 996171], [17099, -9577], [16316, -6301], [26013, -6332], [23230, -11295], [19320, -16783], [10409, -31934], [-6973, -10195], [-8229, -30498], [7865, -31172], [-12880, -13095], [-12427, -34950], [21525, -9744]], [[570159, 726512], [-31003, -5150], [-23306, -14987], [-4977, -13043], [-14652, -2959], [-35598, -30940], [-22669, -24349], [-13821, -872], [-13296, 4333], [-45751, 4120]], [[365086, 642665], [-7359, 2811]], [[357727, 645476], [-306, 3122], [-16152, 8480], [-26544, 2166], [-33516, -8550], [-26712, 23500], [-27614, 30780], [1884, 119705], [85232, -475], [-3488, 12987], [6098, 14091], [-7194, 17645], [4656, 18245], [-4326, 11680], [14119, -946], [2348, -11694], [19184, 908], [25989, -3471], [13680, -17081], [32778, -5247], [25023, 11877], [9184, -19713], [31367, -5257], [15082, -16032], [16812, -20704], [31326, -311], [-3422, 40567], [-11234, -6841], [-28617, 14641], [-11059, 6694], [5068, 37762], [7271, 44542], [-9162, 16591], [11666, 24016], [10972, 4497], [54979, 6349], [16124, -3828]], [[674777, 303863], [-31046, 315]], [[643731, 304178], [-3515, 16630], [-6058, 16871]], [[634158, 337679], [-3495, 13508], [7294, 41942], [-10651, 26728], [-19606, 52950]], [[607700, 472807], [43126, 42701], [10794, 27132], [6183, 3423], [4624, 22148], [-6579, 11143], [1756, 28114], [7981, 26073], [-91, 47615], [-21261, 12089], [-19492, 2733], [-8822, 9309], [-18970, 7939], [-34142, -748], [-2648, 14034]], [[570159, 726512], [-3879, 26775], [124211, 31008]], [[690491, 784295], [23563, -18057], [11262, 3457], [16160, -9520], [2376, -15075], [-8611, -17491], [3029, -26520], [26709, -23240], [12495, 26104], [17717, 7922], [-3482, 48374], [-17146, 27208], [-14769, 12129], [-14210, -548], [-11460, 48906], [11460, 28592], [30798, 3042], [49188, -10601], [10686, 4756], [28495, 969], [14586, 11285], [24556, -617], [44757, 14609], [32566, 21812], [6622, -16867], [-1683, -37481], [5057, -33011], [1589, -58794], [7198, -18426], [-12207, -26881], [-15881, -26127], [-26062, -23330], [-37421, -14301], [-46140, -18259], [-46247, -40379], [-15750, -6869], [-28575, -26731], [-16865, -8698], [-3458, -26825], [19411, -28491], [8076, -22064], [509, -11255], [7232, 1881], [-1171, -36898], [-6637, -17477], [9647, -6441], [-6088, -15652], [-17110, -13384], [-33765, -12714], [-49226, -20363], [-17952, -13910], [3509, -15848], [10462, -2532], [-3513, -19801]]]}}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -491,162 +271,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 LINESTRING (60.0499908999909 88.84999944999944, 60.3000007000007 86.89999889999889)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"59.97199087799088 86.82199887799887 0.4060098440098372 2.106000594000605\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,175.74999834999835)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"60.0499908999909,88.84999944999944 60.3000007000007,86.89999889999889\" stroke=\"#66cc99\" stroke-width=\"0.042120011880012104\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 LINESTRING (61.9000056000056 73.40000660000659, 51.8499915999916 72.09999999999999, 50.8 80.4999922999923, 57.9500077000077 81.40000550000549, 57.50000245000245 85.05000605000605, 59.04999299999299 85.25000275000275, 58.84999754999755 87.14999944999944, 60.0499908999909 88.84999944999944)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"50.13000002200002 71.43000002200002 12.44000555600556 18.089999405999407\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,160.94999944999944)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"61.9000056000056,73.40000660000659 51.8499915999916,72.1 50.8,80.4999922999923 57.9500077000077,81.40000550000549 57.50000245000245,85.05000605000605 59.049992999992995,85.25000275000275 58.84999754999755,87.14999944999944 60.0499908999909,88.84999944999944\" stroke=\"#66cc99\" stroke-width=\"0.36179998811998815\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 LINESTRING (63.70000595000595 77.0000033000033, 62.9999908999909 73.54999944999945, 61.9000056000056 73.40000660000659)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"61.75600573200573 73.25600673200672 2.0880000860000862 3.887996435996442\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,150.40000990000988)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"63.70000595000595,77.0000033000033 62.9999908999909,73.54999944999945 61.9000056000056,73.40000660000659\" stroke=\"#66cc99\" stroke-width=\"0.07775992871992883\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 LINESTRING (61.9000056000056 73.40000660000659, 60.3000007000007 86.89999889999889)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"59.76000100800101 72.8600069080069 2.6800042840042764 14.579991683991693\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,160.30000550000548)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"61.9000056000056,73.40000660000659 60.3000007000007,86.89999889999889\" stroke=\"#66cc99\" stroke-width=\"0.2915998336798339\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 LINESTRING (60.3000007000007 86.89999889999889, 64.14999054999055 87.45000385000385, 64.8500056000056 90.8, 66.35000245000245 90.54999944999945, 65.74999544999545 86.7999911999912, 64.5000084000084 81.10000110000109)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"59.91200074400074 80.71200114400114 6.826001662001666 10.47599881199882\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,171.90000110000108)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"60.3000007000007,86.89999889999889 64.14999054999055,87.45000385000385 64.8500056000056,90.8 66.35000245000245,90.54999944999945 65.74999544999545,86.7999911999912 64.5000084000084,81.1000011000011\" stroke=\"#66cc99\" stroke-width=\"0.20951997623997642\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 LINESTRING (65.74999544999545 86.7999911999912, 70.4999957999958 87.45000385000385, 71.45 79.0000077000077, 69.8499950999951 78.84999614999614, 70.30000035000035 74.4999977999978, 64.14999054999055 73.74999614999615, 63.70000595000595 77.0000033000033)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"63.15200564200564 73.20199584199584 8.845994665994674 14.796008316008326\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,161.2)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"65.74999544999545,86.7999911999912 70.4999957999958,87.45000385000385 71.45,79.0000077000077 69.8499950999951,78.84999614999614 70.30000035000035,74.4999977999978 64.14999054999055,73.74999614999615 63.70000595000595,77.0000033000033\" stroke=\"#66cc99\" stroke-width=\"0.2959201663201665\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 LINESTRING (63.70000595000595 77.0000033000033, 64.5000084000084 81.10000110000109)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"63.53600603800604 76.83600338800339 1.128002274002263 4.427997623997612\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,158.1000044000044)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"63.70000595000595,77.0000033000033 64.5000084000084,81.1000011000011\" stroke=\"#66cc99\" stroke-width=\"0.08855995247995224\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 LINESTRING (64.5000084000084 81.10000110000109, 66.44998984998985 81.35000165000164, 65.74999544999545 86.7999911999912)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"64.27200879600879 80.87200149600149 2.4059806579806633 6.155989307989316\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,167.89999229999228)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"64.5000084000084,81.1000011000011 66.44998984998985,81.35000165000164 65.74999544999545,86.7999911999912\" stroke=\"#66cc99\" stroke-width=\"0.12311978615978632\"/></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "import geopandas\n",
+    "import topojson as tp\n",
+    "from shapely.wkt import loads\n",
+    "\n",
+    "df = pandas.DataFrame({\n",
+    "    \"name\": [\"P1\", \"P2\", \"P3\"],\n",
+    "    \"geometry\": [\n",
+    "        \"POLYGON ((60.05 88.85, 60.3 86.9, 61.9 73.4, 51.85 72.1, 50.8 80.5, 57.95 81.4, 57.5 85.05, 59.05 85.25, 58.85 87.15, 60.05 88.85))\",\n",
+    "        \"POLYGON ((66.35 90.55, 65.75 86.8, 64.5 81.1, 63.7 77, 63 73.55, 61.9 73.4, 60.3 86.9, 64.15 87.45, 64.85 90.8, 66.35 90.55))\",\n",
+    "        \"POLYGON ((65.75 86.8, 70.5 87.45, 71.45 79, 69.85 78.85, 70.3 74.5, 64.15 73.75, 63.7 77, 64.5 81.1, 66.45 81.35, 65.75 86.8))\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "df['geometry'] = df['geometry'].apply(loads)\n",
+    "gdf = geopandas.GeoDataFrame(df, geometry='geometry', crs='EPSG:27700')\n",
+    "topo = tp.Topology(gdf, shared_coords=True)\n",
+    "#topo = tp.Topology(gdf, prequantize=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo.to_alt(color='properties.name:N')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "topo.to_svg(separate=True)"
    ]

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -2,19 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-3b1b2cd61e564f738ef9081f5a0d78b6\"></div>\n",
+       "<div id=\"altair-viz-13fef05ddf42460592bdf8d8ddd843ee\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-3b1b2cd61e564f738ef9081f5a0d78b6\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-3b1b2cd61e564f738ef9081f5a0d78b6\");\n",
+       "    if (outputDiv.id !== \"altair-viz-13fef05ddf42460592bdf8d8ddd843ee\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-13fef05ddf42460592bdf8d8ddd843ee\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -63,7 +63,7 @@
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,9 +108,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"15.309046274484848 -35.17245125095846 19.212571989009135 27.970125293080635\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,-42.374777208836285)\"><g><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"31.19140913262129,-22.2515096981724 32.46213260267845,-28.301011244420557 25.780628289500697,-33.94464609144834 18.377410922934615,-34.13652068454807 16.344976840895242,-28.5767050106977 19.894734327888614,-28.461104831660776 19.895767856534434,-24.76779021576059\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"28.978262566857243,-28.95559661226171 28.074338413207784,-28.851468601193588 26.999261915807637,-29.875953871379984 28.107204624145425,-30.54573211031495 28.978262566857243,-28.95559661226171\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"31.19140913262129,-22.2515096981724 29.43218834810904,-22.091312758067588\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"30.27425581230511,-15.507786960515213 32.847638787575846,-16.713398125884616 31.19140913262129,-22.2515096981724\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"29.43218834810904,-22.091312758067588 21.605896030369394,-26.726533705351756 19.895767856534434,-24.76779021576059\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"19.895767856534434,-24.76779021576059 20.910641310314535,-18.252218926672022 25.08444339366457,-17.661815687737374\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"25.264225701608012,-17.736539808831417 29.43218834810904,-22.091312758067588\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"30.27425581230511,-15.507786960515213 25.264225701608012,-17.736539808831417\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"25.264225701608012,-17.736539808831417 25.08444339366457,-17.661815687737374\" opacity=\"0.8\" /><polyline fill=\"none\" stroke=\"#66cc99\" stroke-width=\"0.5594025058616127\" points=\"25.08444339366457,-17.661815687737374 21.933886346125917,-12.898437188369359 23.912215203555718,-10.926826267137514 29.69961388521949,-13.257226657771831 30.346086053190817,-8.238256524288218 33.48568769708359,-10.525558770391115 30.27425581230511,-15.507786960515213\" opacity=\"0.8\" /></g></g></svg>"
+      ],
+      "text/plain": [
+       "<shapely.geometry.multilinestring.MultiLineString at 0x163034fe0c8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import geopandas\n",
     "from topojson.core.hashmap import Hashmap\n",
@@ -120,7 +133,6 @@
     "    (data.name == \"Botswana\")\n",
     "    | (data.name == \"South Africa\")\n",
     "    | (data.name == \"Zimbabwe\")\n",
-    "    | (data.name == \"Mozambique\")\n",
     "    | (data.name == \"Zambia\")\n",
     "]\n",
     "\n",
@@ -128,61 +140,166 @@
     "# data = data[\n",
     "#     (data.name == \"Togo\") | (data.name == \"Benin\") | (data.name == \"Burkina Faso\")\n",
     "# ]\n",
-    "#topo = Hashmap(data)\n",
-    "topo = topojson.Topology(data)"
+    "#topo = Dedup(data)\n",
+    "topo = topojson.Topology(data, prequantize=False).toposimplify(2)\n",
+    "topo.to_svg()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x24fd770ccc8>"
+       "Topology(\n",
+       "{'arcs': [[[31.19140913262129, -22.2515096981724],\n",
+       "           [32.46213260267845, -28.301011244420557],\n",
+       "           [25.780628289500697, -33.94464609144834],\n",
+       "           [18.377410922934615, -34.13652068454807],\n",
+       "           [16.344976840895242, -28.5767050106977],\n",
+       "           [19.894734327888614, -28.461104831660776],\n",
+       "           [19.895767856534434, -24.76779021576059]],\n",
+       "          [[28.978262566857243, -28.95559661226171],\n",
+       "           [28.074338413207784, -28.851468601193588],\n",
+       "           [26.999261915807637, -29.875953871379984],\n",
+       "           [28.107204624145425, -30.54573211031495],\n",
+       "           [28.978262566857243, -28.95559661226171]],\n",
+       "          [[31.19140913262129, -22.2515096981724],\n",
+       "           [29.43218834810904, -22.091312758067588]],\n",
+       "          [[30.27425581230511, -15.507786960515213],\n",
+       "           [32.847638787575846, -16.713398125884616],\n",
+       "           [31.19140913262129, -22.2515096981724]],\n",
+       "          [[29.43218834810904, -22.091312758067588],\n",
+       "           [21.605896030369394, -26.726533705351756],\n",
+       "           [19.895767856534434, -24.76779021576059]],\n",
+       "          [[19.895767856534434, -24.76779021576059],\n",
+       "           [20.910641310314535, -18.252218926672022],\n",
+       "           [25.08444339366457, -17.661815687737374]],\n",
+       "          [[25.264225701608012, -17.736539808831417],\n",
+       "           [29.43218834810904, -22.091312758067588]],\n",
+       "          [[30.27425581230511, -15.507786960515213],\n",
+       "           [25.264225701608012, -17.736539808831417]],\n",
+       "          [[25.264225701608012, -17.736539808831417],\n",
+       "           [25.08444339366457, -17.661815687737374]],\n",
+       "          [[25.08444339366457, -17.661815687737374],\n",
+       "           [21.933886346125917, -12.898437188369359],\n",
+       "           [23.912215203555718, -10.926826267137514],\n",
+       "           [29.69961388521949, -13.257226657771831],\n",
+       "           [30.346086053190817, -8.238256524288218],\n",
+       "           [33.48568769708359, -10.525558770391115],\n",
+       "           [30.27425581230511, -15.507786960515213]]],\n",
+       " 'bbox': (16.344976840895242,\n",
+       "          -34.81916635512371,\n",
+       "          33.48568769708359,\n",
+       "          -8.238256524288218),\n",
+       " 'coordinates': [],\n",
+       " 'objects': {'data': {'geometries': [{'arcs': [[-5, -3, 0], [1]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 739100.0,\n",
+       "                                                     'iso_a3': 'ZAF',\n",
+       "                                                     'name': 'South Africa',\n",
+       "                                                     'pop_est': 54841552},\n",
+       "                                      'type': 'Polygon'},\n",
+       "                                     {'arcs': [[2, -7, -8, 3]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 28330.0,\n",
+       "                                                     'iso_a3': 'ZWE',\n",
+       "                                                     'name': 'Zimbabwe',\n",
+       "                                                     'pop_est': 13805084},\n",
+       "                                      'type': 'Polygon'},\n",
+       "                                     {'arcs': [[4, 5, -9, 6]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 35900.0,\n",
+       "                                                     'iso_a3': 'BWA',\n",
+       "                                                     'name': 'Botswana',\n",
+       "                                                     'pop_est': 2214858},\n",
+       "                                      'type': 'Polygon'},\n",
+       "                                     {'arcs': [[7, 8, 9]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 65170.0,\n",
+       "                                                     'iso_a3': 'ZMB',\n",
+       "                                                     'name': 'Zambia',\n",
+       "                                                     'pop_est': 15972000},\n",
+       "                                      'type': 'Polygon'}],\n",
+       "                      'type': 'GeometryCollection'}},\n",
+       " 'type': 'Topology'}\n",
+       ")"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPIAAAD4CAYAAADW87vCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO2dd3icxbX/P2eLVr1Zki2ruzdcZRvTIRCawbQQeksA55Lc5OamERISCNxUkvtLSOgQEpIQUx3gEkICNgGCbblhyw3ZsqxiWbLV20q7O78/tCbC3pVW2953V/N5Hj1e7b47c/R6vzszZ86cI0opNBpNbGMx2gCNRhM6WsgaTRyghazRxAFayBpNHKCFrNHEATajDRhKTk6OKi0tNdoMjcaUbNy48bBSKtfXa6YScmlpKRUVFUabodGYEhGp8feanlprNHGAFrJGEwdoIWs0cYAWskYTB2ghazRxgBayRhMHaCFrNHGAFrJGEweYKiBEEzu4PYqGtl7qWnupbe2hrrWXutYeWrr7mVuQwbLJOSwsycRhsxpt6phAC1kzIq3d/bywqY5djZ3UtfZQ29LLoY4+XB7fSSnW7G7ml29VkZOawJ3nz+TyRYVRtnjsoYWsGZZnPqjhvtd20DfgGfV7D3f189/PbWVVRS0/uGQO08anRcBCDeg1smYY+gbc/OLNPUGJeCjrqls493/f4cYn1/PWrkN4/IzkmuDRI7LGLy9uqudId39Y2lIK1u5pZu2eZgoykzh1ag4nTxn8yU5JCEsfYxktZI1PlFI8+V51RNqub+vl2Q21PLuhFhGYOSGdC+fmc/PJpSQn6I9kMOi7pvHJmt3NVDV1RbwfpWDHwQ52HOzgqff286WzpnDN0mLsVr3qGw36bml8crjLaUif3/tLJWc9sIY3Khuj3n8so4Ws8cmlCwooGZdsSN+1Lb2sfGYjz3zg9xy95hi0kDU+sVktfOmsqYb1rxR85+XtPLx2r2E2xBIhCVlEPiMilSLiEZHyY167U0SqRGS3iJwbmpkaI7h0QQGJdmO/63/0+i5++sYuQ22IBUL9X9oOXAa8M/RJEZkFXAXMBs4DfiMiOlYvxujsGwh5Dzkc/PrtvextjrzjLZYJSchKqZ1Kqd0+XloBPKuUciqlqoEqYEkofWmiz77D3Uab8DH/2HnIaBNMTaTmTQVA7ZDf67zPHYeI3CYiFSJS0dzcHCFzNMGwr9lMQm4y2gRTM6KQReTvIrLdx8+K4d7m4zmfcXlKqUeVUuVKqfLcXJ8pezUGUX3YPNPZjTWttPcMGG2GaRkxIEQpdXYQ7dYBRUN+LwQagmhHYyBmGpFdHsWaPU2smO9zYhdztHb3kxXG0NRITa3/AlwlIg4RKQOmAusj1JcmQlSbaI0M8TG9Vkrx+D/3cc4v3sHpcoet3VC3ny4VkTpgGfCaiLwBoJSqBFYBO4C/AncopcJntSbiKKXYf8RcQu7pj+2P0JEuJ7f8dgP3vbaTw11O3t4Vvi+mkGKtlVIvAS/5ee1+4P5Q2tcYR31brym2no6SaLdw9/JZRpsRNO9VHea//ryFps5/h76+uKme8+bkh6V9fWhC45MDR3qMNuETXLW4mGKDQkZDweX28PM39/Dw2r0cewx7z6HOsPWjhWwyao50c88rO8hMtnPbaZOYMSHdEDtqW80l5JOn5BhtwqjY0dDB6q31vLKlgYb2Pp/XJNrDFyOlhWwyirOT2XWwg4b2Pmblpxsm5PrWXkP69YVFYElpttFmjEhdaw+rtzSweks9ew6NvHWXnKCFHLeICKdNy+XZDbX886PDFGcn093vosvpJsEqlIxLoSwnhfHpiRG1o85EQp4xIZ2MZLvRZgCwvb4diwgJNgsO26CveO2eZlZvqaeiphU1iixGSVrI8c3R/dujqXF8kZxgpSwnhYevW0RRdvjXjmYS8omTxhltAn0Dbr7+/Ie8sjV84RBJ9vDJTwvZZPS7PGytaxvxup5+N5UNHXzpT5t5buWysGfUqG8zj5CXTgpsWt3W08/qLQ00dvTR2O796eijs8/FnIJ0FpdmU16SxbyizFGtT5s7ndz6uwq21I78/zIa9Igcx2yrb8fpCnzbZ0ttGz97Yzd3XjBzxGs7+wb43b9q+NwpZcN+kF1uD40dvh00RlCUFdiM47mKOu7/v50+X1uzu5k1uwdnNwlWy8fCXlyaTXlpFikOGy9srOPPFbV09A6e+uobcNM74KZvwH2cxzkcJGtnV/ziGc0iy8uj/9zH+PRETpw0jil5qSTYPjk69/a7eer9ah59Zx9tPQPkpjm4srzIT2vQ0efCbhXcJklbu7WujVkTR3b6vbCpLqD2+t0eNh1oY9OBNh55Zx8ikOqw0dnnCtXUUWGx+DqSEBxayCajvCSLouwkalsCn9oqBfe+ugMAm0UozUlh+oQ0po9Pw2YVnnx3/ydycD39/v5hhZydksDrXz6Nbzy/lQ37W4P/Y8JExf5Wrl5SPOw1Oxo62NUY3L6sUkRdxBDe5YsWsskQES5bUMj/+8dHQb3f5VFUNXVR1dTFaxz0eU1lQwcb9reweJgtnbKcFFbdvoyXNtfzszd2+90LjQYba1pGvCbQ0dhM1IQxBFbn7DIhF5wQnrC94fjKs1v4+nNbeeLdat7fe5i2nuMT0YsIly0s5K2vncHXz51OquPf3/v5GYmkhNFZMxz7j/TQ3Ok/q6fbo1i9JfYO19W39uJyhycMVo/IJmR99ZGI91Hf1stzGz85ik1IT2Tl6ZO46eSyTzyfaLdyx5lT+OziIn7x5h7cHsVdF87k8ofeDyjwIRxsrGnxG5d8oKXHkPS9oeLyKOpaeynNSQm5LS1kE/Kn9bUjXxQBGjv6uOfVHeSlJ/qcFeSkOrj/0hM+/j0rOXqlXtp7/ScVKMlOJtVho8sZ/XVuqOw/0h0WIeuptclo6uhjx8EOw/pXCv7rz1vYdGBkJ1e0ajZdvaSIzy727+yyWIQTCjKiYku4qQnT4RQtZJORl55ITqrDUBucLg+3Pl1Bwwhe1XBmuPDHp2eN575LThjxuvnFmRG3JRKEq0ieFnKEaOroo6mzj8NdTo50OWnt7qetp5/23gE6+gbocrrodrro7R8MOHC63Ay4PbjcHpaUZRltPke6+/nPP20e1hmTHeGptc0i/PjyuVgD2G+dXxSbQh7Qzi7z0tvvZsn//MNoM0KmoqaVB97cwzfPm+Hz9UiPyCdOGhdwHwtidEQeGEUU33DoETkCuIOIzjIrD6/dy5rdvlPSZEX4RNL5J0wI+Nq8tEQKMpMiaE1k6Ncjsnlxu+NHyErBV1dt5aaTSrFaBBGwimC1SETLrloEzp0duJBhcHptpsMegaCn1ibG5TFPrqtw0NLdz8/f3BPVPheXZo/a6Te/KJPXtvmOZjMrozkgMxxayBEgnqbWRhFMdNvCkkzSEm0kJ1hxujy0xUBC+4Ewzd60kCOAWU4NxSoicN6c0U2rARaVZLPt+4OFP9t7Bvjc0xuoqDH+0MdwaGeXiXHF0RrZCJSC//jDJr9OtkDISLbzzOeXcu7s8WG0LPyEy9mlhRwB9IgcOhtrWrnpqQ2s+PV7rAkykXui3cpD1y7i5CnGpwryR7icXVrIEUCvkUNDgCl5KSwty6bf5ebW31fw3Ze3B3VSyGIRvn/RbGxhPMQfTvr11Nq86BF59IxPd7C4NIsFxZmkJ9mpaupmXXULOw92MuBW/P6DGm56asOwhyf8MXV8GtedWBIBq0MnXAc9tJAjgF4jj0xKgpV5hRksKc2mMCuJQx1ONuxvZfOBNr9ifbfqMJf+5r2Pi8v19LtoCTBW+b/OnhbxAJZg2HGwY8SY9kDQXusIoEfk47EITM5NJTslgfbeAaqautha1z7qdvY1d3PJr99j2aRxrN3TjN0qfPuCmVw1QiqgjGQ7Xz1nGt9dXRnsnxARlILVWxr4whmTQ2on1GqMnxGRShHxiEj5kOdLRaRXRLZ4fx4OycoYQ6+RB8nPGJwuzy/KJMVh46OmLtZVt7CrsRNXCF927b0D/LWykd4BNx19Lr714jaufvQDOvuGn3Zfs7SEsjCc/Q03L2+uD7mNUEfk7cBlwCM+XturlJofYvsxiTvOIrsCJdVhZUpeKnarlYa2Hurb+jjYHp3MHf/ad4QdDR0sHSaZvdUiTM5NMV3d54PtvQy4PSHlJg+1rOpOGMztpPk3Y3WNPH1COhsNDMDYf6R7WCEDpCeZb518xaKikAsMRNLZVSYim0VkrYicGsF+TMdYnVobvcXTGMDon55oLiGLwPXLQveojzgii8jfAV/xcncppVb7edtBoFgpdUREFgEvi8hspdRxOWxE5DbgNoDi4uEdFrHCWHV2Gfl3i8CFc0cO68ww2Yh8ypScsKzbRxSyUurs0TaqlHICTu/jjSKyF5gGVPi49lHgUYDy8vK4UEAojpxYxsjkd2dOz2NKXtqI15lNyDcsKw1LOxGZWotIrohYvY8nAVOBfZHoy4zE03nk0RDonm4kuPXUSQFdZyYhF2cn86kZeWFpKyRnl4hcCvwKyAVeE5EtSqlzgdOAe0XEBbiBlUqpkcsFxAljaY2clmijMCuJNIcNpRQdfYMF0KJNoKl+zCTkb5w3PWz1n0L1Wr8EvOTj+ReAF0JpO5aJ9zVyfkYi+RmJ1LX20tTpZOfBf9dcmpKbSlVzdJLWD6Wpw0nxuJGrNpqlYPrC4kyWz50YtvZ0iGYEiOc1cnlJFh29A2w60EaTjzIuxwrFZhGS7FaSI1xeJtAysGYZke+6cFZY29MhmhHAE4dCzkyyU5qTMuJB/e31bSTbLQy4FQMehcujcHncAMwrzMDp8gRdNXE4AhHy/sPdPLRmb9j7Hi0XnpDPopLwpjzWQo4AZvnWDxd2q+CwW9hS2zbitU6XAnx/kR2NrZ6al8qA28P+MFVZADg0TLXI+rZefvLXXbz64UHDlz3JCVa/6YVDQU+tI8CZM/JGrOcbS8zKT+dQR/hCLT9q6qKn301uWvgqary9uwmny+3ztf95bSertzQYLuI0h43f3bIkoLX8aNFCjhD3rpjN0jL/9YdjBZtFwuZZHUpTpxOHzcLSsmwWl2Yxc0JaSOvo9/ce4XO/raCn/5N72fVtvfy1sjFUc0MmPdHG7z+/lPJhalKHghZyhLBbLTx03SKKsmMvaTrAkrJsZk5Iw2qBzQdGnlIHQ11rL+uqW9iwv5WdjZ0k2iwhrR3frTrMDU+sp2PIKain399v+EiclWznj7eeGNGyNlrIESQ7JYHHbiiPWkHwcLG0LJv11S3sbOz0rnmjQ0vPABtrWpmdn05hVnBfgBU1rVzz2Ae0dPfT7XTx7PoDYbZydIxLSeCPt57InAhXi9RCjjAzJqTzi8/OJxYOiFkEFpdmsa7a2NidyoMdHOroIzfIqpTb6zu48pF/8Zs1VXT0GRM2mmCzcNmCAp7/wknMzE+PeH/aax0FPj17At88bwY/en2X0ab4xWYR5hZmsGG/OfJAD7gVNmvw335VTV0RLWnjj8KsJK5dWsJnFxdFrX40aCFHjZWnD6ZyMaOYE2wWZk5IY1OE1sLBEgOTGGDw5NXp03K5/sQSzpyeFxHn4EhoIUeRladPJslu5fuvVGKWcOykBCuTclKCyp811klz2PhMeRE3nlRCyThjUwhpIUeZG08qJclu5VsvfogvZ2pemoOlk8bR73JzuKvfWyi9PyJHBJMSrBRlJVHZcNwxcVNgVr/CpNwUblxWyhWLCklxmENC5rBijHHl4iISE6x89c9bsFiExaVZnDY1l9On5zJjgm/HSF1rDz/+625e2doQFhssAtPyUk09Eptk0gL8e/p800mlnD4t13TprUSZZY7HYGKBiorjcg/ELVVNXRRkJpE0iu2pjTUtfHXVVmpCDG9c4t1iMjMTMxNpaAvsMESksFmEa5cWc+NJpUzKTTXUFhHZqJQq9/WaHpENZEre6D4YLreH5s5+po9PI8lu5UBLDz39vsMShyMWRAwgBru7EqwWfnXNglEXXDcCLWSDUErRO+AmOWHk/4Lalh6e3XCA5yrqPj46mJRgxWGzgFJkpzpIdQzWBT6ajdHtUTR29FHX+skqBnMLM6jYb34RG02S3coj1y/itGm5RpsSEFrIUaLb6WJLbRsba1rZWNPK5gOtZKck8NzKk447PFDb0sPdq7ezdk+zT4cYQG+/m3kFGXxQ3UJPq/+SI1PyUhiXMti+UorKhg6/bZoNo5Z9aQ4bT9y0mCUxFCuvhRwhalt62HSg9WPh7mrsPC7mt6PPxQ1PrufZ204kI8lOv8vDo+/s5cG3qwJKl1PZ0EGqw0qX0//0uqqpmyrMlZA9ELKT7RwMMFlAOMlMtvO7W5YwtzBycdGRQAs5SLbXt7P/SDc9Tjc9/S56Btz09rvZ29zFxprWgI/97TzYwed+u4E7zprCfa/uYG9z4KLrdLpYWpZteEhlJCjLTaUlysnuc9McPPO5pUyfMHI2TrOhhRwkj/1zH6u3hGcrqKKmlZuf2hDUe3cf6iTJbqHXgIR3ESXKs+qCzCSe+fxSU9aGCgR9aCJIzLLObOsZiLlp4EgIsPdw9OKky3JSWLVyWcyKGLSQg8Zjov33jTWtlIc5B5SRTM5Loa1n9AXNg2FeYQZ/vv1ECjJj89z4UfTUOkjMFEjj8igqalo5oSCDbfXmjdQKlLQo1GdaVJLFHWdO5qwZ4yPeVzTQQg4So7NO+KLTOYBgrtDGYIh0Mbh7Lp7NjSeVRrSPaKOn1kFiQh2z/3BP2NOsGoElgnHM37toVtyJGLSQg8ZMU+uh1Lb2kBDCgfx45jsXzuTmk8uMNiMiaCEHiRlHZIBDHU4WFMf2qByJW/ut82fw+QALvcUiWshBYiav9bGsq27hxBgKLzyWcH8ov/bpaR9naIlXtJCDxKwj8lE+qG6J2bzaOxs7SA3Dgf30RBs/WDGbL541NQxWmZuQhCwiPxWRXSLyoYi8JCKZQ167U0SqRGS3iJwbuqnmwqxr5KGsq26JqcD/o7T3upg9MfjMkzaLcNNJpaz9+plcH6ZC4mYn1BH5TWCOUmousAe4E0BEZgFXAbOB84DfHC18Hi+YeWo9lPXVLSwujb01cyj39wtnTOb7F88mK4pZLI0mJCErpf6mlDqaTOoDoND7eAXwrFLKqZSqBqqAJaH0ZTY8MRTavGH/YORXLPmyQ4nsKsoKf20lsxPONfItwOvexwVA7ZDX6rzPHYeI3CYiFSJS0dzcHEZzIos7Rkbko1TUtLKwJAsDMrWOGqvAgZbgUxlNjPFwy2AYUcgi8ncR2e7jZ8WQa+4CXMAfjj7loymfn3yl1KNKqXKlVHlubmxkY4DYWCMfy8aaVuYVZWIzuYuzKDsZpyv4KU9BkOVmYpkRXYNKqbOHe11EbgSWA59S//501wFFQy4rBMJz5s8kmN1r7Y/NB9qYW5hBT7+bfc1dpvs7puSm0jsw+jxkRxGB/IzEMFoUG4TqtT4P+CZwsVJq6FzoL8BVIuIQkTJgKrA+lL7MRqw4u3zxYV07VU1dJCVYOaEgw1QjdLLDSn2b/9RFI2G3WHDG29nsAAj1v/BBIA14U0S2iMjDAEqpSmAVsAP4K3CHUir4r1kTYraRLBi6nW621bdjs5hDyVnJdnaEmCy/3+3hh6/vDJNFsUNIu+5KqSnDvHY/cH8o7ZuZWFwj+8MsDrCp49PCkqb3zxW1XL6okMURKipuRszxVRyDxPLU+ljKDE68fpSW7v6wtKMUfPvFbfSH4DCLNbSQgySW9pFHwgwDcnF2cljLoH7U1MUja/eGrT2zo4UcJPE0Im9v6GBSrnH5qhw2IWUUZXMC5cG3q9h/OPZSAQeDFnKQxJOQATKTIp9exxc2C0yfkM7Oxs6wt+10eXjknbExKmshB0k8eK2HsrWunRkT0qK6FSXA3MJMPoxgRcg3Kg/hcsfROsgPOmdXkMTbiOz2KHY1dpJgszA1J5nM5MERuqW7f1RJ80fD4tIs1u+PbBL6lu5+3t97JGZqOAWLFnKQxJmOP6bf5eGjY5xOcyam09jRx+Gu8HiVgahWyHj1wwYt5LFKU0cfD6/dR5/LTV+/e/DfAQ99A276BtwhRR/FGtsbOshMsjO/KJMttW0htxftMjdr98TOYZxg0UL2Q3OXkyffqzbaDNPQ1jvAlto2Fpdmsb2+PegSNeUlWayPclnX9t7oJLs3Ei1kzag40NLDvKJMup1uRMBmsWC1wO7GTjr6XB9fV5SVhMUi1LX2fpwDfF5RBptr26K+LHG6PDzwt92cNSMv5hMT+kMLWRMQ41ISmJybwuYDbT4rTdotwrzCDBLtVpo7nezz7t8mWIWyvBRyUx1sPNBmSGJ/peBXb1WxMA5yfvtDC1kzLBlJdmZMSGNrbduwHuYBj2Krj22kfrcarNHc1E3JuGRqjgSfMCBUHGY65hVm4vcv04REisPK0rJs3B4P66pb6AtD3HJ+urHnhLWQNWMGh83C0rJs7FYL66pb6HKG7/RpncGefoctrvI/fgItZA0wmFljcWkWaYk21lW3RKSsaV1rL5MMrEGcoEdkTTyTaLewoCiTDftbwxr04YvcNEdE2x+OeJ5aa2fXGCc3zUFGop1NB0IP9AiEAy3GnUaKRt1lo4jfryjNiEzNS8XjUVQ1h+8c8EgcbHcyNS/6iQwWFmeSHccJ6/WIPEZZWJzJ9vp2+t3R39c1QlAXz5sY9T6jiR6Rxxgig7HOmw60GSJigOrD3USwlvlxWC3ChXO1kDVxxJLS6B5Y8EVTp5Pp49Oi1p/bo/jNmqq4zuGlhTyGyE11sPlAZM//Bkp6YnRXdU+9t58H3/ooqn1GEy3kMURZboph0+lj2XWoE7s1umn/zpyRF9X+ookW8hghN9XBFpOMxgAdIdZAHi2l45Lj9uQTaCGPGcw0Gn9MlMyxWYSvnD0tOp0ZhN5+GgNMykkx1Wh8lEpv5pG2CB78T3PYePDahZyuU/1oYpmMJDu9Ay7zjcYMHn2cmJkUMSEXZiXx5E2LmRZFD7lRaCHHMVaLUJSVxPYQC6NFkubO45MUhMrsielcu7SESxZMJDlhbHzEQ/orReSnwEVAP7AXuFkp1SYipcBOYLf30g+UUitD6UszMnlpDspyUnB7FJ19Lpo6+0wt4tQEK81d4RGyw2Zh+dyJXHdicVw7tfwR6tfVm8CdSimXiPwYuJPBeskAe5VS80Ns3zD6XR5vBFQrAyaclvqiLCfF8GCP0ZCfmXRc6t3RUpCZxE0nlfKZ8kIyk+M3lnokQi2r+rchv34AXBGaOebgyXerqWzoYF11C4VZSbT1DNDldI38RgOxWiSsRdCiQUYIZWrmFWVy66llnD8nH6tZ6sIaSDi3n24BXh/ye5mIbBaRtSJyqr83ichtIlIhIhXNzcbnH35hYx33vrrj49/rWnuZFcX9zmCZmZ/GkTCVJY0WoxWgReCcWeNZdfsyVt9xMsvnTtQi9jLiiCwifwcm+HjpLqXUau81dwEu4A/e1w4CxUqpIyKyCHhZRGYrpY5bsCmlHgUeBSgvLzd0Dvu3yka+8cKHxz2/obqFqXmpIU8DfZFgs4QlBjgW09j0BZgbO9Fu4fKFhXzulDImmaSWs9kYUchKqbOHe11EbgSWA59SajBjsVLKCTi9jzeKyF5gGlARssUR4v2qw3zxj5t9pmtVDAbeWy0StnSucwsz6Hd52NvUxaz8dNISbRxo6eFge9+o27JbhT2N5nVq+eNI9/COLqtF+MLpk7nllLK4PkscDkL1Wp/HoHPrdKVUz5Dnc4EWpZRbRCYBU4F9IVkaQbbUtvH531XQP0zVvn2Hu8NS6mTGhDT6XZ5PVCDccXBQhHaLsLQsm2317fT0B5b0Lj3Rxsz89Jhych3l8DAe61SHjV9dvSCu46PDSahr5AeBNOBNEdkiIg97nz8N+FBEtgLPAyuVUqb8pO051MlNT60PSDgf1rUxPj34nFNWi9DldH2cvP1YBjyKddUtJCdYWVSSRXZKgs+DBXarMK8ok/lFGfT2u2NGxHlpjk8kwCvJ9p2IryAziee/sEyLeBSE6rWe4uf5F4AXQmk7GtS29HD9E+sCzhjZO+Bh2vhEn5UWAmFBUSYVNSOHSh7u6v9EErwEq5CWaCcpwUqS3cqhzj62hqGYWrQ4ZUoO910yh9KcFNp7B/i/bQd5aVM9/vxUD123kBkTzO9gNBNjI+zFB00dfVz7+LpRi3JrXTvF2ckcaBldxQSbRWhoDy6vc79bDXqkjctbFxKfXVxEqTcNbkaSnauXFHP1kmLe3tXEBz5mE/uP9DC3MDPaZsY0Y/L0U1tPPzc8uX7UYjxKyyi3ebJTEphbmEFD2+gdWbHOuJQEzvIzRT51ao5PJ9a2utiZbZiFMSfkbqeLm3+7gV2NnUG9f1xKwqiCQ8pLs3B5PFFLN2smROBnn5lHisP3xM9mtXDOzPHHPf/mjkO8uKmOps6x98UXLGNKyE6Xm5XPbGRzCKIKNMF6RpKdORPTqdjfSkevuaPCIsVNJ5WO6LA6d87xQt5/pIevrtrKY++YdqPDdIyZNbLL7eErz27hnx8dDqmdND+jy1AmpCdit4qpDyxEg2+dP2PEa4ZbC0/Ni//jh+FiTIzISim+/dI2Xt/eGPB7/KVrrWnpIcXhP4pqUk4KA24Pta3GFiwzA9YAct7mpDqY4KdK42QDEtnHKnE/IiuluP+1nayqqBvV+/x9BJs6nccFhlhkcMpdkJnEnsZOugIM5oh3egfcpFlHHitOnjKOrbXteJTCg0J5wKMUU8drIQdK3Av5129X8fi71WFtc311C0tKs3C6PLT2DHCwvZdDHc6g95fjlS/+cTMPXbdw2MP9vf1u3trVROsxe/kLijNJj+NaTeEmrqfWv/vXfn72tz1hb1cB6/e3srWunQMtPTFzXjnarN3TzDWPraN1mO26VRW1x4kYYHmcV4YIN3Er5Jc313P36kqjzRjzbKlt44qH36feR5Fzt0fx+LvHe6YtAsvn5kfDvLghLqfW/9h5iP9+bqvRZmi87G3u5oqH3uf/XbWALucAOw92suNgB5X17dS2HC/wxaXZjPVS/4sAAA02SURBVPfjANP4Ju6E/MG+I/zHHzaF7bihJjwcbO/jykf+FdC1F8V55cRIEFdT62117Xz+6QqccVysayygTz2NnrgRclVTFzc+td70ubU0w5NotzAxQ0+rR0tcCLmudfA44mgPM2jMR0l2ChLN4slxQswLubnTyfVPrA8qRY7GfJTmJBttQkwS00IecHu4/fcVVPvJuKGJPUrH+c4aohmemBWyx6O455VKZuSnc+7s40/QaGKTEi3koIjZ7ae7/7KdZz44AAweGXzrv0/nrAfWGmyVJlTmFmYYbUJMEpMj8nde3vaxiAHaewc464G1nD/HV/rt4Fhcmh22tjSBsXxuPnMKtJCDIeaE/Kf1Bz4h4qF8d/mskNuflZ/OqtuXcedL20JuSxM4DpuFOy+YabQZMUvMCfmcWeNJ9XO4/7on1pGSEFzFhTSHje33nMvhLidXPvKvMRsZJgKnTcvlqZsX88SN5eSkRicx/BfOmExBZlJU+opHxFscwhSUl5erioqRi1E8+NZHfk81Tc1L5fw5Ezj/hHyUgnteqRwx7/Mvr17As+sP8P7eI0HZHS9cPG8i//mpKUwZkpnjcJeTbzz/IW/taopInwk2C3ddMJMbTyqNSPvxhIhsVEqV+3wtFoXcN+DmjJ+uobEjsL3ji+ZN5IeXncD/vrmHN3ce4qTJOZw2NYdTp+Xy8Jq9PPh2VaimxzRpDhv3XTqHFfML/F7z+D/38T//t5NwTlTKclL41dUL9Lo4QOJOyADPVdTy9eePL7imGR0LijP55VULKMoeORDjjcpGvvzs5oCLrw3HpQsKuO+SOX4zbGqOZzghx9wa+SiXLyxkZr6uRhAK1ywt5rnblwUkYoBzZ0/gwasXhtRnkt3KT66Yyy8+O1+LOIzErJAtFuHbF4ycpVHjm7Nm5HHfijnYAsipNZSXttQH3WfpuGRe+dLJXFleFHQbGt/ErJABTp2ay2nTco02I+aYMSGNX169AMsoi4S/vauJ1z48GFSfGUl2nrxp8SccaZrwEZKQReQHIvKhtxLj30Rk4pDX7hSRKhHZLSLnhm6qb759wQy/xcA0x5OTmsDjN5b73cLzR0+/i++8vD2oPm0W4dfXLNRFyiNIqCPyT5VSc5VS84FXgbsBRGQWcBUwGzgP+I2IBLfBOwIzJqRzxaLCSDQddzhsFh65vpzCrNGfMHpozV6febcC4e6LZnHK1Jyg3qsJjJCErJQaWkohhcEEkwArgGeVUk6lVDVQBSwJpa/h+Nqnp496hBmLZKckMDFz9If2D3c5eTLIlMKXLijghmWlQb1XEzghr5FF5H4RqQWuxTsiAwVA7ZDL6rzP+Xr/bSJSISIVzc3NQdmQl57Il87yWapZM4SD7X1c+9g6mgLcfwfY29zFPa/soDuIpPuJdgvfPE87JKPBiEIWkb+LyHYfPysAlFJ3KaWKgD8AXzz6Nh9N+dywVko9qpQqV0qV5+YG77i65ZQyJufqI3Ajse9wN9c8vo7DXf6T6a/d08y3X9rGKT9+i089sJZXtjYE1dfNJ5cxQaftiQojClkpdbZSao6Pn9XHXPpH4HLv4zpg6B5DIRDcpyFA7FYL3794diS7iBuqmrq47nHfieMrG9q5+an1/HHdAepCqF+VlWznC2dMDsVMzSgI1Ws9dcivFwO7vI//AlwlIg4RKQOmAutD6SsQTp2aq5MMBMiuxk6ue2Id7cdUebjnlR1hCcP8zoWzdMmXKBKqh+hHIjId8AA1wEoApVSliKwCdgAu4A6lVFQqm313+SzW7mkOSxhhvFPZ0MH1T67ju8tnsW7fEdbsbqaipjXkdq8/sYTL9U5CVInZWOvh+PXbVfz0jd1hsEgzWspLsvjTbSdiH2XEmGZk4jLWejhWnj6ZhcX+C2hrIkNemoPfXLtQi9gA4vKOWy0yGJQfZJIBzeixW4WHrltInq7ZZAhxKWQYzMZ490Whp/7RjIwI/GDFHBaV6DxnRhG3Qgb47OJizpmlvdiRxG4VfnHlfK5aUmy0KWOauBYywI8vn0tumsNoM+KSJLuVx24o55IF/jOLaKJD3As5OyWBn1w+12gz4o7MZDt/uHUpZ0zXlRPNQNwLGQbLdJ49U0+xw8XEjESeX7mMhcVZRpui8TJmjgzp6XV4mJKXyu9uWcJEnbrWVIwZISfax8TkI6LML8rkqZsWk5USnVzXmsAZM0J22PSeciicPi2Xh65bSHLCmPnIxBRj5n9Fj8jBc8WiQn542Qk6YsvEjBkh6xF59IgMZl+540ydtMHsjAkhv191mBc31RltRkyRaLfw8yvnc8EJ+UabogmAuBfyva/s4Mn3gss3NVbJTXPw2A3lzC/SB09ihbgXsi6cPTpOKMjg4esX6cqIMUbcey8umjeR0nGjT/861khPtHHPxbN5+Y6TtYhjkLgXstUi/McZ2lnjD5HBOlpvfe0MbjypFKvO9h+TxL2QAS5dWKBHGR/MmJDGqtuX8cCV88hJ1ZFvsUzcr5FhMMPmNUuLdfofBguLnzNzPJcvKuD0aXl6BI4TxoSQYfDI3VhmQXEmly8s5KK5E8lI1tkt440xI2SPiZIMRouCzCRWzJ/I5YsKmawLqMU1WshxxHUnFrN87kTGpycyPt2h46LHEPp/OkocdSYNLdVSMi6ZOQUZzC3IYEJGInubu9l1sIPdhzo50NKDr++e8ekOLl9YyISMRNZVt7C+uoXmTidpDhvfOG+GTgo/RhkzQj575nge+NsenK7oJa5PsFo4Z9Z4PlNeyGlTc7FYhL4BN3WtveSmOoZdq3Y7Xew51Mmuxk52N3bS1tPPxfMnfsJBdbTK4b7mLo5092sRj2HiMkG9P97adYiPDnXxw9d3jXxxCMzMT+fK8kIumV+gz+5qwsZwCerHzIgMcNaM8Zw1Yzx9Ax5+8fc9YWvXIoPpd0+dmsOV5UXMKdBhoZroMqaEfJQvnz2VPpebh9bsHfV7HTYLsyamMzM/nVn5g//OzE/TjiWNoYzZT983z5vBleVFdPYNUN/ay3dXVw5bMxjgwhPy+e7yWbrmr8Z0hCRkEfkBsILBaoxNwE1KqQYRKQV2AkdDqT5QSq0Mpa9IUJYzWBh9bmEmJxRm8PmnK9jV2HncdSXjkrl3xRxOnxZ8IXaNJpKE5OwSkXSlVIf38X8Cs5RSK71CflUpNWc07UXa2TUSXU4XX/3zFiobOkhLtJHisHHq1BxWnj6ZxDEeGaYxnog5u46K2EsKYB4XeBCkOmw8eoPP+6TRmJqQTz+JyP0iUgtcC9w95KUyEdksImtF5NRh3n+biFSISEVzc3Oo5mg0Y5IRp9Yi8ndggo+X7lJKrR5y3Z1AolLqeyLiAFKVUkdEZBHwMjD7mBH8OIyeWms0ZiakqbVS6uwA+/kj8BrwPaWUE3B6379RRPYC0wCtUo0mAoQ0tRaRqUN+vRjY5X0+V0Ss3seTgKnAvlD60mg0/gl1H/lHIjKdwe2nGuDoFtNpwL0i4gLcwEqlVEuIfWk0Gj+E6rW+3M/zLwAvhNK2RqMJnDGRs0ujiXe0kDWaOEALWaOJA0x1HllEmhl0mpmJHOCw0UYcg7YpMOLNphKllM+Af1MJ2YyISIW/TXij0DYFxliySU+tNZo4QAtZo4kDtJBH5lGjDfCBtikwxoxNeo2s0cQBekTWaOIALWSNJg7QQvYiIkUi8raI7BSRShH5svf5bBF5U0Q+8v6bZQKbvi8i9SKyxftzQRRtShSR9SKy1WvTPd7njbxP/mwy7D4Nsc3qTbDxqvf3iNwnvUb2IiL5QL5SapOIpAEbgUuAm4AWpdSPRORbQJZS6psG23Ql0KWU+lk07DjGJgFSlFJdImIH3gW+DFyGcffJn03nYdB9GmLbV4FyIF0ptVxEfkIE7pMekb0opQ4qpTZ5H3cymAW0gMEsoU97L3uaQSEZbZNhqEG6vL/avT8KY++TP5sMRUQKgQuBx4c8HZH7pIXsA28W0AXAOmC8UuogDAoLyDOBTQBfFJEPReTJaE5jvbZYRWQLgymQ31RKGX6f/NgEBt4n4H+BbzB4Xv8oEblPWsjHICKpDJ6l/spIOcaihQ+bHgImA/OBg8AD0bRHKeVWSs0HCoElIjKqtMdRtMmw+yQiy4EmpdTGaPSnhTwE7/rqBeAPSqkXvU8f8q5Vj65Zm4y2SSl1yPvB9QCPAUuiadNRlFJtwBoG16KG3idfNhl8n04GLhaR/cCzwFki8gwRuk9ayF68DpMngJ1KqZ8PeekvwI3exzcCq499b7RtOvpB8HIpsD2KNuWKSKb3cRJwNoO52oy8Tz5tMvI+KaXuVEoVKqVKgauAt5RS1xGh+6S91l5E5BTgn8A2/r2m+TaDa9JVQDFwAPhMtPKPDWPT1QxOFxWwH7j96LorCjbNZdBJY2VwIFillLpXRMZh3H3yZ9PvMeg+HWPfGcDXvF7riNwnLWSNJg7QU2uNJg7QQtZo4gAtZI0mDtBC1mjiAC1kjSYO0ELWaOIALWSNJg74/3hyiNeku1dIAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
     }
    ],
    "source": [
-    "import json\n",
-    "geopandas.GeoDataFrame().from_features(json.loads(topo.to_geojson())['features']).plot()"
+    "topo"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"15.700290610423913 -34.781206915019396 17.406528222725868 13.334580387423138\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,-56.227833442615655)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.34813056445451734\" opacity=\"0.6\" d=\"M 19.895767856534434,-24.76779021576059 L 21.605896030369394,-26.726533705351756 L 29.43218834810904,-22.091312758067588 L 31.19140913262129,-22.2515096981724 L 32.46213260267845,-28.301011244420557 L 25.780628289500697,-33.94464609144834 L 18.377410922934615,-34.13652068454807 L 16.344976840895242,-28.5767050106977 L 19.894734327888614,-28.461104831660776 L 19.895767856534434,-24.76779021576059 z M 28.978262566857243,-28.95559661226171 L 28.074338413207784,-28.851468601193588 L 26.999261915807637,-29.875953871379984 L 28.107204624145425,-30.54573211031495 L 28.978262566857243,-28.95559661226171 z\" /></g></svg>"
+      ],
+      "text/plain": [
+       "<shapely.geometry.polygon.Polygon at 0x163035156c8>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# import json\n",
+    "# geopandas.GeoDataFrame().from_features(json.loads(topo.to_geojson())['features']).plot()\n",
+    "topo.to_gdf().iloc[0].geometry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x24fd7754688>"
+       "'POLYGON ((19.89576785653443 -24.76779021576059, 21.60589603036939 -26.72653370535176, 29.43218834810904 -22.09131275806759, 31.19140913262129 -22.2515096981724, 32.46213260267845 -28.30101124442056, 25.7806282895007 -33.94464609144834, 18.37741092293462 -34.13652068454807, 16.34497684089524 -28.5767050106977, 19.89473432788861 -28.46110483166078, 19.89576785653443 -24.76779021576059), (28.97826256685724 -28.95559661226171, 28.07433841320778 -28.85146860119359, 26.99926191580764 -29.87595387137998, 28.10720462414542 -30.54573211031495, 28.97826256685724 -28.95559661226171))'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topo.to_gdf().iloc[0].geometry.wkt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x16303524dc8>"
+      ]
+     },
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPIAAAD4CAYAAADW87vCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO2dd3ydZd3/398zcrJ32qTZ3XumLWWWoZS9N1JQZKiP+qiPCCiKyu9x4PgpAjJERBAreygIQquCtE266CadSZpmNHufcT1/JIG0PSc5Oeu+z8n1fr3y6sm573Pd39y9P+da3yFKKTQaTXRjMdoAjUYTPFrIGk0MoIWs0cQAWsgaTQyghazRxAA2ow0YSnZ2tiopKTHaDI3GlFRUVDQqpXK8HTOVkEtKSigvLzfaDI3GlIjIAV/H9NBao4kBtJA1mhhAC1mjiQG0kDWaGEALWaOJAbSQNZoYQAtZo4kBtJA1mhjAVA4hmujB5fZQ29pDVXMX1c3dAz9dHOnoY15BGssmZbOgKJ14u9VoU8cEWsiaEWnq7OP5imp21bVT1dQv3MNtPbg93pNSrNndwK/eqSQrKY67zp3BpQvzEZEIWz220ELWDMtTHxzgh69tp9flGfVnj3T28fW/bObP5VX84KLZTMtNCYOFGtBzZM0w9Djd/OKt3QGJeCjr9jVx9i//ycrfreMfO+p89uSawNE9ssYnL2yooamzL2TtrdndwJrdDUxIi+fUqTmcNDmbEydlkZXsCNk1xipayBqveDyKx/+9NyxtH2rt4dn1VTy7vgqAGXmpnD83jxtPLCHJoR/JQNB3TeOVNbsb2NPQGZFr7ahtY0dtG0+8t4//OmMK1ywpIs6mZ32jQd8tjVcaOnojfs3Gjj6++8o2zvjZat7Yejji149mtJA1XrlkQT5FmYmGXLu6uZvb/ljBUx/4jKPXHIMWssYrdquFL585xVAbvvPSVh5avcdQG6KFoIQsIleIyDYR8YhI2THH7hSRShHZJSJnB2emxggunj8Bh8Fz1R+/sZOfvLETXRFleIL9X9oKXAr8c+ibIjITuBqYBawAHhQR7asXZbT3uILeQw4FD67eE7GFt2glKCErpXYopXZ5OXQR8KxSqlcptQ+oBJYEcy1N5NnbaB7xvLOzzmgTTE24xk35QNWQ36sH3jsOEblFRMpFpLyhoSFM5mgCYZ+JhPz2jnqjTTA1IwpZRN4Wka1efi4a7mNe3vM6yVFKPaKUKlNKleXkeE3ZqzGIvQ0dRpvwMRUHmmnpCp2XWawxokOIUuqsANqtBgqH/F4AHAqgHY2BmKlHdnsUa3Y3cNF8rwO7qKOps4/MpLiQtReuofUrwNUi4hCRUmAKsC5M19KECTMJGWJjeO3xKB77114+/Ys19DjdIWs32O2nS0SkGlgGvC4ibwIopbYBq4DtwBvAF5VSobNaE3Y8HmU6IXf3uYw2ISgaO3r57JPr+eHrO2js6OPdnaH7YgrK11op9SLwoo9j9wH3BdO+xjgOtXabYutpEIfNwnfOn2m0GQHz748a+e9Vm2ho/8T19cWNNZwzJy8k7eugCY1XDhzpMtqEo7hmSRHFWUlGmzFqnG4PP39rNw+v2cOxPi276tpDdh0tZJOxv7GTe1/dRkZiHJ8/dSIz8lINsaO62VxCPnFSltEm+I1Sih217by8qYZXNh+itrXH63kJIcxnpoVsMooyE9l5uJ3a1h5m5KUaKORuQ67rDRFYUppptBkjUtXUxSubD/HSxho+qh956y4hTgs5ZrFYhFOn5PDn8ir+VdlIUVYinb0uOvvc2C1CcVYSpdlJjE91hDWhXY2JhDwjN5X0xNBt1QSKUoqtNW1YLP1z9jirFRFYvbuBlzfWUH6geVTtJWohxzaDq8X/3N3AP3d793ZLsFspzU7i4esXUZQV+nBDM/XISyca3xv3ON184y+beW1Lbcja1EPrGKbX5WZTdcuI53U73WyvbeO/nt3IX25dFvKMGmaaI58w0b/5cXNn38dz0rq2Hmpbu6lr66W9x8ns/DQWl2RSVpzBvMLR5duub+/h83+oYHPVyP8voyEhLnTy00I2GVtr2ugbxbbP5qoW7v/7Lu46d8aI57b1OHnqPwf43Mmlwz7ITreHw23eF2iMoCAjwa/znquo5r6/7vB6bPWuBlbv6h/d2K3CnEFhD4g7yWHjhQ3VPLu+irYeJ71OD91ONz1ON91O93ErzqEgwR66L18tZJMRSKrYR/65l/Gp8SybmMWkcUk4bEeLtKvPxe/f389v1+yltdtJToqDK8sKfbQGbd1O7FaLafaRt1S3MmtC2ojnPb+h2q/2nG7FhoMtbDjYwm//2Z9gMMVho703sg4nVkvo1ji0kE1GWXEGBRkJo56j/uC17UD/w1GancS08SlMy03BahGeeG8fjR2fBBz8/r39XLGowOdiWVayg7995RS++dyWUS/ghIP1+5u4ZknRsOdsO9TKzsOB78tGWsQANS2hG/XoVD8mw2IRLltYEPDn3R5FZX0Hr39Yy8/f2s1P39x1lIgBtte2jSjQiTnJrLp1GT+/ch55afEB2xMKKvz4MnlhQ00ELAktB46EzgVWC9mEnDMnN+zX+Oqzm/jGXzbz+L/38X5lI81eEtFbLMKlCwt45+vL+Z+zp5E0ZLskNzU+pNsnw3HgSBf17b57L5fbw8ubok/I1c3dON2hmb7oobUJWb+vKezXqGnp5rmKo+eUuanx3HraRG46qfSo9xPirHzx9MlcWVbIL9/ejcutuPv8GVz+0PvsrotMzHLF/maffskHm7qOG3VEA26Poqa5m5Ls4F1PtZBNhlKKZ9ZVjXxiGDjc1sO9r25nXEo85809XjQ5KQ7uu2TOx79nRNBJo7Xb6fNYcVYSSXFWOvuiL8Bu/5HOkAhZD61NRn17Lztq2wy14b9XbfJrXhrKwPjhuHpxIVct9r3KbrUIcwpGXtU2I/tDFCqqhWwyxqU4yE421h2xz+Xh838op6Zl+JXzjAgI+VMzx/PDi2eP6I46vzAj7LaEg6Yu3yON0aCFHAaUUtS19VDf3kNDey9HOnpp6uyjpauP1i4nbT1O2nucdPa66O7rdzrodbnpc3lwexSLS4x3SWzq7OPLf9o47GJMZpiH1laL8OPL5mKzjvyYLihKD6st4UIvdpmYHqeHpf/vH0abETQVB5r52d93861zpns9np5oD+v1l03M8nv4vqAwOoU8Gi++4dA9chhweczhERUKHl6zh3d3eU9JE+458mi24calxjPB4P3uQNA9somJIR0D8LU/b+LGE0uxWvr3li0iWEWo9CPmNlBE4NMzR7efPr8onUMfRlcVx1D1yFrIYSCWemSA5i4nv3h7d0SvuaQkk5wUx6g+M78wnb9Gm5B1j2xeAgl80BzNObNH7922sCiDFIeNhDgrvS7PsHvPZsHpDs2zooUcBty6cmDQrJg9+uySZSWZfHhvf+HPlq4+PvdkuV/74UbS5wqNE4te7AoDrhB9y45lvvB0Bat31QdcTjU9MY6nb17Kp2eOD7FloSVUPbIWchjQQ+vg2XCwhRufWM/Fv3kv4ETu8XYrD12/yNQZOEO1aq2FHAZcWshBM3lcEktKM+lze7jlqXK+89LWgB56q0X43oWzQhrEH0pClbxBz5HDgEfPkUfNuBQHRZmJuJViT30HlfWdwCd+yE99cIC9jR08eO0i0kbpiDJ1fAqfOaGY37+/P7RGh4COntAkNNA9chjQc+SRSbRbmFuQxpKSTPIzEqhv76X8QDMbD7bQ5uPhfq/yCJc8+N7H5V47e10c6ej1eu6xfPWsKWH3RAuE7bVtI/q0+4PukcOAniMfjwCTxyWTmRRHS7eTyvoOtlS3jrqdvY2dXPyb91g2KYs1uxuwWy3cfe4MrlpcOGxgRXpiHF//1FS+8/K2IP6K8PDKpkPcvnxSUG0EW43xChHZJiIeESkb8n6JiHSLyKaBn4eDsjLKiDWHkEDJTXVQVpLB/MJ0kh02PqrvYO2+JnYdbg/qy66tx8Wb2+rocXpo73HxrRc+5JpHP6CtZ/h942uWFFEShhzgwfLixuqAV+cHCbZH3gpcCvzWy7E9Sqn5QbYflYzVOXJynJVJ45KJs1mpae7iUGsPh9v8G/oGywd7m9h+qG3YHNg2q4VJOcnsN1mButrWHpxuRZwt8AW5YMuq7gDCWrokGhmrc+SpuSlsOBjaJO6jYX9j54jJ7NMSzDdPvnxRQdAFBsK52FUqIhtFZI2InBLG65iOsTpHtvsRNxxO/Emqn2pCIX/mhOKg2xixRxaRtwFvjq93K6Ve9vGxWqBIKXVERBYBL4nILKXUcTlsROQW4BaAoqLhcxdHC2PVRdPoL7Dz/CgabjYhnzIlm4k5yUG3M6KQlVJnjbZRpVQv0DvwukJE9gBTgXIv5z4CPAJQVlYWEwoYqw4hHQYkeR/kjOnjmDI+ZcTzzDa0DkVvDGEaWotIjohYB15PBKYAe8NxLTPiHqNz5CYvubEjxedPmejXeWYScmFmAmfOCI0veFCLXSJyCfBrIAd4XUQ2KaXOBk4Fvi8iLsAN3KaUCn+yZpMwlnrkFIeNgswEUhw2PB5Fa7fTkJpR/ubsMpOQv3n29JC5jga7av0i8KKX958Hng+m7Wgm1refclPjyUtzUNPSM5C+95OaS5NyktjTELpSKP5S19ZDcdbI+aHNIuQFRemc7yV3eKBoF80wEMs98qLiDNq6+9hY1Up9+/F7xOnHZNa0WYQEu5WEMJeXOdzqX0E0swj52+fNCOm2rXbRDAPuGPTsSkuwU5KdOGKg/ofVLSTaLTjdCqdH4fIoXJ7+4Pm5+Wn0uT1BVU30hT9bT/saO3lodWXIrz1azp2Ty6Li0KY81kIOA2b51g8VNovgsFnYXDWyb3SfW9HnY7FvS03/5yfnJOH0KA6E0MOqbhghVzd38ZM3dvHalkMYPVhKsFu5Y4X39MLBoIfWYeD0aeO4ZonvEifRxsy8VK/D6ECpbOikq9cd0ooa7+5soMfpPW3O//51J69sNl7EyQ4bf/jcEr/m8qNFCzkMiAj3XjibJaXGV4wIFqtFsIQhKL+hoxeHzcKS0gzKijOYnpsS1Dz6P3uP8Lkn19N5zF52dXMXf9taG6y5QZMSb+Opzy0JWxURLeQwEWez8NB1CynISDDalIBYXJLB9NxkrAKbqsLjP13T0sO6fc2UH2hm5+F24m0WFgZR+uW9yiPc8Lt1R2XPfPL9/Yb3xOmJdp65+QQWFIWvPpUWchjJSnbw6A1lESsIHiqWlGSyfn8zOw93+JzvhoPmLicbDrYwMy+V/AC/ACsONHPtox9wpKOXjl4Xz643pkTtIJlJcTxz8wlhrxaphRxmZuSl8ouroiOaUwTKijNYt99Y353ttW3Ut/YEPIfedqiNK3/7Hx58t5L2EKXSGS1xVguXLMjnuduWMXNCativp1etI8DZs3K5Y8V0fvzGTqNN8YnVIswtSKPcJHmgnR4VVDTVnoZOHly9J4QW+Ud+egLXn1DMlWUFZCWPrlJGMGghR4jBVC5mFLPdKszIS2WjgbHE0c5pU3O4YVkxy6eNMyRjpxZyBLl9+SQS7Ba+9+p2o035mAS7ldLsxIDyZ4Ubs6erSHbYuKKsgJXLSijJDv2W0mjQQo4wN55USkKclW+98CHeXLJzUhwsLc2kz+WhsaOXI519NLb30tkXmtIiQ0mwWynITGB7beg9rWKZidlJrDyxhMsWFZDsMIeEzGHFGOOqxUXE2618bdVmrCKUlWRw2tQcTp2aw/TcFK8+uFVNXfzkzV28uvlQSGwQgSnjkj/2tjIlJuuSl0/L4cYTSzh1Sk5Y9taDQYLN3hdKysrKVHn5cbkHYpbK+nYmpCeQGOf/92n5/ia+tmozB5uCc29cXJLB+v3mWNjyxYT0eA61+BcMES6sFuG6pUWsPLGESSHI5BEMIlKhlCrzdkz3yAYyedzIGS2G4nR7aOzoY1puCgl2Kwebu+gOYMgdDSI2A3ar8OtrFrIigBKvkUYL2SA8HkW3002SH3OsqqYunl1/kFXl1TQM+Dwn2K396VPtFjKT4kiJt5MQZ8VuERDB7VYcbu+hpvnoKgZz8lMpjxIRi4Fj63i7hd9+pozTpuYYZsNo0EKOEB29LjZXtVBxoJmKA81sONhMZlIcf7ltGeNS4o869+CRLu55ZStrdjd4XRAD6Ha6mVuQydp9TdS09ADeh6CTcpI+3s9USrGtphXzTKaGx6gEDckOG4+vLGPpCKl1zYQWchhQSlHd3M2Gg/2iLd/fzM7Dbcf5/Lb3uLjh8XX8+ZZlpCXa6XW5eWTNXh54t9KvdDnbDrWRHGelY5jh9Z6GTkMydgRLRqKdWj+TBYSStAQ7f/jsEuYVBu7zbQRayAGytaaVfY2ddPe56exz0dXnprvPzZ6GDioONPsd9rfzcDuffXI9Xzp9Mj94fTt7RyG6jl4XS0v7e+VYY2JO8ohJDEJNdrKDP968hOm54XepDDVayAHy6L/28vKm0GwFVRxo5qbfrw/os4NRQz0GJLwLKxEeVU9Ii+ePNy8NSY5pI9BBEwFidGjcIK3dTuYWhjeyxggqB0qnRoKSrERW3bYsakUMWsgBY6ZMmRUHWlhUHL5Y10gzKSfpqJjicDK3II1Vty6jIMN8VRpHgx5aB4jHLF0y/aVaKg40Mzs/la01x1XliToiUdZlYVE6Xzx9MmdMHxcTRQi1kAPETD3yIB0Gxd6GGmuYhfW9C2ay8sSSmBDwIHpoHSAm6pA/Zv+RLhYVR9e2iTcsYXwq7zl/JjeeVBpTIgYt5IAxk4/6UKqaurFbo/shDZdH193nzuCzJ5eGpW2j0UIOEDP2yAD17b1hTfIWCcLxHXnHiul8/lT/Cr1FI1rIAWLGOfIg6/Y1sTSKU/GGetT79U9N/ThDS6yihRwgZu2RB1m7rylq82rvONxGUggyj6bE2/j+RbP4rzOnhMAqcxOUkEXkpyKyU0S2iMiLIpI+5NidIlIpIrtE5OzgTTUXZp0jD2XdviaWhCkhejhp63YxKz9wJxerRbjxxBLW/M/p3LCsJHSGmZhge+S3gNlKqbnAbuBOABGZCVwNzAJWAA8OFj6PFcw8tB7Kuv1NlJVE35w5mC/K20+bxPcunEVmUuhK0pidoISslPq7Umpw8/IDoGDg9UXAs0qpXqXUPqASWBLMtcyG2+xj6yGU72+OOs+v5q7APbuKMqPbSysQQjlH/izwt4HX+cDQFP/VA+8dh4jcIiLlIlLe0NAQQnPCSxTpGOgPzFhYlG62NFhesQhBpTKakB6dZXqCYUQhi8jbIrLVy89FQ865G3ABTw++5aUpr4++UuoRpVSZUqosJyc6sjFAdMyRj2XDwRbmFaZj9m3mwowE+oKI5pqQHj/ySTHGiC6aSqmzhjsuIiuB84Ez1SdPdzUwtK5oARCamD+TEG098iCbqlqYk59Gt9PNnvoO02ULmZSTRLeP8qj+onvkUSIiK4A7gAuVUkPHQq8AV4uIQ0RKgSnAumCuZTaiZbHLGx/WtFJZ30FCnJU5+Wmm6qGTHLagMmfareKzTnIsE+wc+QEgBXhLRDaJyMMASqltwCpgO/AG8EWlVEzd3WjtkYfS1efmw5rWoGoshZL0RDvbDgUXveV0K370N/OV5Qk3QUU/KaUmD3PsPuC+YNo3M9E4R/aFWeIHpo5PYV0I0hY9u76KSxcWRK1DTCCY46s4ConmofWxlBpct2iQIx3+5Tnzh7te/JBeV0wNAodFCzlAPDGUIstigi65MCMhpNk+K+s7eGTN3pC1Z3a0kAMklnrkrYfaDO2V46ziV6L+0fLrdyvZ1xh9qYADQQs5QGJJyNC/0GQEVoFpuSnsPBz6ipB9Lg+/XRP5YudGoIUcILGwaj2UzVUtTM9NifhW1LzCdD4MY56xN7cdxumOoXmQD3TOrgCJtR7Zo/pzZNutQmlWEhmJdpSCps4+9oZpeBqJYnLNXU7e33Mkamo4BYoWcoDEmI4/xulWVNYfnVN61oRUDrf2cKSzL2TXiWSFjNe3HNJCHqvUtfXw8Jo99Dg99DrddDvd9Djd9Dg99Ljcx1U5jGW2HWojLcHOvMI0NlcFXxh9SUlky9ys3hU9wTiBooXsg8aOXp54b7/RZpiG1m4nm6taKSvOYGtNa8AlahYVZ7Buf2RrVbX1RCbZvZFoIWtGxcGmLuYVptPZ58IiglUEm1XYebid9iF5tQsyErBahKqmro8XBucWpLHxYORrM/c4Pdz/5i7OmDGOhVGemNAXWsgav8hMimNSThIbD3qvNGmzwNz8NBLirDS09368QGa3ChOzEslOclBxsNmw1f4H3q1kURRmSvEXLWTNsKTG25iel8rmquZhV5hdHthSc/z8uX/xrJNKOinKTAwqYUCwOEwSHBIOYvcv0wRFYpyVpaWZeDyKdfua6HUF35XmpRkb8O+wx+7jHrt/mSYg4mwWlpRmYLcKa/c10dEXusCDaoNX+uOsMZX/8Si0kDUfU1aSQYrDxrp9zbR2h74gXE1Lt6E+3bpH1sQ0DpuFBYVplO9vDqnThzfGpTjC2v5wxMXwHFkvdo1xspPjSEuwszEEjh7+cOCIcdFIKfGx+7jH7leUZkQmj0vGowhpHPBIHG7rZfK45Ihdb5AFRelkJRs3Ggg3sfsVpRmWBUXpbK1pxemO/MZuZmLkK0BcOG9CxK8ZSXSPPAZZWprJxoMthogYiHiwv0XgvLl5Eb1mpNFCHmNEMurIFw0dvUwbnxKx63kUPPjunpjO4aWFPIbITo5jgwG+zt5ITYjsrO737+/ngXcqI3rNSKKFPIaYmJNs2HD6WAaTGESS06ePi+j1IokW8hghOznOkMgjX7T3uJg1ITVi1yvOSmRBYfrIJ0YpWshjBDP1xoNEKsuK1SJ89awpiAnS/oYLvf00BijNTjRVbzzItkOtpCXYae0OX+B/ssPGA9cuYPm02B1WgxZyzJMab6O7z2263hj6Qx8npMeHTcj56Qn87sbFTMuN3Aq5UWghxzAWgcLMBLYdCn3O6FDR4CVJQbDMzEvl+hOKuWj+hLAkvjcjQf2VIvJT4AKgD9gD3KSUahGREmAHsGvg1A+UUrcFcy3NyOSkOCjNTsLjUbT3uKhr7zG1iJPirDR2hCZII85m4fy5eVx/QjELCtNjej7sjWC/rt4C7lRKuUTkx8Cd9NdLBtijlJofZPuG4XR7WFqayYaDzaYclnpjYnaS4c4eoyEvPeG41LujJT89gZUnFnPFokIykiLv+mkWgi2r+vchv34AXB6cOebgiff2se1QG2v3NZGfHk9Ll5POEAbYhwOLwEdBiiLSpCUEXqZmXkEaN58ykXNm52KL4fBEfwnlHfgs8Lchv5eKyEYRWSMip/j6kIjcIiLlIlLe0GB8/uEXNlTz/de2f7w1UtPSw8wI7ncGyswJqTSFOZY41Ngsoxv+isBZM8bz51tO4KUvnsQF8yZoEQ8wYo8sIm8DuV4O3a2UenngnLsBF/D0wLFaoEgpdUREFgEvicgspdRxRX6UUo8AjwCUlZUZOoZ9a3sd33xuy3H7m+v3NzN5XHLQw0Bv2K0SkqF7NCaW63b6N8px2CxctqiAz51cyqScyIdARgMjClkpddZwx0VkJXA+cKZS/RJQSvUCvQOvK0RkDzAVKA/a4jDx/p5GvvjMBlw+8rW6PQqLhK5425z8VPpcHvY0dDAzL5XkeCsHj3RzuK1n1G3ZLMKuOvMuavniyAgLXRaB25dP4rMnlcZ0LHEoCHbVegX9i1unKaW6hryfAzQppdwiMhGYApi26vTmqhY+/2Q5fcNUT9jX2BmSyKFp41Poc3uOqkC4vbb/tc3SH520paaVbj/n5CnxNmbkpbIuiha5Bmns8L31lBRn5dfXLuCM6eMjaFH0Eux47AEgBXhLRDaJyMMD758KbBGRzcBzwG1KKVM+aR/VtXPjE+v8WszaXNUSVM4pi0Bnr8tnPK7LA2v3NZFot7KwKJ2MRLvXwAK7VZhXmM68gjS6+1xRI+KcFMdRebOKsxK9npefnsBzt5+oRTwKgl21nuzj/eeB54NpOxJUNXXxmcfX0dzln2dRj8vD1NR4r5UW/GFBUQYVB0Z2lTzS2XdUErw4q5DssJPosBJvt1LX1sPmqpaAbDCCkyZncd/FcyjOSqSt28XrH9by4sZqLD72eh+8biEz8sy/wGgmxobbixfq23u4/vG1o56TbqlppTAjgapR5mi2WoRDLYHlde5zK5q6+jCwSENQXLW4iJKBNLhpiXauXVrEtUuL+MeOOq9TlQMD9aU0/hN9S50hoLXLyQ2Pr+PAkcCUMdptnoxEO3PzU6ltHf1CVrSTmRTHGT7igE+dmkNG4vF7yVuiaLRhFsackLv6XNz0+3XsPBzYKm9mYtyonEPKijNweVTE0s2ajfuvmEuyD39nu9XCp2cev7P51o46nq+opj6AFfyxypgScp/Lw61PVbDhYODf+ONS/VvsSo23MWtCCuUHmo8qNzqWuOmkkhEXrD496/jjB4508fW/bObRf5l2o8N0jJk5stuj+OqfN/KvjxqDasdX7zKU8akO7FaLqQMWIsEdK6aPeM7cAt9zYSPyX0crY6ZHvuuFD/nrh4f9Pt9X8MyBI10kxvkuBlaanYTTrQwvWGYGrH64YOakOMhN9V6lcfK42I8jDhVjoke+7/Xt/Lm8alSf8fUINnT0sqQkg3VDagWL9Nc0mpCewO7D7aYPsIgU3U43dj9cR0+cnMXmqhY8CpRSH/87Oce4gm/RRswL+TfvVvLov/aFtM11+5tZXJJBr8tDS5eT2pZu6tp6qWsLfZB8NPOlZzby0HULhw3u7+pz8c7OelqO2cufX5hOmgEVKaKVmB5aP/Wf/fz0zV0jnhcI6/c3s6W6lYNNXThD5YAdY/xzdwPXPrZ22O26VeurjhMxwAUxXuIl1MSskF/eVMM9r2wz2owxz+aqFi5/+H2qm4/fs3e5PTz27+NHSyJw3pzYLvESamJyaP3Ozjq+vmpzxNKtaoZnb0Mnlz/0H/7/1fPp7HOx/VAbO2rb2Xqo1eui4JKSTMUOiUQAAA1YSURBVHLTvC+AabwTc0Jeu/cIX3jadziixhgOt/Vw1SMf+HWuHlaPnpgaWm+taeXmJ8vpcfoOR9SYn+XTcow2IeqIGSHvaehg5e/W0d47Nr2oYgWHzcKEtASjzYg6YkLINS3dfOaxtUeF/mmik5KsJCyjzOWliQEhN3b08pnH1nJoDEYWxSK+kg1ohieqhexy9wdB7PWRcUMTfZRma2+uQIhaISul+O4r25g6PoUVs7wl+dREI8VZWsiBEJXbT0opvv3SVp5eexDoDxl89xvLOf3+1cYapgmauQVpRpsQlURdj3ysiAHaelycfv9qzp0Tup55cWlmyNrS+Md5c/OYna+FHAhRJ+Q/ras6SsRD+fZ5M4Nuf9aEVFbduoxvPb8l6LY0/hNns3DnOSPHL2u8E3VC/tTM8ST5iAe+/rG1fgX+eyMl3sbWe8+mvr2XK3/7n5Aloo9GTpmSzRM3LeaxG8rIilBhtNtPm0RBhl6xDpSomyPnpDi47bRJ/Oyt3ccd29vYyeRxyZw7O5dzBpzu7311Gx/sHT7v86+uWcCf1h5k9nffDIvN0cIF8ybw5TMmM2X8JwH9bxSeyjef28y7u8JTlyvOauGuc6ez8sSSsLQ/VhBlosiCsrIyVV4+clWZ7j43y+9/1+/43wvmTeB/L53DL9/azds76lg2KZtTp2RzytQcHlpdyW/e3ROs6VFNssPGDy+ezcUL8r0eV0rx+L/3cd9fd4Q0EKUkK5EHrl2o58V+IiIVSqkyr8eiUcgAq8qr+OZzeh4bLPML0/nV1Qso8sMR442th/nKsxvpHaa0jr9cPH8CP7xkTsBTobHIcEKOujnyIJctLGB6rs7pFAzXLCniL7ct80vEACtm5/LAtQuDuma83cJPLpvLL66ar0UcQqJWyFaLcNe5M4w2I2o5fVoOP7x4tl85tYby0qaagK9ZnJXIq186mSsXFyK+shtqAiJqhQz9lQpOmZJttBlRx7TxKfzqmgV+Zbkcyjs763h9S21A10yNt/G7GxcftZCmCR1BCVlEfiAiWwYqMf5dRCYMOXaniFSKyC4ROTt4U71z17kzfKau1RxPVlIcj60sIyX++FItw9HZ6+I7LwWWOslqEX5z3UJdpDyMBNsj/1QpNVcpNR94DbgHQERmAlcDs4AVwIMi4jsZdBDMyEvl8oUF4Wg65oizWXjkhkUUZo5+v/ah1XuoCbAI3T3nz+SUKTpZQDgJSshKqbYhvyYBg0vgFwHPKqV6lVL7gEpgSTDXGo5vnD3Np5OI5hMyE+PICyBov6G9l9+9F1hK4YvnT+CGZcUBfVbjP0HPkUXkPhGpAq5joEcG8oGhGeGrB97z9vlbRKRcRMobGgJzOhifGs+Xz5wS0GfHEofberjusbXU+VkcTSlFZX0H9766ja4Aku47bBbuOGe6XtiKACMKWUTeFpGtXn4uAlBK3a2UKgSeBr40+DEvTXndsFZKPaKUKlNKleXkBD78uumkUibqygQjsq+xk2sf/YCGYYq1r95Vz10vfsjJP36Xs36+htcCXOC66aTSgEYAmtEzopCVUmcppWZ7+Xn5mFOfAS4beF0NFA45VgAcCo3J3omzWfjeBbPCeYmYYU9DJ9f7SBy/taaVm36/nmfWHgx4TgyQnmjn9uWTgjFTMwqCXbUeOp69ENg58PoV4GoRcYhIKTAFWBfMtfzh1Kk5nO2lTKfmeHbVtXP9Y2tp6fpEzEopvv/q9pC4YX77vJmkJYxuZVwTOMG61vxIRKYBHuAAcBuAUmqbiKwCtgMu4ItKqYhUNvv2eTNZvashJG6Esc722jY+8/g6vnP+TNbuPcLq3Q1UHGge+YMjcP0JRVy+SO8kRJKo9bUejgfe+Yj7/358dJQm/CwqzuBPnz+BOFtU+xqZkpj0tR6O206bxIIi3wW0NeEhJ8XBg9ct1CI2gJi84zarhV9eNX/YguSa0GKzCA9dt5DxPoqWa8JLTAoZ+rMx3nN+8Kl/NP7xg4tnU1ai85wZRcwKGeCqxYWcNUOvYocTm0X4xVXzuGZJkdGmjGliWsgiwo8vm0N2ssNoU2KSeLuFR1eWcckCvUJtNDEtZICsZAc/uXyO0WbEHGkJdp6++QROnzbOaFM0jAEhA5wxfTxnzdAPXKjIS4vnuduWsag4w2hTNAOMmVwrOSl6eB0KJuUk8YfPLSU/XftQm4kxI2SHTW9FBcu8wnSeuHExmRHKda3xnzEj5Hi7FnIwnDo1h4euW0iSTphnSsbM/4pDexsFzGULC/jfS+dojy0TM2aErHvkwPifs6fxheWTdHIAkzMmhPxeZSPPb6g22oyowmGz8PMr53Pe3DyjTdH4QcwL+d5Xt/HEe/uNNiOqyE528OgNi1hQpLeXooWYF/K8Ah0FNRpm56fy8PWLdGXEKCPmVy/On5tHsZ8lUcYyKfE27r1wFi994SQt4igk5oVss1r4gs4dNSyXLSzgna8vZ+WJJdhGWUJGYw7GxP/aJQsKtCeSF6bnprDq1mX87Mp52vMtyon5OTL0Z9i8ZkmhTv9Df2Hxs2aO47KFBZw2NUf3wDHCmBAyQGLcmPlTvTK/MJ3LFhVwwdw80hO1i2WsMWaebo+JkgxGiglp8Vy8IJ9LFxYweZwuoBbLaCHHENctLeKCeRMYnxrPuBSH9oseQ4yZ/2mjdZyd3D+cbez4JCF8UWYicwrSmJOfRl5aPHvqO9h5uJ2dh9s52NTltZ1xKQ4uW1RAbmo86/Y1sXZfE40dvSQ7bHxzxXSdFH6MMmaEfNbM8fzsrd30RTBxvd0qfHpmLleUFXDKlBysFqG7z01NSxfZyY5h56odvS5217Wz63A7O2vbaOl2cuG8CUctUK08sQSlFPsaO2ns6NMiHsPEZIJ6X/xjRx0f1Xfwo7/tHPnkIJiem8JViwu5aH6+jt3VhIzhEtSPmR4Z4MwZ4zlzxnh6nG5++fZHIWtXBEqykjh5cjZXlhUyOz9VRwtpIsqYEvIgXzlzCj1ODw+v2TPqz8bZLMzMS2XmhFRm5KUyMy+V6bkpemFJYyhj8ukTEe5YMY0rywro6HVR3dzNPS9vPWohyhvnzsnlO+fP1DV/NaYjKCGLyA+Ai+ivxlgP3KiUOiQiJcAOYNfAqR8opW4L5lqhRkSYmNO/tzq3IJ05+Wnc/GQ5u+rajzu3KDOR7180i+U69avGpAS12CUiqUqptoHXXwZmKqVuGxDya0qp2aNpL9yLXSPR3uPka6s2s/1QG8kOG8nxNk6enM3tyyfpDCMawwnbYtegiAdIAsyzBB4AKfF2Hr3B633SaExN0B7zInKfiFQB1wH3DDlUKiIbRWSNiJwyzOdvEZFyESlvaGgI1hyNZkwy4tBaRN4Gcr0culsp9fKQ8+4E4pVS3xURB5CslDoiIouAl4BZx/Tgx2H00FqjMTNBDa2VUmf5eZ1ngNeB7yqleoHegc9XiMgeYCqgVarRhIGghtYiMmXIrxcCOwfezxER68DricAUYG8w19JoNL4Jdh/5RyIyjf7tpwPA4BbTqcD3RcQFuIHblFJNQV5Lo9H4INhV68t8vP888HwwbWs0Gv/ReV40mhhAC1mjiQG0kDWaGMBU8cgi0kD/opmZyAYajTbiGLRN/hFrNhUrpXK8HTCVkM2IiJT72oQ3Cm2Tf4wlm/TQWqOJAbSQNZoYQAt5ZB4x2gAvaJv8Y8zYpOfIGk0MoHtkjSYG0ELWaGIALeQBRKRQRN4VkR0isk1EvjLwfqaIvCUiHw38m2ECm74nIjUismng59wI2hQvIutEZPOATfcOvG/kffJlk2H3aYht1oEEG68N/B6W+6TnyAOISB6Qp5TaICIpQAVwMXAj0KSU+pGIfAvIUErdYbBNVwIdSqn7I2HHMTYJkKSU6hARO/Bv4CvApRh3n3zZtAKD7tMQ274GlAGpSqnzReQnhOE+6R55AKVUrVJqw8DrdvqzgObTnyX0yYHTnqRfSEbbZBiqn46BX+0DPwpj75MvmwxFRAqA84DHhrwdlvukheyFgSygC4C1wHilVC30CwswJCfuMTYBfElEtojI7yI5jB2wxSoim+hPgfyWUsrw++TDJjDwPgG/BL5Jf7z+IGG5T1rIxyAiyfTHUn91pBxjkcKLTQ8Bk4D5QC3ws0jao5RyK6XmAwXAEhEZVdrjCNpk2H0SkfOBeqVURSSup4U8hIH51fPA00qpFwberhuYqw7OWeuNtkkpVTfw4HqAR4ElkbRpEKVUC7Ca/rmooffJm00G36eTgAtFZD/wLHCGiPyRMN0nLeQBBhZMHgd2KKV+PuTQK8DKgdcrgZeP/WykbRp8EAa4BNgaQZtyRCR94HUCcBb9udqMvE9ebTLyPiml7lRKFSilSoCrgXeUUtcTpvukV60HEJGTgX8BH/LJnOYu+uekq4Ai4CBwRaTyjw1j0zX0DxcVsB+4dXDeFQGb5tK/SGOlvyNYpZT6vohkYdx98mXTUxh0n46xbznwjYFV67DcJy1kjSYG0ENrjSYG0ELWaGIALWSNJgbQQtZoYgAtZI0mBtBC1mhiAC1kjSYG+D9i1HUQF/QGUAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALoAAAD4CAYAAABbnvyWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAfvElEQVR4nO2deZicVZX/P6eqq/d9y9JLurMRknSSJk0HSAzIImGRmAQUgor6U0HBccRRh8FR0YlsMy6gwDDiqPNTBFlEYWAEF9YxTXf2BBITutNrQpJe01291p0/qjoUTfVW9W5VdT/P009X11t176H45tR57z33HFFKodHEOi67DdBorEALXRMXaKFr4gItdE1coIWuiQsS7DYgmPz8fFVWVma3GZoopa6u7rhSqiDUNUcJvaysjNraWrvN0EQpInJ4vGs6dNHEBVromrhAC10TF2iha+ICLXRNXKCFrokLtNA1cYEWuiYu0ELXGMq2xg62NXbYbcZ70ELXGMqOxk6ueuB/ue8vB/H5nHOoRwtdYyhNHX2M+BR3Pbefj/10K29399ttEqCFrjGYpnbvqcevHjzBuh++zJ/ffNtGi/xooWsMpbmj711/t/cO8smfvc53nt7HwPCITVZpoWsMRClFU3tfyGsPvVLPpvtf461jJy22yo8WusYwOvqG6B0c32vvaenm8ntf4bG6ZqyuPqGFrjGM8bx5MH2DI/zDb3bypUd20NM/ZIFVfrTQNYbR1DG50Ef57Y5WLr/3FXY2dZpo0TtooWsMI3jFZSocPtHHpvtf499fPGT6mrsWusYwpuPRRxn2KW5/9k0+8bPXOdYzYIJVfiISuohcJSJ7RcQnIlVjrt0iIgdFZL+IXByZmZpoYCox+ni8dOAYl/zwJV48cMxAi94hUo++B9gIvBT8pIgsBq4GlgDrgPtExB3hXBqH09wxvdBlLMdPDnLdT2v47n+/weCwzyCr/EQkdKXUG0qp/SEurQd+rZQaUErVAweB6kjm0jgbn0/REqHQR3nwpbe46oHXOHyi15DxwLwYvQhoCvq7OfDcexCRz4pIrYjUHjtmzteWxnyO9vQzOGKcF97Z3MVl97zCb7e3GDLepEIXkRdEZE+In/UTvS3EcyFvq5VSDyqlqpRSVQUFIWvPaKKA6a64TIWTA8P8/SM7uPnRHfQODEc01qQFjJRSF4YxbjNQEvR3MdAaxjiaKCGSG9HJeGJbC9sbO7n3mkqWFmWFNYZZocvvgKtFJElEyoEFQI1Jc2kcQDhLi9Oh/ngvG+57NexQJtLlxQ0i0gycDTwjIv8DoJTaCzwK7AOeA25UStmXuqYxHTNCl7H4FMwvTA/rvRHVXlRKPQk8Oc61LcCWSMbXRA9me3SAT7+v3HGhiyYMjvUMMOKg42fTodnEGB2gLC+VL124MOz3O6qabjyzp6WLa3+ylfSkBK6pLuHDVSUUZibbbdaUGBz20WbykbnbNy4j2RP+nqP26A5gVORd3iFaOr386x8OcM4df+KG/6rjpQPHHHXIOBStnV7MTC+/prqEs+flRTSG9ug2EyzyYIZ9iuf2HuG5vUcozU3l6uoSrlpZQkFGkk2Wjo+Z8XlhRhL/eMnpEY+jPbqNjCfysTS293HXc/s5544/cuMvt/HqweOO8vJmrrh850NLyUrxRDyO9ug2sbu5i2t/8le6+6e+4zc0onhmdxvP7G6jLC+Va6pLuXJlMXnp9np5szz6pRUzuXjJTEPG0h7dBnY1d05b5GNpONHH7c++ydm3/4kvPLydv751wvJzmKOYsSualeLhW1csMWw87dEtZldzJx/9ydaIRB7M4IiP3+9s5fc7W5lXkHbKy2enJhoy/lRoMihrMZhbLzudwgzjVp20R7eQnU2dXGugyMdy6Fgv//LMG1R/94986ZEdvN7QbomXN3oNfc38fK5aWWzomNqjW8SOpk4+9tBWekwSeTCDwz6e3N7Ck9tbWFCYzuZVpWysLCYrNfKburH0DgxzonfQsPFSPG6+u6ECkVAJsOGjPboF7Gjq5GM/sUbkY/nb2ye57ff7qP7uC3z50Z3UHe4w1MtHeqpoLF/+wEJK81INHRO0Rzed7Y0dfPyhGnoizKeOlIFhH49va+bxbc0smpnB5lWlfKiyiMzkyLy8kTeiy4uz+OTqcsPGC0Z7dBPZ5hCRj+XNIz1846m9rNryR7722C52NnWG7eXH1loMlwSXcMemZbhdxoYsp8Y3ZVTNKZGfdJjIg/EOjfBIbROP1DaxZHYmm1eVsn5FEelJU5eFUSsunztvHqfPyjRkrFBoj24CdYedL/Kx7G3t5tYn97Bqywvc8sRu9rR0Tel9RoQu8wrSuOn8+RGPMxHaoxvMnpYurvtpdIk8mN7BER6uaeThmkaWFWexubqUDy6fTdo4Xj5Sjy4Cd25aRlKCudVQtNANpjAjybQ402p2NXexq3k3//LMG3yocjabq+ewePY74YVSKuI19I+dNYeqstxITZ0UHboYTGFmMt/84GK7zTCUkwPD/P+/NnLpPS+z4b5X+U1tE97BEbq8QxHdaM/OSuar6xYZaOn4aI9uAhsqi3h6Vxt/ckBLE6PZ3tjJ9sZOvv30PtbMz49orC0bKqZ14xsJ2qObgIjw3Q0VZCTHrh/p6R/m2T1Hwn7/+hWzef+iQgMtmhgtdJOYmZXMP18eWyGMUeSkeviGxZ+NFrqJXLWymLULdfWxsXzzg0ssz6HXQjcREeGOjdbFodHAeacVsH7FbMvn1UI3mdnZKdx6WeRnHmOBtEQ3W0zITJwKWugWcPWZJRGvUMQCX123iKLsFFvm1kK3ABHh9o0VpCbGby+ElXNy+NhZc2ybXwvdIkpyU7nl0vgMYRLdLu7cVIHLxh1jLXQLuba6lLPmmr/d7TRuOn8+8wszbLVBC91CXC7hrk3LSYmgtFq0cdqMDG44d57dZpjTlU5EykTEKyI7Aj8PRG5qbFCal8rX1p1mtxmW4BK488plJCbY709N6UoX4JBSakXg54YI54kpPn52GdUWZOzZzSdXl7OiJNtuMwDzutJpJsDlEu68chlJDvB0ZlGSm8KXPxB+mWejMfOTLheR7SLyooi8b7wXxWtXuvL8NL5yceyGMLdvWEZqonN2hM3qStcGlCqlKoGbgV+JSMgDgfHcle6Tq8s5o9QZX+1GcuXKYtYscNYGmSld6ZRSA8BA4HGdiBwCFgK107YwhnG7hLuuXM6l97xseKdku8hPT+LrDkx5MCV0EZGC0ZboIjIXf1e6t8yYK9qZX5jOzRc5J5aNhGSPi5svWmBp3cepYkpXOmAtsEtEdgKPATcopdojMzV2+fSacpY7ZHUiHPLSEllVnovH7eLrv93DFx7ezt7WqVURsAqxq9RwKKqqqlRtbXxGN3872sNl97xiaJtxsynPTyM3NZGdzR2EirzWLizgc+fO46y5uZZkLIpInVKqKtS12F3fijIWzMjgixcusNuMKbGsKIvFszKpP95LXWNokQO8dOAY1/zHX9lw32v8z94jtnbp0EJ3ENevnUtFmH00zSYpwcWZZbkUZ6ewq6WLfW3dU37vjqZOrv+vOi76/ov8prbJlhtvLXQHkeB2cfdVy/C4nVMXZjT+TvK4eL2hnebO8AsWHTrWy1ce28W5d/+Zh16pp9fCIk9a6A5j0cxMbnq//SFMeX4qK+dk0+UdZGt9O91e40TZ1tXPd57exzl3/InvPX+AdgPrq4+Hvhl1IEMjPtb/6NVphQdGUVGUxYhPWTp3isfNR84s4TNr50Z0AknfjEYZnkAIk2DRQQV//J1DcXYKu6cZfxuBd2iEn73WwLl3/ZmbH93BgaM9hs+hhe5QlszO4vPnmZvHnfuu+LsjovjbCIZ9iie2tfCB77/Ep39ey7bGDsPG1kJ3MDedv4BFM40/mVOWl8rKOTl0mxB/G8ULbxzlP19tMGw8LXQHk5jg4u4rlxtWnbeiKIslszNoONFH3eHx17+dwgUGlqzTQnc4FcVZXL92btjvPxV/5/jj772txse/ZuB2CeedZlw2qxZ6FPB3FyxgfmH6tN6Tm+ZhVXkuyaPxtwlNb81k5ZwcQ5PDtNCjgGSPm7uvXMZUIpiyvFSq5uTQ4x1ma307XQ6Mv6eCkWELaKFHDZWlOXzmfeOHMMHxd+3hDoZszCsxggtOn2HoeFroUcSXLlrI3Py0U38nBuLvkiiLvydjTl4q8wrSJn/hNHDOoT7Nu/D5FEe6+2k40UvD8T4On+il4UQvqUluqstyEBH2H+3h9Qbj1pqdwgWLZhie1quFbiMjPkVrp5fDJ/poONHL4RO91AdEfbi9b8Isv8rSbDr7hiy01jouON34Thha6CYzPOKjtbOf+oCQg71zU7s37IMW2xs7WTknh7rDseXRM5ISONOEmjda6AYwNOKjucPr98rHe2k45aH7aGrvY9ikG8O6wx2cWZYTU+HL2oUFplT20kKfJm1dXv5795GAV+6j4XgvLZ1eRmxa5Xi9oYPq8lxq6mPjSK4ZYQtooU+bF/Yd5TtP77PbjHdRU98eE2J3CZx3mjlC18uL0+TQsV67TQiJX+w5dpsREWeU5pCbZk6pDC30aXLo2Em7TRiXmnp/zB6tGL1JFIwW+jQ59LZzhQ7+mH3lnOgUu1nxOWihT4vegWFau/rtNmNStjd2UBllBZFKclNYMM3EtemghT4N6o87Mz4fi0/B7pYuljm0dEYozNgNDUYLfRo4OT4fy7BP8caRbpbMDlnE2HGYGbaAFvq0cHp8PpahEcWhYydZNNO8kMAI0hLdVJeb2wFEC30aHIqS0CWY/iEfje1e5hcamw1oJGsXFpCUYG4DMy30aRBtHn2UvsERjnYPUJaXarcpITnf4EMWoYi0bPTdIvKmiOwSkSdFJDvo2i0iclBE9ovIxZGbai8jPhU1N6Oh6Okfpss7RHGOPS3Kx0ME3u90oQPPA0uVUsuAA8AtACKyGLgaWAKsA+4bbQwQrbR2ehlw+rH5SejoG6J/aIRZWUl2m3KKypJs8tPNtyfSrnR/UEqNHkr8K1AceLwe+LVSakApVQ8cBKojmctuDkbRistEHD85iFJCgQXimgpm7oYGY2SM/ing2cDjIqAp6Fpz4Ln3EC1d6aI1Pg/Fke5+Ej0uclM9dpti+rLiKIZ0pRORW4Fh4JejT4UYKmQea7R0pXNqMle4tHR4yUzxkJFsXwJrUXYKp80wvhJZKCLuSici1wGXAxeod0rzNgMlQS8rBlrDNdIJRNNm0VRpONHHvII0fD5F7+CI5fNfcHqhJS1fIPJVl3XA14ArlFJ9QZd+B1wtIkkiUo6/K11NJHPZzVsx5tFHOXSsl+KcVJJt6GJtxbLiKJH+1/0IyACeF5EdIvIAgFJqL/AosA94DrhRKWW9yzCIrr4hjp8csNsM09h/tIe5BemWdtpITXRz1tw8y+aLKEBTSs2f4NoWYEsk4zuFQ8djL2wZy762biqKstjX2sWIBacC18zPJ9lj3Yqz3hmdArG04jIRu1u6qCjODrmSYDQXWrSsOIoW+hSItRWXidjR1MkZFhzcOG+RtStsWuhTIBZXXCZitIyGWSwvyaYwI9m08UOhhT4F4k3oECijYUIhIYALLVxtGUULfRKGRnw0nuib/IUxSE1DO6tMyBM/36Ld0GC00Ceh0cRKW9HA1kDNGKOYlZXM4lnWn3rSQp+EeFlxmYia+naqDYrZz19k3W5oMFrokxBPKy4TUdPQQZUBqzFWLyuOooU+CfF4IzoedY0dVJaGX0Yj2ePi7HnW7YYGo4U+CVro76AU7GruYnlxeGU01swvsHQ3NBhdZHQClFI6Rh/DopkZnDg5SIrHRXZqIhnJCaR43CQmuBARlFIMjii8g8P09A/T0TdI/5D/ZJZVueeh0EKfgOMnB+nuj86ubkYzMzOZGZlJ7GzuOvWct6uftq4J3hRg9B+FnYezdegyATps8TfkrS7Ppb134F0inw7eIR9tXf3sbgnv/UaghT4BsZqDPlWWl2STneKhpr6dQQNSGnc22Sd0HbpMQLx69OKcFLJTPOxs6jR03B0GjzcdtEefgHgTekqgNFxbp5c9rd2Gj9/S6bXtAIsW+gTEk9BXluaQ6nFTU99u6sGLXc32eHUt9HHoHxqhucNrtxmmU56fyqKZ6dQ1dnCid9D0+XbYFKfrGH0c6o/3omI4lysjOYHTZ2bwekNH6DokJmF03D9VtEcfh1gNW0TgzLIcXOLPX7H63/LO5k6UDR5Ee/RxOPR27C0tLihMx6eUrQ14O/uGaGzvY06etWWstdDH4a0YOvmfk+phXkE6tQ5pp76zuctyoevQZRxiIXRxCVSX5TI07HOMyMGeOF179BD4fCrqQ5dFMzPwDo5Q0+C8btJa6A7hSHc/3qHoLCyWn55ISW4q2xvt24WcjD2tXQyP+EhwWxdQ6NAlBNEYtnjcwqryXE72Dzta5ODvq3TgqLWfsRZ6CKItB72iKIvCjCS21rfTHyVdOXZavEOqhR6CaDknOisrmeXFWexu6aKl0/kdrYOxOk7XQg+B00OXpAQXq8pzOX4y/Bxxu7E6k9GUrnQiUiYi3kAp6VPlpKMFJ+ehrwjkiG+tb2fIirK3JnHgaA99g9ad3jKlK12AQ0qpFYGfGyKcxzIGh0dwWV92ZFJKclNYMjuDHU2dHO2J/lrtPgV7TUgFHg+zutJFLT4FIkJWiv2NrMBfML+6LJfWDi97W3vsNsdQrIzTzepKB1AuIttF5EURed94b3JiV7qWTi8zM5Ms7QARipWlOSQnuKlpMDdH3C6sjNMn3TASkReAmSEu3aqUeirwmrFd6dqAUqXUCRFZCfxWRJYopd7zXaWUehB4EKCqqsox/zv3Hz1JZUk2223YxSvPTyPR7aKu0Tnb9mZg5RKjKV3plFIDwEDgcZ2IHAIWArURW2wh25s6WVWey9Z6a7bRM5MTOC2QIx4PNLV7ae8dJDct0fS5TOlKJyIFoy3RRWQu/q50b0Uyl11srW83tSg++HPEq8pyQIgbkY9ilVc3pSsdsBbYJSI7gceAG5RSzssumiK1DR0sKwqvDNtkLJyRTnleGrUNHXR7469YklU3pKZ0pVNKPQ48HsnYTkLhX/edV5Bm2K5pbpqH8vw06g47Oy/FbKwSut4ZnSL9wz46egeZmRlZ7x23S6guz2VgyBf3Igf/IQwrjtZpoU+D9r4hPG4hIym8L8LFszKZnZ1MTX27LS3JnUh776Al1Ra00KdJU4eXopyUaa2xF2YkUVmSxb62bpraY7+ExnSx4oZUCz0M3jzSQ8UUbk5Hc8S7vINst7HuoNOxIk7XQg+TbY2dEzaxWlacRX66P0d8YNgx+2COxIrio1roEVBT3/6evj6zs5OpKMpkV3MXbV3RlSNuF7tb/EfrzEQLfQzTXQDY1tjB0qJMkj3+HPFj3QPsbrEuKy8W8A6NcNDkMwBa6BHiU/6jd5nJgRzxOO5JGglmx+la6AbgHfLxdgzkiNuJ2cVHtdA1jkB7dE1csP9oD/0m1tLRQtc4ghGfYm+reeGLFrrGMZgZp2uhaxyDmXG6FrrGMZjZ30gLXeMYGk700dlnTh8lLXSNozCr8pgWusZRmBWna6FrHIUWuiYuyDSpQlrMd7xQSjEw7PP/DI0EHo/QP+T/PTDkoz/we2DYR0//kN0mxy3Xr53LV9ctMmXsqBD6wPAI3/vDAfqHggQ67KP/lHCDHwdeE3RN42wSXMKWDUv5yJml5s1h2sgGkpTgZltjR9wV94kHslI83P/RMzhnXr6p80SF0AE2VBZroZvMJUtnMjDso7XTS2unl+5+cwsqleen8dB1VcwtSDd1HogioV9WMYtv/X4vgzoUMYVvXL6YT60pf9dzJweGaev00tLp5eZHd9Lea9xmzllzc3ngoyvJTjW/7iJE0apLVqqHC08vtNuMmEME7txU8R6RA6QnJbBgRgZ9gyOGivzDVcX84lOrLBM5RJHQATZWRn2fAUfhdgk/+MiKCW8CB4d93PXcm4bMJwL/dOki7ty0jMQEa6UXNaELwLmnFZCblmiod4lXEt0ufrS5kg8sCVX6/h0ermmk4UTfhK+ZCikeNz+4egUXTzKfWUSVR/e4XVyxfLbdZkQ9yR4XD32ialKRd/cP8cM//i3i+WZmJvObG862TeQQeX307wQ60u0QkT+IyOyga7eIyEER2S8iF0duqp+NZxQZNVRckp6UwC8+tYr3LSiY9LX//uKhiL89K4qyeOqm1Sw1qez2VInUo9+tlFqmlFoBPA18A0BEFgNXA0uAdcB9o40BIqWiKIt5BWlGDBV3ZKd6+NVnVk1YYWyUti4vP3m5PqL5Llk6k0evP5sZEVYgNoJIu9IFV+pJw19KHGA98Gul1IBSqh44CFRHMtcoIsLGM/RNaThsqCxiyeypedbvP38gol3lG98/jx9vPoOUREP8W8REHKOLyBYRaQKuJeDRgSKgKehlzYHnQr1/2l3pPlSpw5dw+M9XG1j/41fYPkkTsDePdPObuuaw5vC4hX+7ajlfuXgRLgc1bJ1U6CLygojsCfGzHkApdatSqgR/R7qbRt8WYqiQJayUUg8qpaqUUlUFBZPHjQBF2SmcPTdvSq/VvJs9Ld1svP81bnliFx3jxN93PPvmtEvzAeSkevjlp89i00rnfeNG3JUuiF8BzwDfxO/BS4KuFQOt07ZuAjaeUcT/vnXCyCHjBqXg4Zomnt1zhK+tW8RHqkpOed9XDx7nL/un3+91XkEaP/3EmczJc+b9U6SrLguC/rwCGN1Z+B1wtYgkiUg5/q50NZHMNZZLKmaR7Imq1VHH0dk3xC1P7GbD/a+xu7kLn09x+7NvTHucNfPzeeLzqx0rcoh8w+gOETkN8AGHgRsAlFJ7ReRRYB/+Rrs3KqUMLcOUnpTAxUtm8tQOQ78o4pKdTZ1c8eNXWD0vnz3TrAS8eVUpt12xBI/b2U4n0q50mya4tgXYEsn4k7GhskgL3SCUglcOHp/y610CX79sMZ9cXYaIc246xyOqUgDGsmZ+PgUZSRzTlWwtJS3Rzb2bKzl/0Qy7TZkyzv6+mYQEt4v1OiXAUoqyU3jsc+dElcghyoUO6M0jC1lRks2TN57D6bMy7TZl2kS90BfPzmTRzAy7zYh5Ll82i19/9iwKM+zfzg+HqBc66EQvs/m7CxZwz9WVJHucsZ0fDjEh9PUrinDQbnPMkOh28YOPrODmixY6ajs/HGJC6DMyk1k939xT5PFGXloiD392VczkFcWE0AE26ZtSw1hQmM5vb1zNyjmTp/NGC1G9jh7MB5bMIDXRTd+geX1w4oFzFxZw7+ZKMpPNKQ1nFzHj0VMTE7hk6Sy7zYhqrjt7Dg9dVxVzIocYEjrAJr36EhYugduuWMJt65eS4PCclXCJmdAF4Ky5eczKSqatq99uU6KGjKQE7t1cyXmnxXbNnJj65+tyScysElhBcU4Kj3/+nJgXOcSY0AE2aqFPiZVzcnjqxtUsnBEfu8oxJ/QFMzKosLm0gtPZUFnELz+9irz0JLtNsYyYEzr4/0dqQvPlixbyvQ8vj+rt/HCISaFfsWI27ijfsjaapAR/CbovXLAgKg5KGE1MCj0/PYnzFk6tokA8kJ+exCPXn83ly+I3dz8mhQ6wQa+pA7BoZgZP3bSaFSXZdptiKzG1jh7MhafPICM5gR6TuzY4mQsWFfLDaypJT4rZ/81TJmY9erLHzWUV8ZsS8P/WlPPgx6u0yAPErNAhPo/ZuQMd3v758sX6hjyImP7nXjUnh+KcFJo7vHabYgkZyQncf+1K1izQufljiWmP7nJJ3OyUzslL5cnPr9YiH4eY9ugAG84o5p4/HbTbjHeR4BISE1x43C4SE1wkBv32JMipvz1uF0kJ7zz2X/f/Tgp6f1KCi6uqSshNs675VbQR80Ivz09j7cIC/na0513C8iS4SAohrFHhjAorpCDf85yQ6HYHnpeJX+t2Rf35y2gk5oUO8ItPGdKDQBPFxHSMrtGMooWuiQtM6UonImUi4g08v0NEHjDGXI0mPEzpShfgkFJqReDnhgjn0WgiwqyudBqNo4h41UVEtgAfB7qA9wddKheR7UA38HWl1MuRzqXRhItZXenagFKlVCVwM/ArEQlZazic9osazXQRFU6fvVADicwBnlFKLQ1x7S/APyilaicao6qqStXWTvgSjWZcRKROKVUV6popXelEpGC0JbqIzMXfle6tSObSaCIhIo8uIo8D7+pKp5RqEZFNwLfxd6QbAb6plPr9FMY7FhjHCeQDU+9eZR3arvGZo5QKeYbSsNAl1hCR2vG+Bu1E2xUeemdUExdooWviAi308XnQbgPGQdsVBjpG18QF2qNr4gItdE1cEPdCF5ESEfmziLwhIntF5IuB53NF5HkR+Vvgd45D7PqWiLQEpUBfarFdySJSIyI7A3bdFnje1s9rMuI+RheRWcAspdQ2EckA6oAPAZ8A2pVSd4jIPwI5SqmvOcCuDwMnlVL/apUtY+wSIE0pdVJEPMArwBeBjdj4eU1G3Ht0pVSbUmpb4HEP8AZQBKwHfh542c/xi8wJdtmK8nMy8Kcn8KOw+fOajLgXejAiUgZUAluBGUqpNvCLDrCt/8kYuwBuCpzs+qkdIYKIuEVkB/A28LxSylGfVyi00AOISDrwOPD3Yw6U2EoIu+4H5gEr8KdD/5vVNimlRgKnyoqBahF5T8aq09BCBwKx5uPAL5VSTwSePhqIk0fj5bedYJdS6mhAaD7gPwDbankopTqBvwDrcMDnNRFxL/TAzdVDwBtKqe8FXfodcF3g8XXAU06wa1RMATYAeyy2q0BEsgOPU4AL8adn2/p5TYZedRFZA7wM7MafbgzwT/jj4UeBUqARuEop1e4Au67BH7YooAG4fjQ2tsiuZfhvNt34HeWjSqlvi0geNn5ekxH3QtfEB3EfumjiAy10TVygha6JC7TQNXGBFromLtBC18QFWuiauOD/ABo8sdiTvED4AAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -199,19 +316,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "import geopandas\n",
+    "import topojson as tp\n",
+    "from shapely.wkt import loads\n",
+    "\n",
+    "df = pandas.DataFrame({\n",
+    "    \"name\": [\"P1\", \"P2\", \"P3\"],\n",
+    "    \"geometry\": [\n",
+    "        \"POLYGON ((60.05 88.85, 60.3 86.9, 61.9 73.4, 51.85 72.1, 50.8 80.5, 57.95 81.4, 57.5 85.05, 59.05 85.25, 58.85 87.15, 60.05 88.85))\",\n",
+    "        \"POLYGON ((66.35 90.55, 65.75 86.8, 64.5 81.1, 63.7 77, 63 73.55, 61.9 73.4, 60.3 86.9, 64.15 87.45, 64.85 90.8, 66.35 90.55))\",\n",
+    "        \"POLYGON ((65.75 86.8, 70.5 87.45, 71.45 79, 69.85 78.85, 70.3 74.5, 64.15 73.75, 63.7 77, 64.5 81.1, 66.45 81.35, 65.75 86.8))\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "df['geometry'] = df['geometry'].apply(loads)\n",
+    "gdf = geopandas.GeoDataFrame(df, geometry='geometry', crs='EPSG:27700')\n",
+    "topo = tp.Topology(gdf, prequantize=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-da213561796344f68d78e8933d5cde7c\"></div>\n",
+       "<div id=\"altair-viz-ceed25ff0f8240c3a2d7df5f21554eb0\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-da213561796344f68d78e8933d5cde7c\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-da213561796344f68d78e8933d5cde7c\");\n",
+       "    if (outputDiv.id !== \"altair-viz-ceed25ff0f8240c3a2d7df5f21554eb0\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-ceed25ff0f8240c3a2d7df5f21554eb0\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -253,14 +395,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-e4fdaaa1ba119db35f7650622ecb3459\", \"format\": {\"feature\": \"data\", \"type\": \"topojson\"}}, \"mark\": \"geoshape\", \"encoding\": {\"color\": {\"type\": \"nominal\", \"field\": \"properties.name\", \"legend\": {\"columns\": 2}}, \"tooltip\": [{\"type\": \"nominal\", \"field\": \"properties.name\"}]}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-e4fdaaa1ba119db35f7650622ecb3459\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"properties\": {\"pop_est\": 54841552, \"continent\": \"Africa\", \"name\": \"South Africa\", \"iso_a3\": \"ZAF\", \"gdp_md_est\": 739100.0}, \"type\": \"Polygon\", \"arcs\": [[0, -6, -5, -15, 1, -13, 2], [3]]}, {\"properties\": {\"pop_est\": 13805084, \"continent\": \"Africa\", \"name\": \"Zimbabwe\", \"iso_a3\": \"ZWE\", \"gdp_md_est\": 28330.0}, \"type\": \"Polygon\", \"arcs\": [[4, -8, -10, -16]]}, {\"properties\": {\"pop_est\": 2214858, \"continent\": \"Africa\", \"name\": \"Botswana\", \"iso_a3\": \"BWA\", \"gdp_md_est\": 35900.0}, \"type\": \"Polygon\", \"arcs\": [[5, 6, -11, 7]]}, {\"properties\": {\"pop_est\": 15972000, \"continent\": \"Africa\", \"name\": \"Zambia\", \"iso_a3\": \"ZMB\", \"gdp_md_est\": 65170.0}, \"type\": \"Polygon\", \"arcs\": [[8, -17, 9, 10, 11]]}, {\"properties\": {\"pop_est\": 26573706, \"continent\": \"Africa\", \"name\": \"Mozambique\", \"iso_a3\": \"MOZ\", \"gdp_md_est\": 35010.0}, \"type\": \"Polygon\", \"arcs\": [[12, 13, 14, 15, 16, 17]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [16.344976840895242, -34.81916635512371, 40.775475294768995, -8.238256524288218], \"transform\": {\"scale\": [2.4430522884396637e-05, 2.6580936411771908e-05], \"translate\": [16.344976840895242, -34.81916635512371]}, \"arcs\": [[[0, 234847], [19608, 18606], [16165, -10300], [6900, -16086], [18364, -2741], [25737, -7114], [21990, 2747], [36536, 19237], [42, 138946]], [[634158, 337679], [-20656, 6890], [-11832, -2681], [-3865, -10955], [-11177, -14124], [383, -13008], [24429, -20392], [23957, 4062], [8334, 16707]], [[674777, 303863], [-10228, -27386], [-4835, -31258], [-10591, -16982], [-27932, -18998], [-8000, -5439], [-17347, -19111], [-11418, -19330], [-23212, -26955], [-46261, -38817], [-28890, -22569], [-30910, -17118], [-42781, -14596], [-20866, -1960], [-5282, -10444], [-24877, 5560], [-20262, -7160], [-44363, 7250], [-24799, -4588], [-16948, 1969], [-42216, -14851], [-34946, -5957], [-25287, -14219], [-18619, -904], [-17319, 13414], [-13834, 689], [-17628, 16795], [-1934, -5216], [-5440, 10111], [228, 22058], [-13298, 25211], [13210, 6853], [-1071, 28874], [-26804, 35210], [-20569, 31868], [-61, 101], [-29387, 48879], [19608, 18606], [16165, -10300], [6900, -16086], [18364, -2741], [25737, -7114], [21990, 2747], [36536, 19237], [42, 138946]], [[517111, 220593], [-17870, 11591], [-19130, -7674], [-22178, -14718], [-21828, -23824], [30705, -28936], [14646, 3739], [7526, 12020], [22813, 5875], [6959, 12275], [12556, 18298], [-14199, 11354]], [[607700, 472807], [-21757, 3760], [-13794, -4516], [-19805, 6373], [-16653, 410]], [[535691, 478834], [-57917, -27706], [-36751, -28086], [-13630, -25070], [-12307, -14132], [-22271, -3011], [-7196, -18001], [-4142, -11736], [-26176, -8760], [-33315, 1860], [-19553, 10537], [-17252, 4569], [-19968, -8719], [-10018, -18020], [-19384, -11317], [-20469, -16789], [-29319, -3838], [-9134, 13208], [3772, 22923], [-24269, 35747], [-11050, 5649]], [[145342, 378142], [-12, 109802], [40346, 1310], [1208, 134010], [30470, 1244], [63110, 13172], [15642, -15508], [26130, 14744], [12416, 83], [23075, 8477]], [[365086, 642665], [15757, -30078], [8236, -6711], [12870, -21770], [46323, -41324], [17529, -4046], [102, -13271], [12040, -23858], [31652, -5774], [26096, -16999]], [[589223, 996171], [17099, -9577], [16316, -6301], [26013, -6332], [23230, -11295], [19320, -16783], [10409, -31934], [-6973, -10195], [-8229, -30498], [7865, -31172], [-12880, -13095], [-12427, -34950], [21525, -9744]], [[570159, 726512], [-31003, -5150], [-23306, -14987], [-4977, -13043], [-14652, -2959], [-35598, -30940], [-22669, -24349], [-13821, -872], [-13296, 4333], [-45751, 4120]], [[365086, 642665], [-7359, 2811]], [[357727, 645476], [-306, 3122], [-16152, 8480], [-26544, 2166], [-33516, -8550], [-26712, 23500], [-27614, 30780], [1884, 119705], [85232, -475], [-3488, 12987], [6098, 14091], [-7194, 17645], [4656, 18245], [-4326, 11680], [14119, -946], [2348, -11694], [19184, 908], [25989, -3471], [13680, -17081], [32778, -5247], [25023, 11877], [9184, -19713], [31367, -5257], [15082, -16032], [16812, -20704], [31326, -311], [-3422, 40567], [-11234, -6841], [-28617, 14641], [-11059, 6694], [5068, 37762], [7271, 44542], [-9162, 16591], [11666, 24016], [10972, 4497], [54979, 6349], [16124, -3828]], [[674777, 303863], [-31046, 315]], [[643731, 304178], [-3515, 16630], [-6058, 16871]], [[634158, 337679], [-3495, 13508], [7294, 41942], [-10651, 26728], [-19606, 52950]], [[607700, 472807], [43126, 42701], [10794, 27132], [6183, 3423], [4624, 22148], [-6579, 11143], [1756, 28114], [7981, 26073], [-91, 47615], [-21261, 12089], [-19492, 2733], [-8822, 9309], [-18970, 7939], [-34142, -748], [-2648, 14034]], [[570159, 726512], [-3879, 26775], [124211, 31008]], [[690491, 784295], [23563, -18057], [11262, 3457], [16160, -9520], [2376, -15075], [-8611, -17491], [3029, -26520], [26709, -23240], [12495, 26104], [17717, 7922], [-3482, 48374], [-17146, 27208], [-14769, 12129], [-14210, -548], [-11460, 48906], [11460, 28592], [30798, 3042], [49188, -10601], [10686, 4756], [28495, 969], [14586, 11285], [24556, -617], [44757, 14609], [32566, 21812], [6622, -16867], [-1683, -37481], [5057, -33011], [1589, -58794], [7198, -18426], [-12207, -26881], [-15881, -26127], [-26062, -23330], [-37421, -14301], [-46140, -18259], [-46247, -40379], [-15750, -6869], [-28575, -26731], [-16865, -8698], [-3458, -26825], [19411, -28491], [8076, -22064], [509, -11255], [7232, 1881], [-1171, -36898], [-6637, -17477], [9647, -6441], [-6088, -15652], [-17110, -13384], [-33765, -12714], [-49226, -20363], [-17952, -13910], [3509, -15848], [10462, -2532], [-3513, -19801]]]}}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-fb22bc5f439b0e71d8904af02159afb7\", \"format\": {\"feature\": \"data\", \"type\": \"topojson\"}}, \"mark\": \"geoshape\", \"encoding\": {\"color\": {\"type\": \"nominal\", \"field\": \"properties.name\", \"legend\": {\"columns\": 2}}, \"tooltip\": [{\"type\": \"nominal\", \"field\": \"properties.name\"}]}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-fb22bc5f439b0e71d8904af02159afb7\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"properties\": {\"name\": \"P1\"}, \"type\": \"Polygon\", \"arcs\": [[0, -4, 1]]}, {\"properties\": {\"name\": \"P2\"}, \"type\": \"Polygon\", \"arcs\": [[-7, 2, 3, 4]]}, {\"properties\": {\"name\": \"P3\"}, \"type\": \"Polygon\", \"arcs\": [[5, 6, 7]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [50.8, 72.1, 71.45, 90.8], \"arcs\": [[[60.05, 88.85], [60.3, 86.9]], [[61.9, 73.4], [51.85, 72.1], [50.8, 80.5], [57.95, 81.4], [57.5, 85.05], [59.05, 85.25], [58.85, 87.15], [60.05, 88.85]], [[63.7, 77.0], [63.0, 73.55], [61.9, 73.4]], [[61.9, 73.4], [60.3, 86.9]], [[60.3, 86.9], [64.15, 87.45], [64.85, 90.8], [66.35, 90.55], [65.75, 86.8], [64.5, 81.1]], [[65.75, 86.8], [70.5, 87.45], [71.45, 79.0], [69.85, 78.85], [70.3, 74.5], [64.15, 73.75], [63.7, 77.0]], [[63.7, 77.0], [64.5, 81.1]], [[64.5, 81.1], [66.45, 81.35], [65.75, 86.8]]]}}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -577,7 +719,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -2,50 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import topojson as tp\n",
-    "import geopandas as gpd\n",
-    "import altair as alt\n",
-    "\n",
-    "gdf_basins = gpd.read_file(r\"C:\\Users\\lilei\\Documents\\china_floods\\main_basins.json\")\n",
-    "gdf_rivers = gpd.read_file(r\"C:\\Users\\lilei\\Documents\\china_floods\\main_rivers.json\")\n",
-    "\n",
-    "basins = alt.Chart(gdf_basins).mark_geoshape(filled=False, stroke='gray')\n",
-    "rivers = alt.Chart(gdf_rivers).mark_geoshape(filled=False, strokeWidth=1)\n",
-    "\n",
-    "basins + rivers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from shapely.wkt import loads\n",
-    "from topojson.core.extract import Extract\n",
-    "from topojson.core.cut import Cut\n",
-    "from topojson.core.dedup import Dedup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-286513854da04015b5c5527eb8d28587\"></div>\n",
+       "<div id=\"altair-viz-96f19616fba14059b5e76ca06dcaa296\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-286513854da04015b5c5527eb8d28587\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-286513854da04015b5c5527eb8d28587\");\n",
+       "    if (outputDiv.id !== \"altair-viz-96f19616fba14059b5e76ca06dcaa296\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-96f19616fba14059b5e76ca06dcaa296\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -87,14 +56,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-337501cc7cbad23d8aa7c8257c789fbe\", \"format\": {\"mesh\": \"data\", \"type\": \"topojson\"}}, \"mark\": {\"type\": \"geoshape\", \"filled\": false}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-337501cc7cbad23d8aa7c8257c789fbe\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"type\": \"Polygon\", \"arcs\": [[0, 1, -1]]}, {\"type\": \"Polygon\", \"arcs\": [[1, 2]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [0.0, 0.0, 2.0, 1.0], \"transform\": {\"scale\": [2.000002000002e-06, 1.000001000001e-06], \"translate\": [0.0, 0.0]}, \"arcs\": [[[500000, 0], [-500000, 0], [0, 999999], [500000, 0]], [[500000, 0], [0, 999999]], [[500000, 999999], [499999, 0], [0, -999999], [-499999, 0]]]}}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-ded9e650ec702f296c1982da2caad281\", \"format\": {\"mesh\": \"data\", \"type\": \"topojson\"}}, \"mark\": {\"type\": \"geoshape\", \"filled\": false}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-ded9e650ec702f296c1982da2caad281\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"type\": \"Polygon\", \"arcs\": [[-2, 0]]}, {\"type\": \"Polygon\", \"arcs\": [[1, 2]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [0.0, 0.0, 2.0, 1.0], \"transform\": {\"scale\": [2.000002000002e-06, 1.000001000001e-06], \"translate\": [0.0, 0.0]}, \"arcs\": [[[500000, 0], [-500000, 0], [0, 999999], [500000, 0]], [[500000, 0], [0, 999999]], [[500000, 999999], [499999, 0], [0, -999999], [-499999, 0]]]}}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,12 +99,556 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "e = Extract(data, options={'prequantize':False})\n",
-    "e.to_svg(separate=True)"
+    "import geopandas\n",
+    "from topojson.core.hashmap import Hashmap\n",
+    "\n",
+    "# data = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "# data = data[\n",
+    "#     (data.name == \"Botswana\")\n",
+    "#     | (data.name == \"South Africa\")\n",
+    "#     | (data.name == \"Zimbabwe\")\n",
+    "#     | (data.name == \"Mozambique\")\n",
+    "#     | (data.name == \"Zambia\")\n",
+    "# ]\n",
+    "\n",
+    "data = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "data = data[\n",
+    "    (data.name == \"Togo\") | (data.name == \"Benin\") | (data.name == \"Burkina Faso\")\n",
+    "]\n",
+    "#topo = Hashmap(data)\n",
+    "topo = topojson.Topology(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Topology(\n",
+       "{'arcs': [[[880723, 35917], [-89176, -12698]],\n",
+       "          [[822755, 654305],\n",
+       "           [36222, 31881],\n",
+       "           [38680, 281],\n",
+       "           [82280, -62637],\n",
+       "           [-4205, -36162],\n",
+       "           [24267, -64566],\n",
+       "           [-21261, -43817],\n",
+       "           [11369, -29277],\n",
+       "           [-52342, -67382],\n",
+       "           [-33238, -33366],\n",
+       "           [-20341, -68655],\n",
+       "           [2727, -69238],\n",
+       "           [-6190, -175450],\n",
+       "           [-89176, -12698]],\n",
+       "          [[687348, 551684],\n",
+       "           [-13728, -57311],\n",
+       "           [32960, -32131],\n",
+       "           [37470, -38119],\n",
+       "           [4099, -53418],\n",
+       "           [21735, -22426],\n",
+       "           [-4913, -249970],\n",
+       "           [26576, -75090]],\n",
+       "          [[791547, 23219],\n",
+       "           [-86874, -23219],\n",
+       "           [-24083, 38220],\n",
+       "           [-28761, 69050],\n",
+       "           [-8570, 54138],\n",
+       "           [23854, 98039],\n",
+       "           [-27066, 39703],\n",
+       "           [-10282, 85746],\n",
+       "           [181, 79045],\n",
+       "           [-45034, 56132],\n",
+       "           [7940, 33934]],\n",
+       "          [[822755, 654305],\n",
+       "           [-23575, -32545],\n",
+       "           [-52743, -10170],\n",
+       "           [-21981, -47588],\n",
+       "           [-37108, -12318]],\n",
+       "          [[687348, 551684], [-94496, 2323]],\n",
+       "          [[592852, 554007],\n",
+       "           [-49905, 8670],\n",
+       "           [-34839, -17568],\n",
+       "           [-47669, 7933],\n",
+       "           [-187431, -5129],\n",
+       "           [-2534, -61755],\n",
+       "           [14718, -81947],\n",
+       "           [-73848, 28068],\n",
+       "           [-50558, -4134],\n",
+       "           [-37744, -27376],\n",
+       "           [-48516, 22983],\n",
+       "           [-18858, 35998],\n",
+       "           [-48522, 23731],\n",
+       "           [-7146, 63188],\n",
+       "           [29427, 46137],\n",
+       "           [-2492, 36868],\n",
+       "           [85650, 90210],\n",
+       "           [15835, 74646],\n",
+       "           [29567, 26563],\n",
+       "           [52180, -14675],\n",
+       "           [45221, 22161],\n",
+       "           [14676, 27961],\n",
+       "           [83718, 48792],\n",
+       "           [20586, 34024],\n",
+       "           [100853, 45150],\n",
+       "           [59401, 15493],\n",
+       "           [26932, -20882],\n",
+       "           [69181, 501],\n",
+       "           [-8550, -52755],\n",
+       "           [14489, -49579],\n",
+       "           [60761, -71075],\n",
+       "           [3351, -52672],\n",
+       "           [124412, -24688],\n",
+       "           [-2443, -74544]]],\n",
+       " 'bbox': (-5.470564947929006,\n",
+       "          5.928837388528876,\n",
+       "          3.7971122575117136,\n",
+       "          15.116157741755728),\n",
+       " 'coordinates': [],\n",
+       " 'objects': {'data': {'geometries': [{'arcs': [[0, -3, -5, 1]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 24310.0,\n",
+       "                                                     'iso_a3': 'BEN',\n",
+       "                                                     'name': 'Benin',\n",
+       "                                                     'pop_est': 11038805},\n",
+       "                                      'type': 'Polygon'},\n",
+       "                                     {'arcs': [[2, 3, -6]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 11610.0,\n",
+       "                                                     'iso_a3': 'TGO',\n",
+       "                                                     'name': 'Togo',\n",
+       "                                                     'pop_est': 7965055},\n",
+       "                                      'type': 'Polygon'},\n",
+       "                                     {'arcs': [[4, 5, 6]],\n",
+       "                                      'properties': {'continent': 'Africa',\n",
+       "                                                     'gdp_md_est': 32990.0,\n",
+       "                                                     'iso_a3': 'BFA',\n",
+       "                                                     'name': 'Burkina Faso',\n",
+       "                                                     'pop_est': 20107509},\n",
+       "                                      'type': 'Polygon'}],\n",
+       "                      'type': 'GeometryCollection'}},\n",
+       " 'transform': {'scale': [9.267686473127193e-06, 9.187329540556393e-06],\n",
+       "               'translate': [-5.470564947929006, 5.928837388528876]},\n",
+       " 'type': 'Topology'}\n",
+       ")"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 LINESTRING (2.691699685742995 6.25881870363704, 1.865244476815404 6.142157993131055)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"1.8321862684583001 6.109099784773951 0.8925716256417981 0.18277712722019235\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,12.400976696768094)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"2.6916996857429947,6.25881870363704 1.8652444768154037,6.142157993131055\" stroke=\"#66cc99\" stroke-width=\"0.01785143251283596\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 LINESTRING (2.154470436268758 11.94015304356263, 2.490164575698371 12.23305429664511, 2.84863868847893 12.235635936246, 3.611183931487837 11.66016917581417, 3.572213309868337 11.32793696496857, 3.797112257511714 10.73474784585301, 3.600071975406557 10.33218662737445, 3.705436302919539 10.06320918041558, 3.220347057543115 9.444148541313806, 2.912307694549314 9.137604103863602, 2.723793683999434 8.506847994256702, 2.749066665011652 7.87073567152766, 2.691699685742995 6.25881870363704, 1.865244476815404 6.142157993131055)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"1.621505359090806 5.898418875406457 2.4193460161455054 6.580956178564143\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,18.377793929377056)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"2.154470436268758,11.940153043562628 2.490164575698371,12.233054296645106 2.84863868847893,12.235635936246002 3.6111839314878367,11.660169175814172 3.572213309868337,11.327936964968572 3.7971122575117136,10.734747845853008 3.600071975406557,10.332186627374448 3.705436302919539,10.063209180415578 3.2203470575431155,9.444148541313806 2.9123076945493143,9.137604103863602 2.7237936839994337,8.506847994256702 2.749066665011652,7.87073567152766 2.6916996857429947,6.25881870363704 1.8652444768154037,6.142157993131055\" stroke=\"#66cc99\" stroke-width=\"0.13161912357128286\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 LINESTRING (0.8995608140020241 10.99734009878119, 0.7723340140989334 10.47080505548236, 1.077796960253206 10.17560697001474, 1.425057172401281 9.825395155258276, 1.46304541925463 9.334626385860833, 1.66447858474805 9.128591333584316, 1.618946441105575 6.832034568331435, 1.865244476815404 6.142157993131055)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"0.578126729872928 5.947950708905049 1.4813250311684811 5.243596674102147\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,17.139498091912245)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"0.8995608140020241,10.99734009878119 0.7723340140989334,10.470805055482362 1.077796960253206,10.175606970014744 1.4250571724012815,9.825395155258276 1.4630454192546303,9.334626385860833 1.6644785847480499,9.128591333584316 1.6189464411055754,6.8320345683314345 1.8652444768154037,6.142157993131055\" stroke=\"#66cc99\" stroke-width=\"0.10487193348204293\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 LINESTRING (1.865244476815404 6.142157993131055, 1.060123482148953 5.928837388528876, 0.8369297888166303 6.279977123568941, 0.5703818581630191 6.914362228344361, 0.4909577850883187 7.411745875011002, 0.7120291782182946 8.312462475837611, 0.4611899761366347 8.677227020586322, 0.3658996238199403 9.465003779370869, 0.3675770750715763 10.19121624290415, -0.04978391755923361 10.70691942467466, 0.0238015130373963 11.0186822653039)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"-0.2533777126302346 5.725243593457876 2.3222159845166397 5.497032466917027\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,16.947519653832778)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"1.8652444768154037,6.142157993131055 1.0601234821489527,5.928837388528876 0.8369297888166303,6.279977123568941 0.5703818581630191,6.914362228344361 0.49095778508831867,7.411745875011002 0.7120291782182946,8.312462475837611 0.4611899761366347,8.677227020586322 0.36589962381994035,9.46500377937087 0.36757707507157633,10.19121624290415 -0.049783917559233615,10.706919424674663 0.023801513037396305,11.018682265303902\" stroke=\"#66cc99\" stroke-width=\"0.10994064933834054\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 LINESTRING (2.154470436268758 11.94015304356263, 1.935984727664784 11.64115140366522, 1.447179140012636 11.54771626223776, 1.243466123646828 11.11050962406176, 0.8995608140020241 10.99734009878119)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"0.8493644291113548 10.94714371389052 1.3553023920480722 1.0432057145627773\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,22.93749314234382)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"2.154470436268758,11.940153043562628 1.935984727664784,11.64115140366522 1.4471791400126364,11.54771626223776 1.2434661236468276,11.110509624061763 0.8995608140020241,10.99734009878119\" stroke=\"#66cc99\" stroke-width=\"0.027106047840961444\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 LINESTRING (0.8995608140020241 10.99734009878119, 0.0238015130373963 11.0186822653039)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"-0.011228859001188807 10.962309726742605 0.9458200450417982 0.09140291059988215\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,22.016022364085092)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"0.8995608140020241,10.99734009878119 0.023801513037396305,11.018682265303902\" stroke=\"#66cc99\" stroke-width=\"0.018916400900835965\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 LINESTRING (0.0238015130373963 11.0186822653039, -0.438702380404016 11.09833641242053, -0.7615793094412941 10.93693340705203, -1.203360655928795 11.00981649229727, -2.940412399273497 10.96269467908375, -2.963896716796401 10.39533114330669, -2.827494907284915 9.642457049446717, -3.511895017952412 9.900327014991053, -3.980450710660777 9.862346594670393, -4.33025026890249 9.610834261168122, -4.779881345832729 9.821986655998728, -4.954651377342961 10.15271214479968, -5.404338060392039 10.37073666212662, -5.470564947929006 10.9512656411353, -5.197844738084292 11.37514146414795, -5.220939812775325 11.71385992964918, -4.427162466351981 12.54264892750277, -4.280408651050012 13.22844632838715, -4.00639096509906 13.47248936297295, -3.522803084931283 13.33766530196528, -3.103709034929998 13.54126571191355, -2.967696468250384 13.79815263319705, -2.191824292093121 14.24642081613988, -2.001039698357325 14.55901051642777, -1.066365714483029 14.97381844518389, -0.5158558702927998 15.11615774175573, -0.2662585381985387 14.92430792628983, 0.3748892796988743 14.92891077838965, 0.2956505603536366 14.4442332084776, 0.4299300696627766 13.98873459718635, 0.9930439674564582 13.33574515009131, 1.024099984827907 12.85183012853112, 2.177111394322607 12.62501333683386, 2.154470436268758 11.94015304356263)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"-5.77647200161907 9.304927207478057 8.259490449631741 6.117137587967736\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,24.72699200292385)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"0.023801513037396305,11.018682265303902 -0.438702380404016,11.098336412420526 -0.7615793094412941,10.936933407052031 -1.2033606559287948,11.009816492297265 -2.940412399273497,10.96269467908375 -2.9638967167964014,10.395331143306692 -2.8274949072849154,9.642457049446717 -3.5118950179524124,9.900327014991053 -3.980450710660777,9.862346594670393 -4.33025026890249,9.610834261168122 -4.779881345832729,9.821986655998728 -4.9546513773429615,10.152712144799679 -5.404338060392039,10.370736662126621 -5.470564947929006,10.951265641135299 -5.197844738084292,11.37514146414795 -5.220939812775325,11.713859929649182 -4.427162466351981,12.542648927502775 -4.280408651050012,13.228446328387147 -4.00639096509906,13.472489362972947 -3.522803084931283,13.33766530196528 -3.1037090349299983,13.541265711913553 -2.967696468250384,13.798152633197049 -2.1918242920931212,14.246420816139876 -2.001039698357325,14.559010516427767 -1.0663657144830285,14.97381844518389 -0.5158558702927998,15.116157741755728 -0.26625853819853873,14.92430792628983 0.3748892796988743,14.92891077838965 0.29565056035363657,14.444233208477597 0.4299300696627766,13.988734597186351 0.9930439674564582,13.335745150091306 1.0240999848279069,12.85183012853112 2.1771113943226075,12.625013336833863 2.154470436268758,11.940153043562628\" stroke=\"#66cc99\" stroke-width=\"0.16518980899263483\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "topo.to_svg(separate=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "import geopandas\n",
+    "import topojson as tp\n",
+    "from shapely.wkt import loads\n",
+    "\n",
+    "df = pandas.DataFrame({\n",
+    "    \"name\": [\"P1\", \"P2\", \"P3\"],\n",
+    "    \"geometry\": [\n",
+    "        \"POLYGON ((60.05 88.85, 60.3 86.9, 61.9 73.4, 51.85 72.1, 50.8 80.5, 57.95 81.4, 57.5 85.05, 59.05 85.25, 58.85 87.15, 60.05 88.85))\",\n",
+    "        \"POLYGON ((66.35 90.55, 65.75 86.8, 64.5 81.1, 63.7 77, 63 73.55, 61.9 73.4, 60.3 86.9, 64.15 87.45, 64.85 90.8, 66.35 90.55))\",\n",
+    "        \"POLYGON ((65.75 86.8, 70.5 87.45, 71.45 79, 69.85 78.85, 70.3 74.5, 64.15 73.75, 63.7 77, 64.5 81.1, 66.45 81.35, 65.75 86.8))\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "df['geometry'] = df['geometry'].apply(loads)\n",
+    "gdf = geopandas.GeoDataFrame(df, geometry='geometry', crs='EPSG:27700')\n",
+    "topo = tp.Topology(gdf, shared_coords=True)\n",
+    "#topo = tp.Topology(gdf, prequantize=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-ef7ac57a9df244fc99a36020e825864b\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-ef7ac57a9df244fc99a36020e825864b\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-ef7ac57a9df244fc99a36020e825864b\");\n",
+       "    }\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.8.1?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function loadScript(lib) {\n",
+       "      return new Promise(function(resolve, reject) {\n",
+       "        var s = document.createElement('script');\n",
+       "        s.src = paths[lib];\n",
+       "        s.async = true;\n",
+       "        s.onload = () => resolve(paths[lib]);\n",
+       "        s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "        document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "      });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else if (typeof vegaEmbed === \"function\") {\n",
+       "      displayChart(vegaEmbed);\n",
+       "    } else {\n",
+       "      loadScript(\"vega\")\n",
+       "        .then(() => loadScript(\"vega-lite\"))\n",
+       "        .then(() => loadScript(\"vega-embed\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-39eac94c17de9e71257464246046ce6d\", \"format\": {\"feature\": \"data\", \"type\": \"topojson\"}}, \"mark\": \"geoshape\", \"encoding\": {\"color\": {\"type\": \"nominal\", \"field\": \"properties.name\", \"legend\": {\"columns\": 2}}, \"tooltip\": [{\"type\": \"nominal\", \"field\": \"properties.name\"}]}, \"projection\": {\"reflectY\": true, \"type\": \"identity\"}, \"width\": 300, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.8.1.json\", \"datasets\": {\"data-39eac94c17de9e71257464246046ce6d\": {\"type\": \"Topology\", \"objects\": {\"data\": {\"geometries\": [{\"properties\": {\"name\": \"P1\"}, \"type\": \"Polygon\", \"arcs\": [[0, -4, 1]]}, {\"properties\": {\"name\": \"P2\"}, \"type\": \"Polygon\", \"arcs\": [[-7, 2, 3, 4]]}, {\"properties\": {\"name\": \"P3\"}, \"type\": \"Polygon\", \"arcs\": [[5, 6, 7]]}], \"type\": \"GeometryCollection\"}}, \"bbox\": [50.8, 72.1, 71.45, 90.8], \"transform\": {\"scale\": [2.0650020650020655e-05, 1.8700018700018704e-05], \"translate\": [50.8, 72.1]}, \"arcs\": [[[447941, 895721], [12107, -104278]], [[537530, 69519], [-486683, -69519], [-50847, 449197], [346247, 48129], [-21792, 195187], [75060, 10695], [-9685, 101604], [58111, 90909]], [[624697, 262032], [-33899, -184492], [-53268, -8021]], [[537530, 69519], [-77482, 721924]], [[460048, 791443], [186440, 29412], [33899, 179144], [72639, -13369], [-29056, -200535], [-60532, -304812]], [[723970, 786095], [230024, 34760], [46005, -451871], [-77482, -8022], [21792, -232620], [-297821, -40107], [-21791, 173797]], [[624697, 262032], [38741, 219251]], [[663438, 481283], [94430, 13369], [-33898, 291443]]]}}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.Chart(...)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topo.to_alt(color='properties.name:N')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 LINESTRING (60.0499908999909 88.84999944999944, 60.3000007000007 86.89999889999889)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"59.97199087799088 86.82199887799887 0.4060098440098372 2.106000594000605\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,175.74999834999835)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"60.0499908999909,88.84999944999944 60.3000007000007,86.89999889999889\" stroke=\"#66cc99\" stroke-width=\"0.042120011880012104\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 LINESTRING (61.9000056000056 73.40000660000659, 51.8499915999916 72.09999999999999, 50.8 80.4999922999923, 57.9500077000077 81.40000550000549, 57.50000245000245 85.05000605000605, 59.04999299999299 85.25000275000275, 58.84999754999755 87.14999944999944, 60.0499908999909 88.84999944999944)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"50.13000002200002 71.43000002200002 12.44000555600556 18.089999405999407\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,160.94999944999944)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"61.9000056000056,73.40000660000659 51.8499915999916,72.1 50.8,80.4999922999923 57.9500077000077,81.40000550000549 57.50000245000245,85.05000605000605 59.049992999992995,85.25000275000275 58.84999754999755,87.14999944999944 60.0499908999909,88.84999944999944\" stroke=\"#66cc99\" stroke-width=\"0.36179998811998815\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 LINESTRING (63.70000595000595 77.0000033000033, 62.9999908999909 73.54999944999945, 61.9000056000056 73.40000660000659)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"61.75600573200573 73.25600673200672 2.0880000860000862 3.887996435996442\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,150.40000990000988)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"63.70000595000595,77.0000033000033 62.9999908999909,73.54999944999945 61.9000056000056,73.40000660000659\" stroke=\"#66cc99\" stroke-width=\"0.07775992871992883\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 LINESTRING (61.9000056000056 73.40000660000659, 60.3000007000007 86.89999889999889)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"59.76000100800101 72.8600069080069 2.6800042840042764 14.579991683991693\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,160.30000550000548)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"61.9000056000056,73.40000660000659 60.3000007000007,86.89999889999889\" stroke=\"#66cc99\" stroke-width=\"0.2915998336798339\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 LINESTRING (60.3000007000007 86.89999889999889, 64.14999054999055 87.45000385000385, 64.8500056000056 90.8, 66.35000245000245 90.54999944999945, 65.74999544999545 86.7999911999912, 64.5000084000084 81.10000110000109)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"59.91200074400074 80.71200114400114 6.826001662001666 10.47599881199882\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,171.90000110000108)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"60.3000007000007,86.89999889999889 64.14999054999055,87.45000385000385 64.8500056000056,90.8 66.35000245000245,90.54999944999945 65.74999544999545,86.7999911999912 64.5000084000084,81.1000011000011\" stroke=\"#66cc99\" stroke-width=\"0.20951997623997642\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 LINESTRING (65.74999544999545 86.7999911999912, 70.4999957999958 87.45000385000385, 71.45 79.0000077000077, 69.8499950999951 78.84999614999614, 70.30000035000035 74.4999977999978, 64.14999054999055 73.74999614999615, 63.70000595000595 77.0000033000033)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"63.15200564200564 73.20199584199584 8.845994665994674 14.796008316008326\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,161.2)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"65.74999544999545,86.7999911999912 70.4999957999958,87.45000385000385 71.45,79.0000077000077 69.8499950999951,78.84999614999614 70.30000035000035,74.4999977999978 64.14999054999055,73.74999614999615 63.70000595000595,77.0000033000033\" stroke=\"#66cc99\" stroke-width=\"0.2959201663201665\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 LINESTRING (63.70000595000595 77.0000033000033, 64.5000084000084 81.10000110000109)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"63.53600603800604 76.83600338800339 1.128002274002263 4.427997623997612\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,158.1000044000044)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"63.70000595000595,77.0000033000033 64.5000084000084,81.1000011000011\" stroke=\"#66cc99\" stroke-width=\"0.08855995247995224\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 LINESTRING (64.5000084000084 81.10000110000109, 66.44998984998985 81.35000165000164, 65.74999544999545 86.7999911999912)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg height=\"100.0\" preserveAspectRatio=\"xMinYMin meet\" viewBox=\"64.27200879600879 80.87200149600149 2.4059806579806633 6.155989307989316\" width=\"100.0\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g transform=\"matrix(1,0,0,-1,0,167.89999229999228)\"><polyline fill=\"none\" opacity=\"0.8\" points=\"64.5000084000084,81.1000011000011 66.44998984998985,81.35000165000164 65.74999544999545,86.7999911999912\" stroke=\"#66cc99\" stroke-width=\"0.12311978615978632\"/></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "topo.to_svg(separate=True)"
    ]
   },
   {

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -244,3 +244,31 @@ def test_dedup_topology_false():
 
     assert len(topo["linestrings"]) == 288
     assert len(topo["junctions"]) == 0
+
+
+# see https://github.com/mattijn/topojson/issues/104 for context
+# TypeError: cannot unpack non-iterable NoneType object and
+# TypeError: 'NoneType' object is not iterable
+def test_dedup_merge_continous():
+    data = [
+        {"type": "LineString", "coordinates": [(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]},
+        {
+            "type": "LineString",
+            "coordinates": [
+                (5, 0),
+                (4, -1),
+                (4, 0),
+                (4, 1),
+                (3, 1),
+                (3, 0),
+                (2, 1),
+                (2, 0),
+                (1, 0),
+                (1, 1),
+            ],
+        },
+    ]
+    topo = Dedup(data, options={"prequantize": False}).to_dict()
+
+    assert len(topo["linestrings"]) == 6
+    assert len(topo["junctions"]) == 5

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -71,7 +71,7 @@ def test_hashmap_benin_surrounding_countries():
     ]
     topo = Hashmap(data).to_dict()
 
-    assert len(topo["linestrings"]) == 7
+    assert len(topo["linestrings"]) == 6
 
 
 # something is wrong with hashmapping once a geometry has only shared arcs
@@ -101,7 +101,7 @@ def test_hashmap_shared_arcs_ordering_issues():
         | (data.name == "Zambia")
     ]
     topo = Hashmap(data).to_dict()
-    assert len(topo["linestrings"]) == 18
+    assert len(topo["linestrings"]) == 17
 
 
 def test_hashmap_super_function():

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -71,7 +71,7 @@ def test_hashmap_benin_surrounding_countries():
     ]
     topo = Hashmap(data).to_dict()
 
-    assert len(topo["linestrings"]) == 6
+    assert len(topo["linestrings"]) == 7
 
 
 # something is wrong with hashmapping once a geometry has only shared arcs
@@ -101,7 +101,7 @@ def test_hashmap_shared_arcs_ordering_issues():
         | (data.name == "Zambia")
     ]
     topo = Hashmap(data).to_dict()
-    assert len(topo["linestrings"]) == 17
+    assert len(topo["linestrings"]) == 18
 
 
 def test_hashmap_super_function():

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -8,6 +8,7 @@ from ..ops import asvoid
 from ..ops import map_values
 from ..ops import np_array_from_lists
 from ..ops import lists_from_np_array
+from ..ops import cart
 from ..utils import serialize_as_svg
 
 
@@ -21,7 +22,7 @@ class Dedup(Cut):
         super().__init__(data, options)
 
         # initation topology items
-        self._merged_arcs_idx = []
+        self._idx_merged_dups = []
 
         # execute main function of Dedup
         self.output = self._deduper(self.output)
@@ -94,12 +95,16 @@ class Dedup(Cut):
             slice_idx = np.all(~np.isnan(array_bk_ndp)[:, [0, -1]], axis=1)
             sliced_array_bk_ndp = array_bk_ndp[slice_idx]
 
-            # apply linemerge on geoms containing contigious arcs and maintain
-            # bookkeeping
-            self._merge_contigious_arcs(data, sliced_array_bk_ndp)
-
-            # pop the merged contigious arcs and maintain bookkeeping.
-            self._pop_merged_arcs(data, array_bk, array_bk_sarcs)
+            # apply linemerge on geoms containing contigious arcs and collect idx
+            idx_merged_dups = self._merge_contigious_arcs(data, sliced_array_bk_ndp)
+            # use deduplicate as proxy-function for merged arcs index bookkeeping
+            if idx_merged_dups is not None:
+                array_bk, array_bk_sarcs = self._deduplicate(
+                    idx_merged_dups, data["linestrings"], array_bk
+                )
+            # # pop the merged contigious arcs and maintain bookkeeping.
+            # self._pop_merged_arcs(idx_merged_dups, data["linestrings"], array_bk)
+            # self._pop_merged_arcs(data, array_bk, array_bk_sarcs)
 
         # prepare to return object
         del data["bookkeeping_linestrings"]
@@ -128,8 +133,8 @@ class Dedup(Cut):
 
         Returns
         -------
-        int
-            index of LineString that contains merged LineStrings
+        np.array
+            combinations of index of LineString that contains merged LineStrings
         """
 
         for segment_idx in range(no_ndp_arcs):
@@ -139,11 +144,13 @@ class Dedup(Cut):
                     asvoid(data["linestrings"][i]), asvoid(ndp_arcs[segment_idx])
                 ).any()
                 for i in ndp_arcs_bk
-            ].count(True)
-            if merged_arcs_bool == 2:
-                return segment_idx, "first_last"
-            elif merged_arcs_bool == len(ndp_arcs_bk):
-                return segment_idx, "all"
+            ]
+            count_merged_arcs = merged_arcs_bool.count(True)
+            if count_merged_arcs >= 2:
+                merged_arcs = ndp_arcs_bk[merged_arcs_bool]
+                # create dedup pairs of merged arcs
+                merged_dedups = cart(merged_arcs)
+                return segment_idx, merged_dedups
 
     def _deduplicate(self, bk_dups, linestring_list, array_bk):
         """
@@ -151,7 +158,7 @@ class Dedup(Cut):
 
         Parameters
         ----------
-        dup_pair_list : numpy.ndarray
+        bk_dups : numpy.ndarray
             array containing pair of indexes that refer to duplicate linestrings.
         linestring_list : list of shapely.geometry.LineStrings
             list of linestrings from which items will be removed.
@@ -173,11 +180,13 @@ class Dedup(Cut):
         vals2keep = bk_dups[:, 0]
         vals2pop = bk_dups[:, 1]
 
-        # remove duplicate linestrings (loop over indices backwards to avoid popping subsequent indices)
+        # remove duplicate linestrings (loop over indices backwards to avoid popping
+        # subsequent indices)
         for idx in sorted(vals2pop, reverse=True):
             del linestring_list[idx]
 
-        # prepare bookkeeping array, add +1 so NaN can be 0 and array only contains positive integers
+        # prepare bookkeeping array, add +1 so NaN can be 0 and array only contains
+        # positive integers
         arr = array_bk + 1
         arr[np.isnan(arr)] = 0
         arr = arr.astype(np.int64)
@@ -195,7 +204,7 @@ class Dedup(Cut):
         arr_new[arr_new == 0] = np.nan
         arr_new -= 1
 
-        # collect new indices of shared ars
+        # collect new indices of shared arcs
         u, c = np.unique(arr_new, return_counts=True)
         arr_bk_sarcs = u[c > 1]
 
@@ -216,7 +225,9 @@ class Dedup(Cut):
             bookkeeping array where shared linestrings are set to np.nan.
         """
 
+        list_merged_dups = []
         for arcs_geom_bk in sliced_array_bk_ndp:
+            list_merged_dups = []
             # set number of arcs before trying linemerge
             ndp_arcs_bk = arcs_geom_bk[~np.isnan(arcs_geom_bk)].astype(np.int64)
             no_ndp_arcs_bk = len(ndp_arcs_bk)
@@ -232,28 +243,61 @@ class Dedup(Cut):
             # bookkeeping
             if no_ndp_arcs != no_ndp_arcs_bk:
                 # get the idx of the linestring which was merged
-                idx_merg_arc, consec_behavior = self._find_merged_linestring(
+                idx_merg_arc, merged_dedups = self._find_merged_linestring(
                     data, no_ndp_arcs, ndp_arcs, ndp_arcs_bk
                 )
 
-                # keep last arc of non-duplicate arcs and pop the remaining arcs
-                idx_keep = ndp_arcs_bk[-1]
-                # replace linestring of idx_keep with merged linestring
+                # replace arc with highest index of non-duplicate arcs
+                # and collect remaining arcs as duplicates
+                idx_keep = merged_dedups[0][0]
                 data["linestrings"][idx_keep] = np.asarray(ndp_arcs[idx_merg_arc])
-                if consec_behavior == "first_last":
-                    idx_pop = ndp_arcs_bk[0]
-                    self._merged_arcs_idx.append(idx_pop)
-                elif consec_behavior == "all":
-                    idx_pop = np.delete(ndp_arcs_bk, -1)
-                    self._merged_arcs_idx.extend(idx_pop.tolist())
+                list_merged_dups.append(merged_dedups)
 
-    def _pop_merged_arcs(self, data, array_bk, array_bk_sarcs):
+        if len(list_merged_dups):
+            idx_merged_dups = np.vstack(list_merged_dups)
+            return idx_merged_dups
+        else:
+            return None
+
+    def _pop_merged_arcs(self, bk_dups, linestring_list, array_bk):
         """
         The collected indici that can be popped, since they have been merged
         """
 
-        self._merged_arcs_idx.sort(reverse=True)
-        for idx_pop in self._merged_arcs_idx:
+        # guarantee that first column contain higher values than second column
+        bk_dups.sort(axis=1)
+        bk_dups = bk_dups[:, ::-1]
+
+        # define arrays from wich the indices can be kept and popped
+        vals2keep = bk_dups[:, 0]
+        vals2pop = bk_dups[:, 1]
+
+        # remove duplicate linestrings (loop over indices backwards to avoid popping
+        # subsequent indices)
+        for idx in sorted(vals2pop, reverse=True):
+            del linestring_list[idx]
+
+        # prepare bookkeeping array, add +1 so NaN can be 0 and array only contains
+        # positive integers
+        arr = array_bk + 1
+        arr[np.isnan(arr)] = 0
+        arr = arr.astype(np.int64)
+
+        # replace duplicates by single values, add +1 since NaNs are on 0
+        arr_map = map_values(arr, vals2pop + 1, vals2keep + 1)
+
+        # popped indices changes the bookkeeping, align decremented indices
+        # add +1 since NaNs are on 0
+        arr_bin = np.digitize(arr_map, sorted(vals2pop + 1), right=False)
+        arr_new = arr_map - arr_bin
+
+        # set 0 to nan and subtract -1
+        arr_new = arr_new.astype(float)
+        arr_new[arr_new == 0] = np.nan
+        arr_new -= 1
+
+        self._idx_merged_dups.sort(reverse=True)
+        for idx_pop in self._idx_merged_dups:
 
             # remove merged linestring
             del data["linestrings"][idx_pop]

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -224,7 +224,6 @@ class Dedup(Cut):
 
         list_merged_dups = []
         for arcs_geom_bk in sliced_array_bk_ndp:
-            list_merged_dups = []
             # set number of arcs before trying linemerge
             ndp_arcs_bk = arcs_geom_bk[~np.isnan(arcs_geom_bk)].astype(np.int64)
             no_ndp_arcs_bk = len(ndp_arcs_bk)

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -66,7 +66,7 @@ class Hashmap(Dedup):
         topo_object = copy.copy(self.output)
         topo_object = geometry.MultiLineString(topo_object["linestrings"])
 
-        return serialize_as_altair(topo_object, mesh=True, geo_interface=True)
+        return serialize_as_altair(topo_object, geo_interface=True)
 
     def _hashmapper(self, data):
         """

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -804,6 +804,16 @@ def delta_encoding(linestrings):
     return linestrings
 
 
+def cart(arr):
+    """
+    Function that returns all combinations as a 2D array
+    [3, 152,  62, 52] is returned as [[152,  62], [152,  52], [152,   3]]
+    """
+    arr = -np.sort(-arr)
+    arr = np.array(np.meshgrid(arr[0], arr[1:])).T.reshape(-1, 2)
+    return arr
+
+
 def find_duplicates(segments_list, type="array"):
     """
     Function for solely detecting and recording duplicate LineStrings. The function 
@@ -839,28 +849,18 @@ def find_duplicates(segments_list, type="array"):
         sorted_hashes, return_counts=True, return_index=True
     )
     if count.max() > 1:
-
-        def _cart(arr):
-            """
-            Function that returns the all combinations as a 2D array
-            [3, 152,  62, 52] is returned as [[152,  62], [152,  52], [152,   3]]
-            """
-            arr = -np.sort(-arr)
-            arr = np.array(np.meshgrid(arr[0], arr[1:])).T.reshape(-1, 2)
-            return arr
-
         # split on indices that occures > 1
         idx_dups = np.split(idx_sort, idx_start[1:])
         list_dups = []
         for dup in idx_dups:
             if dup.size > 2:
-                list_dups.append(_cart(dup))
+                list_dups.append(cart(dup))
             elif dup.size > 1:
                 list_dups.append(dup)
         idx_dups = np.vstack(list_dups)
-        # idx_dups = np.array([dup for dup in idx_dups if dup.size > 1])
 
         # apply sorting on duplicate-pairs
+        # pylint: disable=invalid-unary-operand-type
         idx_dups = -np.sort(-idx_dups, axis=1)
         idx_dups = idx_dups[np.argsort(idx_dups[:, 0])]
         return idx_dups


### PR DESCRIPTION
This PR changes how non-shared arcs are merged, when possible. 

Original codebase did not detect a single shared coordinate as junction and also start of geometries were not seen as a junction. This is changed in the last year and now this need some side solving of side effects.

The new approach detects which arcs were merged and set the merged linestring on the highest index of the arcs that are part of this merged linestring.

The remaining indici are collected and set to NaN, when bookkeeping for all other arcs are maintained. The implemented approach is very similar to the deduplication of duplicate linestrings.

A new test was added and all existing tests still pass.

Fix #104 
