### PR TITLE
Update topology bbox when applying toposimplify or topoquantize

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -515,3 +515,13 @@ def test_topology_nested_list_properties():
     topo = topojson.Topology(fc, prequantize=False).to_dict()
 
     assert len(topo) == 4
+
+def test_topology_update_bbox_topoquantize_toposimplify():
+    # load example data representing continental Africa
+    data = topojson.utils.example_data_africa()  
+    # compute the topology
+    topo = topojson.Topology(data)  
+    # apply simplification on the topology and render as SVG
+    bbox = topo.topoquantize(10).to_dict()['bbox'] 
+
+    assert bbox == (0, 0, 9, 9)    

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -9,6 +9,7 @@ from ..ops import quantize
 from ..ops import simplify
 from ..ops import delta_encoding
 from ..ops import bounds
+from ..ops import compare_bounds
 from ..utils import TopoOptions
 from ..utils import instance
 from ..utils import serialize_as_svg
@@ -402,6 +403,9 @@ class Topology(Hashmap):
             arcs = l_arcs
 
         arcs_qnt, transform = quantize(arcs, result.output["bbox"], quant_factor)
+        lsbs = bounds(arcs_qnt)
+        ptbs = bounds(result.output["coordinates"])
+        result.output["bbox"] = compare_bounds(lsbs, ptbs)          
 
         result.output["arcs"] = delta_encoding(arcs_qnt)
         result.output["transform"] = transform
@@ -493,6 +497,10 @@ class Topology(Hashmap):
                 input_as="array",
                 prevent_oversimplify=result.options.prevent_oversimplify,
             )
+
+            lsbs = bounds(result.output["arcs"])
+            ptbs = bounds(result.output["coordinates"])
+            result.output["bbox"] = compare_bounds(lsbs, ptbs)            
 
             # quantize aqain if quantization was applied
             if transform is not None:


### PR DESCRIPTION
This PR fix #117. Once toposimplify is used the bbox of the overall topology should be updated as well. This is done through this PR. One thing to consider are data files that both contain points and lines. A topology does not apply on points, so for computing the bbox the location of the points should also be considered. 

Example that the bbox is updated once applying topoquantize:
```python
import topojson as tp

# load example data representing continental Africa
data = tp.utils.example_data_africa()  
# compute the topology
topo = tp.Topology(data)  
# apply simplification on the topology and render as SVG
bbox = topo.topoquantize(10).to_dict()['bbox'] 

assert bbox == (0, 0, 9, 9)
```