### PR TITLE
fix syntaxwarning and apply black style formatting

### DIFF
--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -65,10 +65,10 @@ class Cut(Join):
         Parameters
         ----------
         separate : boolean
-            If `True`, each of the linestrings will be displayed separately. 
+            If `True`, each of the linestrings will be displayed separately.
             Default is `False`
         include_junctions : boolean
-            If `True`, the detected junctions will be displayed as well. 
+            If `True`, the detected junctions will be displayed as well.
             Default is `False`
         """
         serialize_as_svg(

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -45,10 +45,10 @@ class Dedup(Cut):
         Parameters
         ----------
         separate : boolean
-            If `True`, each of the linestrings will be displayed separately. 
+            If `True`, each of the linestrings will be displayed separately.
             Default is `False`
         include_junctions : boolean
-            If `True`, the detected junctions will be displayed as well. 
+            If `True`, the detected junctions will be displayed as well.
             Default is `False`
         """
         serialize_as_svg(self.output, separate, include_junctions)
@@ -259,7 +259,7 @@ class Dedup(Cut):
     def _pop_merged_arcs(self, bk_dups, linestring_list, array_bk):
         """
         The collected indici that can be popped, since they have been merged
-        This functions looks like _deduplicate(), but is slightly different where 
+        This functions looks like _deduplicate(), but is slightly different where
         vals2pop indici are set to 0 (NaN).
         """
 

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -59,7 +59,7 @@ class Extract(object):
         self._invalid_geoms = 0
         self._tried_geojson = False
 
-        if instance(data) is "Collection":  # fiona.Collection)
+        if instance(data) == "Collection":  # fiona.Collection
             copydata = data
         else:
             # FIXME: try except is not necessary once the following issue is fixed:

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -29,8 +29,8 @@ class Extract(object):
     with an equivalent `"coordinates"` array that points to one of the
     linestrings as indexed in `bookkeeping_geoms` and stored in `linestrings`.
 
-    For Points geometries count the same, but are stored in `coordinates` and 
-    referenced in `bookkeeping_coords`.    
+    For Points geometries count the same, but are stored in `coordinates` and
+    referenced in `bookkeeping_coords`.
 
     Parameters
     ----------
@@ -91,13 +91,13 @@ class Extract(object):
         Parameters
         ----------
         separate : boolean
-            If `True`, each of the linestrings will be displayed separately. 
+            If `True`, each of the linestrings will be displayed separately.
             Default is `False`
         """
         serialize_as_svg(self.output, separate, include_junctions=False)
 
     def _extractor(self, data):
-        """"
+        """
         Entry point for the class Extract.
 
         The extract function is the first step in the topology computation.
@@ -120,7 +120,7 @@ class Extract(object):
         with an equivalent `"coordinates"` array that points to one of the
         linestrings as indexed in `bookkeeping_geoms` and stored in `linestrings`.
 
-        For Points geometries count the same, but are stored in `coordinates` and 
+        For Points geometries count the same, but are stored in `coordinates` and
         referenced in `bookkeeping_coords`.
         """
 
@@ -696,4 +696,3 @@ class Extract(object):
             # reset geom collection counter and level
             self._geomcollection_counter = 0
             self._geom_level_1 = 0
-

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -38,7 +38,7 @@ class Hashmap(Dedup):
         Parameters
         ----------
         separate : boolean
-            If `True`, each of the linestrings will be displayed separately. 
+            If `True`, each of the linestrings will be displayed separately.
             Default is `False`
         """
         serialize_as_svg(self.output, separate, include_junctions=False)

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -328,7 +328,7 @@ class Hashmap(Dedup):
             arcs_in_geom = self._data[bk_objects][geom]
             for idx_arc, arc_ref in enumerate(arcs_in_geom):
                 arc_ids = self._data[bk_element][arc_ref]
-                if len(arc_ids) > 1 and key is not "coordinates":
+                if len(arc_ids) > 1 and key != "coordinates":
                     self._inner = True if idx_arc > 0 else False
                     arc_ids = self._backward_arcs(arc_ids)
 

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -79,10 +79,10 @@ class Join(Extract):
         Parameters
         ----------
         separate : boolean
-            If `True`, each of the linestrings will be displayed separately. 
+            If `True`, each of the linestrings will be displayed separately.
             Default is `False`
         include_junctions : boolean
-            If `True`, the detected junctions will be displayed as well. 
+            If `True`, the detected junctions will be displayed as well.
             Default is `False`
         """
         serialize_as_svg(self.output, separate, include_junctions)
@@ -240,7 +240,7 @@ class Join(Extract):
 
     def _validate_linemerge(self, merged_line):
         """
-        Return list of linestrings. If the linemerge was a MultiLineString 
+        Return list of linestrings. If the linemerge was a MultiLineString
         then returns a list of multiple single linestrings
         """
 

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -16,73 +16,73 @@ from ..utils import serialize_as_geojson
 
 class Topology(Hashmap):
     """
-    Returns a TopoJSON topology for the specified geometric object. TopoJSON is an 
-    extension of GeoJSON providing multiple approaches to compress the geographical 
-    input data. These options include simplifying the linestrings or quantizing the 
+    Returns a TopoJSON topology for the specified geometric object. TopoJSON is an
+    extension of GeoJSON providing multiple approaches to compress the geographical
+    input data. These options include simplifying the linestrings or quantizing the
     coordinates but foremost the computation of a topology.
 
     Parameters
     ----------
     data : _any_ geometric type
-        Geometric data that should be converted into TopoJSON 
+        Geometric data that should be converted into TopoJSON
     topology : boolean
-        Specifiy if the topology should be computed for deriving the TopoJSON. 
+        Specifiy if the topology should be computed for deriving the TopoJSON.
         Default is `True`.
     prequantize : boolean, int
-        If the prequantization parameter is specified, the input geometry is 
-        quantized prior to computing the topology, the returned topology is 
-        quantized, and its arcs are delta-encoded. Quantization is recommended to 
-        improve the quality of the topology if the input geometry is messy (i.e., 
-        small floating point error means that adjacent boundaries do not have 
-        identical values); typical values are powers of ten, such as `1e4`, `1e5` or 
-        `1e6`. 
+        If the prequantization parameter is specified, the input geometry is
+        quantized prior to computing the topology, the returned topology is
+        quantized, and its arcs are delta-encoded. Quantization is recommended to
+        improve the quality of the topology if the input geometry is messy (i.e.,
+        small floating point error means that adjacent boundaries do not have
+        identical values); typical values are powers of ten, such as `1e4`, `1e5` or
+        `1e6`.
         Default is `True` (which correspond to a quantize factor of `1e6`).
     topoquantize : boolean or int
-        If the topoquantization parameter is specified, the input geometry is quantized 
-        after the topology is constructed. If the topology is already quantized this 
-        will be resolved first before the topoquantization is applied. See for more 
-        details the `prequantize` parameter. 
+        If the topoquantization parameter is specified, the input geometry is quantized
+        after the topology is constructed. If the topology is already quantized this
+        will be resolved first before the topoquantization is applied. See for more
+        details the `prequantize` parameter.
         Default is `False`.
     presimplify : boolean, float
-        Apply presimplify to remove unnecessary points from linestrings before the 
+        Apply presimplify to remove unnecessary points from linestrings before the
         topology is constructed. This will simplify the input geometries. Use with care.
         Default is `False`.
-    toposimplify : boolean, float 
-        Apply toposimplify to remove unnecessary points from arcs after the topology 
-        is constructed. This will simplify the constructed arcs without altering the 
-        topological relations. Sensible values for coordinates stored in degrees are 
-        in the range of `0.0001` to `10`. 
+    toposimplify : boolean, float
+        Apply toposimplify to remove unnecessary points from arcs after the topology
+        is constructed. This will simplify the constructed arcs without altering the
+        topological relations. Sensible values for coordinates stored in degrees are
+        in the range of `0.0001` to `10`.
         Defaults to `False`.
     shared_coords : boolean
-        Sets the strategy to detect junctions. When set to `True` a path is 
-        considered shared when all coordinates appear in both paths 
-        (`coords-connected`). When set to `False` a path is considered shared when 
-        coordinates are the same path (`path-connected`). The path-connected strategy 
-        is more 'correct', but slower. 
+        Sets the strategy to detect junctions. When set to `True` a path is
+        considered shared when all coordinates appear in both paths
+        (`coords-connected`). When set to `False` a path is considered shared when
+        coordinates are the same path (`path-connected`). The path-connected strategy
+        is more 'correct', but slower.
         Default is `True`.
     prevent_oversimplify: boolean
-        If this setting is set to `True`, the simplification is slower, but the 
-        likelihood of producing valid geometries is higher as it prevents 
-        oversimplification. Simplification happens on paths separately, so this 
-        setting is especially relevant for rings with no partial shared paths. This 
-        is also known as a topology-preserving variant of simplification. 
-        Default is `True`.        
+        If this setting is set to `True`, the simplification is slower, but the
+        likelihood of producing valid geometries is higher as it prevents
+        oversimplification. Simplification happens on paths separately, so this
+        setting is especially relevant for rings with no partial shared paths. This
+        is also known as a topology-preserving variant of simplification.
+        Default is `True`.
     simplify_with : str
-        Sets the package to use for simplifying (both pre- and toposimplify). Choose 
-        between `shapely` or `simplification`. Shapely adopts solely Douglas-Peucker 
-        and simplification both Douglas-Peucker and Visvalingam-Whyatt. The pacakge 
-        simplification is known to be quicker than shapely. 
+        Sets the package to use for simplifying (both pre- and toposimplify). Choose
+        between `shapely` or `simplification`. Shapely adopts solely Douglas-Peucker
+        and simplification both Douglas-Peucker and Visvalingam-Whyatt. The pacakge
+        simplification is known to be quicker than shapely.
         Default is `shapely`.
     simplify_algorithm : str
-        Choose between `dp` and `vw`, for Douglas-Peucker or Visvalingam-Whyatt 
-        respectively. `vw` will only be selected if `simplify_with` is set to 
-        `simplification`. 
+        Choose between `dp` and `vw`, for Douglas-Peucker or Visvalingam-Whyatt
+        respectively. `vw` will only be selected if `simplify_with` is set to
+        `simplification`.
         Default is `dp`.
     winding_order : str
-        Determines the winding order of the features in the output geometry. Choose 
+        Determines the winding order of the features in the output geometry. Choose
         between `CW_CCW` for clockwise orientation for outer rings and counter-
-        clockwise for interior rings. Or `CCW_CW` for counter-clockwise for outer 
-        rings and clockwise for interior rings. 
+        clockwise for interior rings. Or `CCW_CW` for counter-clockwise for outer
+        rings and clockwise for interior rings.
         Default is `CW_CCW` for TopoJSON.
     """
 
@@ -123,7 +123,7 @@ class Topology(Hashmap):
         Parameters
         ----------
         options : boolean
-            If `True`, the options also will be included. 
+            If `True`, the options also will be included.
             Default is `False`
         """
         topo_object = copy.deepcopy(self.output)
@@ -139,7 +139,7 @@ class Topology(Hashmap):
         Parameters
         ----------
         separate : boolean
-            If `True`, each of the arcs will be displayed separately. 
+            If `True`, each of the arcs will be displayed separately.
             Default is `False`
         """
         serialize_as_svg(self.output, separate, include_junctions=False)
@@ -154,11 +154,11 @@ class Topology(Hashmap):
             If set, writes the object to a file on drive.
             Default is `None`.
         options : boolean
-            If `True`, the options also will be included. 
+            If `True`, the options also will be included.
             Default is `False`.
         pretty : boolean
-            If `pretty=True`, the JSON object will be 'pretty', depending on the 
-            `ident` and `maxlinelength` options. If `pretty=False`, it will `compact`, 
+            If `pretty=True`, the JSON object will be 'pretty', depending on the
+            `ident` and `maxlinelength` options. If `pretty=False`, it will `compact`,
             eliminating whitespace.
             Default is `False`.
         indent : int
@@ -189,7 +189,7 @@ class Topology(Hashmap):
     ):
         """
         Convert the Topology to a GeoJSON object. Remember that this will destroy the
-        computed Topology. 
+        computed Topology.
 
         Parameters
         ----------
@@ -197,8 +197,8 @@ class Topology(Hashmap):
             If set, writes the object to a file on drive.
             Default is `None`
         pretty : boolean
-            If `pretty=True`, the JSON object will be 'pretty', depending on the 
-            `ident` and `maxlinelength` options. If `pretty=False`, it will `compact`, 
+            If `pretty=True`, the JSON object will be 'pretty', depending on the
+            `ident` and `maxlinelength` options. If `pretty=False`, it will `compact`,
             eliminating whitespace.
             Default is `False`.
         indent : int
@@ -208,15 +208,15 @@ class Topology(Hashmap):
             If `pretty=True`, declares the maximum length of each line.
             Default is `88`.
         validate : boolean
-            Set to `True` to validate each feature before inclusion in the GeoJSON. Only 
+            Set to `True` to validate each feature before inclusion in the GeoJSON. Only
             features that are valid geometries objects will be included.
             Default is `False`.
         winding_order : str
-            Determines the winding order of the features in the output geometry. Choose 
+            Determines the winding order of the features in the output geometry. Choose
             between `CW_CCW` for clockwise orientation for outer rings and counter-
-            clockwise for interior rings. Or `CCW_CW` for counter-clockwise for outer 
-            rings and clockwise for interior rings. 
-            Default is `CCW_CW` for GeoJSON.            
+            clockwise for interior rings. Or `CCW_CW` for counter-clockwise for outer
+            rings and clockwise for interior rings.
+            Default is `CCW_CW` for GeoJSON.
         objectname : str
             The name of the object within the Topology to convert to GeoJSON.
             Default is `data`.
@@ -235,29 +235,29 @@ class Topology(Hashmap):
     ):
         """
         Convert the Topology to a GeoDataFrame. Remember that this will destroy the
-        computed Topology. 
+        computed Topology.
 
-        Note: This function use not the TopoJSON driver within Fiona, but a custom 
-        implemented more robust variant. See for info the `to_geojson()` function. 
+        Note: This function use not the TopoJSON driver within Fiona, but a custom
+        implemented more robust variant. See for info the `to_geojson()` function.
 
         Parameters
         ----------
         crs : str, dict
             coordinate reference system to set on the resulting frame.
-            Default is `None`. 
+            Default is `None`.
         validate : boolean
-            Set to `True` to validate each feature before inclusion in the GeoJSON. Only 
+            Set to `True` to validate each feature before inclusion in the GeoJSON. Only
             features that are valid geometries objects will be included.
             Default is `False`.
         winding_order : str
-            Determines the winding order of the features in the output geometry. Choose 
+            Determines the winding order of the features in the output geometry. Choose
             between `CW_CCW` for clockwise orientation for outer rings and counter-
-            clockwise for interior rings. Or `CCW_CW` for counter-clockwise for outer 
-            rings and clockwise for interior rings. 
-            Default is `CCW_CW` for GeoJSON.            
+            clockwise for interior rings. Or `CCW_CW` for counter-clockwise for outer
+            rings and clockwise for interior rings.
+            Default is `CCW_CW` for GeoJSON.
         objectname : str
             The name of the object within the Topology to convert to GeoJSON.
-            Default is `data`.            
+            Default is `data`.
         """
         from ..utils import serialize_as_geodataframe
 
@@ -278,9 +278,9 @@ class Topology(Hashmap):
         ----------
         color : str
             Assign an property attribute to be used for color encoding and renders the
-            Altair visualization as geoshape. Remember that most of the time the wanted 
-            attribute is nested within properties. Moreover, specific type declaration 
-            is required. Eg `color='properties.name:N'`. 
+            Altair visualization as geoshape. Remember that most of the time the wanted
+            attribute is nested within properties. Moreover, specific type declaration
+            is required. Eg `color='properties.name:N'`.
             Default is `None` (render as mesh).
         tooltip : boolean
             Option to include or exclude tooltips on geoshape objects
@@ -305,7 +305,7 @@ class Topology(Hashmap):
         slider_topoquantize={"min": 1, "max": 6, "step": 1, "value": 1e5, "base": 10},
     ):
         """
-        Create an interactive widget based on Altair. The widget includes sliders to 
+        Create an interactive widget based on Altair. The widget includes sliders to
         interactively change the `toposimplify` and `topoquantize` settings.
 
         Parameters
@@ -328,9 +328,9 @@ class Topology(Hashmap):
 
     def topoquantize(self, quant_factor, inplace=False):
         """
-        Quantization is recommended to improve the quality of the topology if the 
-        input geometry is messy (i.e., small floating point error means that 
-        adjacent boundaries do not have identical values); typical values are powers 
+        Quantization is recommended to improve the quality of the topology if the
+        input geometry is messy (i.e., small floating point error means that
+        adjacent boundaries do not have identical values); typical values are powers
         of ten, such as `1e4`, `1e5` or  `1e6`.
 
         Parameters
@@ -338,13 +338,13 @@ class Topology(Hashmap):
         quant_factor : float
             tolerance parameter
         inplace : bool, optional
-            If `True`, do operation inplace and return `None`. 
+            If `True`, do operation inplace and return `None`.
             Default is `False`.
 
         Returns
         -------
         object or None
-            Quantized coordinates and delta-encoded arcs if `inplace` is `False`. 
+            Quantized coordinates and delta-encoded arcs if `inplace` is `False`.
         """
         result = copy.deepcopy(self)
         arcs = result.output["arcs"]
@@ -386,9 +386,9 @@ class Topology(Hashmap):
         inplace=False,
     ):
         """
-        Apply toposimplify to remove unnecessary points from arcs after the topology 
-        is constructed. This will simplify the constructed arcs without altering the 
-        topological relations. Sensible values for coordinates stored in degrees are 
+        Apply toposimplify to remove unnecessary points from arcs after the topology
+        is constructed. This will simplify the constructed arcs without altering the
+        topological relations. Sensible values for coordinates stored in degrees are
         in the range of `0.0001` to `10`.
 
         Parameters
@@ -396,31 +396,31 @@ class Topology(Hashmap):
         epsilon : float
             tolerance parameter.
         simplify_algorithm : str, optional
-            Choose between `dp` and `vw`, for Douglas-Peucker or Visvalingam-Whyatt 
-            respectively. `vw` will only be selected if `simplify_with` is set to 
-            `simplification`. 
-            Default is `None`, meaning that the default (`dp`) is not overwritten.  
+            Choose between `dp` and `vw`, for Douglas-Peucker or Visvalingam-Whyatt
+            respectively. `vw` will only be selected if `simplify_with` is set to
+            `simplification`.
+            Default is `None`, meaning that the default (`dp`) is not overwritten.
         simplify_with : str, optional
-            Sets the package to use for simplifying. Choose between `shapely` or 
-            `simplification`. Shapely adopts solely Douglas-Peucker and simplification 
-            both Douglas-Peucker and Visvalingam-Whyatt. The pacakge simplification is 
-            known to be quicker than shapely. 
-            Default is `None`, meaning that the default (`shapely`) is not overwritten.                         
+            Sets the package to use for simplifying. Choose between `shapely` or
+            `simplification`. Shapely adopts solely Douglas-Peucker and simplification
+            both Douglas-Peucker and Visvalingam-Whyatt. The pacakge simplification is
+            known to be quicker than shapely.
+            Default is `None`, meaning that the default (`shapely`) is not overwritten.
         prevent_oversimplify: boolean, optional
-            If this setting is set to `True`, the simplification is slower, but the 
-            likelihood of producing valid geometries is higher as it prevents 
-            oversimplification. Simplification happens on paths separately, so this 
-            setting is especially relevant for rings with no partial shared paths. This 
-            is also known as a topology-preserving variant of simplification. 
+            If this setting is set to `True`, the simplification is slower, but the
+            likelihood of producing valid geometries is higher as it prevents
+            oversimplification. Simplification happens on paths separately, so this
+            setting is especially relevant for rings with no partial shared paths. This
+            is also known as a topology-preserving variant of simplification.
             Default is `None`, meaning that the default (`True`) is not overwritten.
         inplace : bool, optional
-            If `True`, do operation inplace and return `None`. 
+            If `True`, do operation inplace and return `None`.
             Default is `False`.
 
         Returns
         -------
         object or None
-            Topology object with simplfified linestrings if `inplace` is `False`. 
+            Topology object with simplfified linestrings if `inplace` is `False`.
         """
         result = copy.deepcopy(self)
 

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -6,7 +6,7 @@ from shapely import wkt
 from shapely.strtree import STRtree
 import pprint
 import copy
-import logging 
+import logging
 
 
 try:
@@ -45,7 +45,7 @@ def asvoid(arr):
 
     arr = np.ascontiguousarray(arr)
     if np.issubdtype(arr.dtype, np.floating):
-        """ Care needs to be taken here since
+        """Care needs to be taken here since
         np.array([-0.]).view(np.void) != np.array([0.]).view(np.void)
         Adding 0. converts -0. to 0.
         """
@@ -100,7 +100,7 @@ def insert_coords_in_line(line, tree_splitter):
     Returns
     -------
     (numpy.array)
-        `new_ls_xy` is an array with inserted coordinates, if any, representing a line 
+        `new_ls_xy` is an array with inserted coordinates, if any, representing a line
         segment
     (numpy.array)
         `pts_xy_on_line` is an array with coordinates that are on the line
@@ -333,7 +333,7 @@ def compare_bounds(b0, b1):
     b0 : tuple
         tuple of xmin, ymin, xmax, ymax
     b1 : tuple
-        tuple of xmin, ymin, xmax, ymax        
+        tuple of xmin, ymin, xmax, ymax
 
     Returns
     -------
@@ -516,7 +516,7 @@ def quantize(linestrings, bbox, quant_factor=1e6):
         `bbox`, bounding box of all linestrings
     """
 
-    x0, y0, x1, y1 = bbox 
+    x0, y0, x1, y1 = bbox
 
     try:
         kx = 1 if (x1 - x0) == 0 else (x1 - x0) / (quant_factor - 1)
@@ -551,7 +551,7 @@ def quantize(linestrings, bbox, quant_factor=1e6):
             if hasattr(ls, "coords"):
                 ls.coords = ls_xy
             else:
-                linestrings[idx] = ls_xy.tolist()            
+                linestrings[idx] = ls_xy.tolist()
 
     transform_ = {"scale": [kx, ky], "translate": [x0, y0]}
 
@@ -580,7 +580,7 @@ def simplify(
     * https://observablehq.com/@lemonnish/minify-topojson-in-the-browser
     * https://github.com/topojson/topojson-simplify#planarTriangleArea
     * https://www.jasondavies.com/simplify/
-    * https://bost.ocks.org/mike/simplify/    
+    * https://bost.ocks.org/mike/simplify/
     * https://pdfs.semanticscholar.org/9877/cdf50a15367bcb86649b67df8724425c5451.pdf
 
     Parameters
@@ -824,8 +824,8 @@ def cart(arr):
 
 def find_duplicates(segments_list, type="array"):
     """
-    Function for solely detecting and recording duplicate LineStrings. The function 
-    converts sorts the coordinates of each linestring and gets the hash. Using the 
+    Function for solely detecting and recording duplicate LineStrings. The function
+    converts sorts the coordinates of each linestring and gets the hash. Using the
     hashes it can quickly detect duplicates and return the indices.
 
     Parameters
@@ -881,7 +881,7 @@ def map_values(arr, search_vals, replace_vals):
     This function replace values element-wise in a numpy array.
     Its quick and avoids a np.where-loop (which is slow).
     The result is a new array, not inplace.
-    
+
     Parameters
     ----------
     arr : np.array
@@ -890,7 +890,7 @@ def map_values(arr, search_vals, replace_vals):
         array with 'bad' values
     replace_vals : list or 1D np.array
         array with 'good' values
-    
+
     Returns
     -------
     np.array

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -89,9 +89,9 @@ class TopoOptions(object):
 def coordinates(arcs, tp_arcs, geom_type):
     """
     Return GeoJSON coordinates for the sequence(s) of arcs.
-    
-    The arcs parameter may be a sequence of ints, each the index of a coordinate 
-    sequence within tp_arcs within the entire topology describing a line string, a 
+
+    The arcs parameter may be a sequence of ints, each the index of a coordinate
+    sequence within tp_arcs within the entire topology describing a line string, a
     sequence of such sequences, describing a polygon, or a sequence of polygon arcs.
     """
 
@@ -100,7 +100,7 @@ def coordinates(arcs, tp_arcs, geom_type):
         for i, arc in enumerate(arcs):
             arc_coords = tp_arcs[arc if arc >= 0 else ~arc][:: arc >= 0 or -1]
             arc_coords = arc_coords[~np.isnan(arc_coords).any(axis=1)]
-            coord_list.append(arc_coords[i > 0:])
+            coord_list.append(arc_coords[i > 0 :])
         coords = np.concatenate(coord_list).tolist()
         if geom_type in ["Polygon", "MultiPolygon"]:
             if len(coords) < 3:
@@ -120,7 +120,7 @@ def coordinates(arcs, tp_arcs, geom_type):
 def geometry(obj, tp_arcs, transform=None):
     """
     Converts a topology object to a geometry object.
-    
+
     The topology object is a dict with 'type' and 'arcs' items.
     """
     if obj["type"] == "GeometryCollection":
@@ -336,7 +336,7 @@ def serialize_as_geodataframe(fc, crs=None):
         a complete object representing a GeoJSON file
     crs : str, dict
         coordinate reference system to set on the resulting frame.
-        Default is `None`.      
+        Default is `None`.
 
     Returns
     -------


### PR DESCRIPTION
As was raised in #120, there were some syntax style warnings.
I also applied black formatting to remove spaces from the end of a comment/docstring sentence.