### PR TITLE
Fix case surround repeating coords during quantization

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -202,15 +202,8 @@ def test_topology_polygon_point():
 def test_topology_point():
     data = [{"type": "Point", "coordinates": [0.5, 0.5]}]
     topo = topojson.Topology(data, topoquantize=True).to_dict()
-    # with pytest.warns(RuntimeWarning) as topo:
-    #     topojson.Topology(data, topoquantize=True).to_dict()
 
     assert len(topo["arcs"]) == 0
-    # assert topo._record is True
-    # assert (
-    #     topo._list[0].message.args[0] == "divide by zero encountered in double_scalars"
-    # )
-    # # assert topo.value.code == "Cannot quantize when xmax-xmin OR ymax-ymin equals 0"
 
 
 def test_topology_multipoint():
@@ -438,3 +431,13 @@ def test_topology_geojson_duplicates():
     p0_wkt = topo.to_gdf().geometry[0].wkt
 
     assert p0_wkt == 'POLYGON ((0 1, 0 0, 1 0, 2 0, 2 1, 1 1, 0 1))'
+
+# test for https://github.com/mattijn/topojson/issues/110
+def test_topology_topoquantization_dups():
+    gdf = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    gdf = gdf[gdf.name.isin(['France', 'Belgium', 'Netherlands'])]
+    topo = topojson.Topology(data=gdf, prequantize=False).toposimplify(4)
+    topo = topo.topoquantize(50).to_dict()
+
+    assert topo['arcs'][6] == [[44, 47], [0, 0]]
+ 

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -516,7 +516,8 @@ def quantize(linestrings, bbox, quant_factor=1e6):
         `bbox`, bounding box of all linestrings
     """
 
-    x0, y0, x1, y1 = bbox
+    x0, y0, x1, y1 = bbox 
+
     try:
         kx = 1 if (x1 - x0) == 0 else (x1 - x0) / (quant_factor - 1)
         ky = 1 if (y1 - y0) == 0 else (y1 - y0) / (quant_factor - 1)
@@ -539,11 +540,18 @@ def quantize(linestrings, bbox, quant_factor=1e6):
             np.insert(np.absolute(np.diff(ls_xy, 1, axis=0)).sum(axis=1), 0, 1) != 0
         )
 
+        # only remove repeating coordinates when possible
+        # linestring should not become a single point
         if not bool_slice.sum() == 1 or len(ls_xy) == bool_slice.sum():
             if hasattr(ls, "coords"):
                 ls.coords = ls_xy[bool_slice]
             else:
                 linestrings[idx] = ls_xy[bool_slice].tolist()
+        else:
+            if hasattr(ls, "coords"):
+                ls.coords = ls_xy
+            else:
+                linestrings[idx] = ls_xy.tolist()            
 
     transform_ = {"scale": [kx, ky], "translate": [x0, y0]}
 


### PR DESCRIPTION
This PR fix #110. 

After quantization the repeating coordinates in a linestring are filtered. But it should not happen that LineStrings become Points due to removal of repeating coordinates. This was correctly computed, but this case was not written back to the corresponding LineString.

Now this resolves correctly
```python
import topojson as tp
import geopandas as gpd

gdf = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
gdf = gdf[gdf.name.isin(['France', 'Belgium', 'Netherlands'])]
tp.Topology(data=gdf).toposimplify(4).topoquantize(500).to_alt(color='properties.name:N')
```
<img width="463" alt="image" src="https://user-images.githubusercontent.com/5186265/101980906-2bdbf480-3c69-11eb-89e6-0ddf88fbda47.png">

