### PR TITLE
Fix the duplicate coordinates in geojson export of topology

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,6 +1,6 @@
 import os
 import json
-from shapely import geometry
+from shapely import geometry, wkt
 import geopandas
 import geojson
 import fiona
@@ -427,3 +427,14 @@ def test_topology_geodataframe_valid():
 
     assert gdf.shape[0] == 177
 
+
+def test_topology_geojson_duplicates():
+
+    p0 = wkt.loads('POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))')
+    p1 = wkt.loads('POLYGON ((0 1, 0 2, 1 2, 1 1, 0 1))')
+    p2 = wkt.loads('POLYGON ((1 0, 2 0, 2 -1, 1 -1, 1 0))')
+    data = geopandas.GeoDataFrame({"name": ["abc", "def", "ghi"], "geometry": [p0, p1, p2]})
+    topo = topojson.Topology(data, prequantize=False)
+    p0_wkt = topo.to_gdf().geometry[0].wkt
+
+    assert p0_wkt == 'POLYGON ((0 1, 0 0, 1 0, 2 0, 2 1, 1 1, 0 1))'

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -152,13 +152,12 @@ def coordinates(arcs, tp_arcs, geom_type):
     """
 
     if isinstance(arcs[0], int):
-        coords = np.concatenate(
-            [
-                tp_arcs[arc if arc >= 0 else ~arc][:: arc >= 0 or -1][i > 0 :]
-                for i, arc in enumerate(arcs)
-            ]
-        )
-        coords = coords[~np.isnan(coords).any(axis=1)].tolist()
+        coord_list = []
+        for i, arc in enumerate(arcs):
+            arc_coords = tp_arcs[arc if arc >= 0 else ~arc][:: arc >= 0 or -1]
+            arc_coords = arc_coords[~np.isnan(arc_coords).any(axis=1)]
+            coord_list.append(arc_coords[i > 0:])
+        coords = np.concatenate(coord_list).tolist()
         if geom_type in ["Polygon", "MultiPolygon"]:
             if len(coords) < 3:
                 # This may happen if an arc has only two points.


### PR DESCRIPTION
Modifies function coordinates in utils.py to remove the nan padding in coordinate arrays before removing the first point of an arc.

Added test of the above fix in test_topology.py