### PR TITLE
filter nan before converting array to int64

### DIFF
--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -298,6 +298,7 @@ class Dedup(Cut):
 
         # collect new indices of shared arcs
         u, c = np.unique(arr_new, return_counts=True)
-        arr_bk_sarcs = u[c > 1]  # should I check here if c also is not NaN? 
-
+        arr_bk_sarcs = u[c > 1] 
+        arr_bk_sarcs = arr_bk_sarcs[~np.isnan(arr_bk_sarcs)]
+        
         return arr_new, arr_bk_sarcs

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -298,6 +298,6 @@ class Dedup(Cut):
 
         # collect new indices of shared arcs
         u, c = np.unique(arr_new, return_counts=True)
-        arr_bk_sarcs = u[c > 1]
+        arr_bk_sarcs = u[c > 1]  # should I check here if c also is not NaN? 
 
         return arr_new, arr_bk_sarcs


### PR DESCRIPTION
This PR makes sure that NaN values are filtered before converting the array into an integer in Dedup phase.