### PR TITLE
Move deep-copy from top-level to dict-level

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -361,3 +361,57 @@ def test_extract_fiona_file_gpkg():
     topo = Extract(feats).to_dict()
 
     assert len(topo["bookkeeping_geoms"]) == 4
+
+def test_extract_dict_org_data_untouched():
+    data = {
+        "foo": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+        "bar": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
+    }
+    topo = Extract(data).to_dict()
+    topo_foo = topo['objects']['foo']
+    data_foo = data["foo"]
+
+    assert 'arcs' in topo_foo.keys()
+    assert 'arcs' not in data_foo.keys()
+
+def test_extract_list_org_data_untouched():
+    data = [
+        geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+        geometry.Polygon([[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]),
+    ]
+    topo = Extract(data).to_dict()
+    topo_0 = topo['objects'][0]
+    data_0 = data[0]
+
+    assert 'arcs' in topo_0.keys()
+    assert data_0.type == 'Polygon'
+
+def test_extract_gdf_org_data_untouched():
+    data = geopandas.read_file(
+        "tests/files_geojson/naturalearth_alb_grc.geojson", driver="GeoJSON"
+    )
+    topo = Extract(data).to_dict()
+    topo_0 = topo['objects'][0]
+    data_0 = data.iloc[0]
+
+    assert 'arcs' in topo_0.keys()
+    assert data_0.geometry.type == 'Polygon'
+
+def test_extract_shapely_org_data_untouched():
+    data = geometry.LineString([[0, 0], [1, 0], [1, 1], [0, 1]])
+    topo = Extract(data).to_dict()  
+    topo_0 = topo['objects'][0]
+
+    assert 'arcs' in topo_0.keys()
+    assert data.type == 'LineString'    
+
+def test_extract_shapefile_org_data_untouched():
+    import shapefile
+
+    data = shapefile.Reader("tests/files_shapefile/southamerica.shp")
+    topo = Extract(data).to_dict()
+    topo_0 = topo['objects']['feature_00']['geometries'][0]
+    data_0 = data.__geo_interface__['features'][0]['geometry']
+
+    assert 'arcs' in topo_0.keys()
+    assert 'arcs' not in data_0.keys() 

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -59,19 +59,19 @@ class Extract(object):
         self._invalid_geoms = 0
         self._tried_geojson = False
 
-        if instance(data) == "Collection":  # fiona.Collection
-            copydata = data
-        else:
-            # FIXME: try except is not necessary once the following issue is fixed:
-            # https://github.com/geopandas/geopandas/issues/1070
-            try:
-                copydata = copy.deepcopy(data)
-            except TypeError:
-                if hasattr(data, "copy"):
-                    copydata = data.copy()
-                else:
-                    copydata = data
-        self.output = self._extractor(copydata)
+        # if instance(data) == "Collection":  # fiona.Collection
+        #     copydata = data
+        # else:
+        #     # FIXME: try except is not necessary once the following issue is fixed:
+        #     # https://github.com/geopandas/geopandas/issues/1070
+        #     try:
+        #         copydata = copy.deepcopy(data)
+        #     except TypeError:
+        #         if hasattr(data, "copy"):
+        #             copydata = data.copy()
+        #         else:
+        #             copydata = data
+        self.output = self._extractor(data)
 
     def __repr__(self):
         return "Extract(\n{}\n)".format(pprint.pformat(self.output))
@@ -610,6 +610,7 @@ class Extract(object):
         """
 
         self._is_single = False
+        self._data = copy.deepcopy(self._data)
         # iterate over the input dictionary or geographical object
         for key in list(self._data):
             # based on the geom type the right function is serialized


### PR DESCRIPTION
This PR fix #120. The deep copy is now applied on the dict-level and not on the top-level. It will not throw AttributeErrors for pyshp.

Several tests are included to check if the original data remains untouched and this is OK now for the data files considered in these tests. 

Thanks @karimbahgat for providing the hints how to approach this! 