### PR TITLE
Allow Topojson dicts to be parsed into Topology

### DIFF
--- a/docs/example/input-types.md
+++ b/docs/example/input-types.md
@@ -310,3 +310,29 @@ tp.Topology(dict_in, prequantize=False).to_json()
 ```
 </div>
 </div>
+
+* * * 
+
+## TopoJSON file loaded as json-dict
+A TopoJSON file can be postprocessed.
+
+<div class="code-example mx-1 bg-example">
+<div class="example-label" markdown="1">
+Example 🔧
+{: .label .label-blue-000 }
+</div>
+<div class="example-text" markdown="1">
+
+```python
+import topojson as tp
+import json
+
+with open("tests/files_topojson/naturalearth_lowres_africa.topojson", 'r') as f:
+    data = json.load(f)
+# parse topojson file using `objects_name`
+topo = topojson.Topology(data, objects_name="data")
+topo.toposimplify(4).to_svg()
+```
+<img src="../images/africa_toposimp.svg">
+</div>
+</div>

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -211,7 +211,6 @@ def test_extract_geopandas_geoseries():
     assert len(topo["objects"]) == 3
     assert len(topo["bookkeeping_geoms"]) == 3
     assert len(topo["linestrings"]) == 3
-    # TEST FAILS because of https://github.com/geopandas/geopandas/issues/1070
 
 
 # test shapely geometry collection.
@@ -362,6 +361,7 @@ def test_extract_fiona_file_gpkg():
 
     assert len(topo["bookkeeping_geoms"]) == 4
 
+# test to check if original data is not modified
 def test_extract_dict_org_data_untouched():
     data = {
         "foo": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]},
@@ -374,6 +374,7 @@ def test_extract_dict_org_data_untouched():
     assert 'arcs' in topo_foo.keys()
     assert 'arcs' not in data_foo.keys()
 
+# test to check if original data is not modified
 def test_extract_list_org_data_untouched():
     data = [
         geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
@@ -386,6 +387,7 @@ def test_extract_list_org_data_untouched():
     assert 'arcs' in topo_0.keys()
     assert data_0.type == 'Polygon'
 
+# test to check if original data is not modified
 def test_extract_gdf_org_data_untouched():
     data = geopandas.read_file(
         "tests/files_geojson/naturalearth_alb_grc.geojson", driver="GeoJSON"
@@ -397,6 +399,7 @@ def test_extract_gdf_org_data_untouched():
     assert 'arcs' in topo_0.keys()
     assert data_0.geometry.type == 'Polygon'
 
+# test to check if original data is not modified
 def test_extract_shapely_org_data_untouched():
     data = geometry.LineString([[0, 0], [1, 0], [1, 1], [0, 1]])
     topo = Extract(data).to_dict()  
@@ -405,6 +408,7 @@ def test_extract_shapely_org_data_untouched():
     assert 'arcs' in topo_0.keys()
     assert data.type == 'LineString'    
 
+# test to check if original data is not modified
 def test_extract_shapefile_org_data_untouched():
     import shapefile
 
@@ -414,4 +418,4 @@ def test_extract_shapefile_org_data_untouched():
     data_0 = data.__geo_interface__['features'][0]['geometry']
 
     assert 'arcs' in topo_0.keys()
-    assert 'arcs' not in data_0.keys() 
+    assert 'arcs' not in data_0.keys()  

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -35,7 +35,7 @@ def test_topology_winding_order_TopoOptions():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 10
+    assert len(topo["options"]) == 11
 
 
 # test winding order using kwarg variables
@@ -46,7 +46,7 @@ def test_topology_winding_order_kwarg_vars():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 10
+    assert len(topo["options"]) == 11
 
 
 def test_topology_computing_topology():
@@ -441,7 +441,7 @@ def test_topology_topoquantization_dups():
 
     assert topo['arcs'][6] == [[44, 47], [0, 0]]
  
- # parse topojson from file
+# parse topojson from file
 def test_topology_topojson_from_file():
     with open("tests/files_topojson/naturalearth.topojson", 'r') as f:
         data = json.load(f)
@@ -449,3 +449,29 @@ def test_topology_topojson_from_file():
     topo = topojson.Topology(data).to_dict()
 
     assert len(topo["objects"]) == 1   
+
+# parse topojson file and plot with altair
+def test_topology_topojson_to_alt():
+    # load topojson file into dict
+    with open("tests/files_topojson/naturalearth_lowres_africa.topojson", 'r') as f:
+        data = json.load(f)
+        
+    # parse topojson file using `objects_name`
+    topo = topojson.Topology(data, objects_name="data")
+    # apply toposimplify and serialize to altair
+    chart = topo.toposimplify(1).to_alt()    
+
+    assert len(chart.__dict__.keys()) == 2
+
+# Object of type int64 is not JSON serializable
+def test_topology_topojson_to_alt_int64():
+    # load topojson file into dict
+    with open("tests/files_topojson/mesh2d.topojson", 'r') as f:
+        data = json.load(f)    
+
+    # parse topojson file using `objects_name`
+    topo = topojson.Topology(data, objects_name="mesh2d_flowelem_bl")
+    # apply toposimplify and serialize to altair
+    chart = topo.toposimplify(1).to_alt()  
+
+    assert len(chart.__dict__.keys()) == 2       

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -441,3 +441,11 @@ def test_topology_topoquantization_dups():
 
     assert topo['arcs'][6] == [[44, 47], [0, 0]]
  
+ # parse topojson from file
+def test_topology_topojson_from_file():
+    with open("tests/files_topojson/naturalearth.topojson", 'r') as f:
+        data = json.load(f)
+
+    topo = topojson.Topology(data).to_dict()
+
+    assert len(topo["objects"]) == 1   

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -59,18 +59,6 @@ class Extract(object):
         self._invalid_geoms = 0
         self._tried_geojson = False
 
-        # if instance(data) == "Collection":  # fiona.Collection
-        #     copydata = data
-        # else:
-        #     # FIXME: try except is not necessary once the following issue is fixed:
-        #     # https://github.com/geopandas/geopandas/issues/1070
-        #     try:
-        #         copydata = copy.deepcopy(data)
-        #     except TypeError:
-        #         if hasattr(data, "copy"):
-        #             copydata = data.copy()
-        #         else:
-        #             copydata = data
         self.output = self._extractor(data)
 
     def __repr__(self):
@@ -176,6 +164,7 @@ class Extract(object):
         - dict of objects that provide a __geo_interface__
         - list of objects that provide a __geo_interface__
         - object that provide a __geo_interface__
+        - TopoJSON dict
         - TopoJSON string
         - GeoJSON string
 
@@ -611,6 +600,7 @@ class Extract(object):
 
         self._is_single = False
         self._data = copy.deepcopy(self._data)
+
         # iterate over the input dictionary or geographical object
         for key in list(self._data):
             # based on the geom type the right function is serialized

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -105,7 +105,7 @@ class Hashmap(Dedup):
             objects["geometries"].append(feat)
 
         data["objects"] = {}
-        data["objects"]["data"] = objects
+        data["objects"][self.options.objects_name] = objects
 
         # prepare to return object
         data = self._data

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -25,6 +25,7 @@ class TopoOptions(object):
         simplify_with="shapely",
         simplify_algorithm="dp",
         winding_order=None,
+        objects_name="data"
     ):
         # get all arguments
         arguments = locals()
@@ -80,6 +81,11 @@ class TopoOptions(object):
             self.winding_order = arguments["winding_order"]
         else:
             self.winding_order = None
+
+        if "objects_name" in arguments:
+            self.objects_name = arguments["objects_name"]
+        else:
+            self.objects_name = "data"            
 
     def __repr__(self):
         return "TopoOptions(\n  {}\n)".format(pprint.pformat(self.__dict__))


### PR DESCRIPTION
This PR will fix #124. This PR provides an enhancement by supporting reading topojson files. This enables loading Topojson structured json data into a `Topology` and process them further. Such as the following example:
```python
import json
import topojson

# load topojson file into dict
with open("tests/files_topojson/nybb_from_mapshaper.topojson", 'r') as f:
    data = json.load(f)

# parse topojson file using `objects_name`
topo = topojson.Topology(data, objects_name="nybb")

# apply toposimplify, serialise into a geodataframe and plot
topo.toposimplify(5000).to_gdf().plot()
``` 
<img width="286" alt="image" src="https://user-images.githubusercontent.com/5186265/132140870-f10e6d6f-5261-4830-8ed2-0c22dff42985.png">

Not all functions are working yet (eg `to_alt()`), but it is a good start.