### PR TITLE
Skip properties and bbox in resolve objects

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -474,4 +474,44 @@ def test_topology_topojson_to_alt_int64():
     # apply toposimplify and serialize to altair
     chart = topo.toposimplify(1).to_alt()  
 
-    assert len(chart.__dict__.keys()) == 2       
+    assert len(chart.__dict__.keys()) == 2     
+
+def test_topology_nested_list_properties():
+    from geojson import Feature, Polygon, FeatureCollection
+
+    feat_1 = Feature(
+        geometry=Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]),
+        bbox=[-7.45337, 8.36618, -7.2835, 8.47532],
+        properties={
+            "name": "abc",
+            "geo.neighbors": [
+                "bi_ssu_2",
+                "bi_ssu_3",
+                "bi_ssu_5",
+                "bi_ssu_9",
+                "bi_ssu_11",
+                "bi_ssu_12",
+                "bi_ssu_13",
+            ],
+        },
+    )
+    feat_2 = Feature(
+        geometry=Polygon([[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]),
+        bbox=[-7.45337, 8.36618, -7.2835, 8.47532],
+        properties={
+            "name": "def",
+            "geo.neighbors": [
+                "bi_ssu_2",
+                "bi_ssu_3",
+                "bi_ssu_5",
+                "bi_ssu_9",
+                "bi_ssu_11",
+                "bi_ssu_12",
+                "bi_ssu_13",
+            ],
+        },
+    )
+    fc = FeatureCollection([feat_1, feat_2])
+    topo = topojson.Topology(fc, prequantize=False).to_dict()
+
+    assert len(topo) == 4

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -346,6 +346,8 @@ class Hashmap(Dedup):
             if str(k) in keys and v is not None:
                 dictionary[k] = self._resolve_bookkeeping(v, k)
                 yield v
+            elif k in ["properties", "bbox"]:
+                continue
             elif isinstance(v, dict):
                 for result in self._resolve_objects(keys, v):
                     yield result


### PR DESCRIPTION
This PR fix #125. In the function `_resolve_objects()` it is iteratively searching for an `arcs` or `coordinate` key so the arc indici can be resolved. This keys can be in different location for different geometry types, but it is highly unlikely (incorrect topojson) that these are within the `properties` or `bbox` key per topojson specifcation.

A note to add: a `bbox` element is currently created on topology level. On geometry level no such thing is implemented within this library.