### PR TITLE
decimals for geojson and fix topoquantize in class

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,13 +11,16 @@
       "program": "${workspaceFolder}/topojson/__init__.py",
       "console": "integratedTerminal",
       "justMyCode": false
+    },
+    {
+      "name": "Python: Debug Unit Tests",
+      "type": "python",
+      "request": "launch",
+      "purpose": [
+        "debug-test"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false,
     }
-    // {
-    //   "name": "Debug Tests",
-    //   "type": "python",
-    //   "request": "test",
-    //   "console": "integratedTerminal",
-    //   "justMyCode": false
-    // }
   ]
 }

--- a/docs/api/topojson.core.topology.md
+++ b/docs/api/topojson.core.topology.md
@@ -161,6 +161,9 @@ computed Topology.
 > + ###### `objectname` : str
     The name of the object within the Topology to convert to GeoJSON.
     Default is `data`
+> + ###### `decimals` : int or None
+    Evenly round the coordinates to the given number of decimals. 
+    Default is `None`, which means no rounding is applied. 
 
 ### to_gdf
 ```python

--- a/docs/example/output-types.md
+++ b/docs/example/output-types.md
@@ -263,7 +263,7 @@ print(topo.to_json(pretty=True))
 </pre>
 The `pretty` option depends on the setting `indent` and `maxlinelength`, these default to `4` and `88` respectively.
 
-More options in generating the GeoJSON from the computed Topololgy are `validate` (`True` or `False`) and `winding_order`. Where the TopoJSON standard defines a winding order of clock-wise orientation for outer polygons and counter-clockwise orientation for innner polygons is the winding order in the GeoJSON standard the opposite (`CCW_CW`).
+More options in generating the GeoJSON from the computed Topololgy are `validate` (`True` or `False`), `winding_order` and `decimals`. Where the TopoJSON standard defines a winding order of clock-wise orientation for outer polygons and counter-clockwise orientation for innner polygons is the winding order in the GeoJSON standard the opposite (`CCW_CW`). The `decimals` option defines the number of decimals for the output coordinates.
 </div>
 </div>
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "topojson" %}
-{% set version = "1.2" %}
+{% set version = "1.4" %}
 
 package:
   name: "{{ name|lower }}"

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -559,3 +559,21 @@ def test_topology_toposimplify_on_topojson_data():
     gdf_1 = topo_1.toposimplify(10).to_gdf()
 
     assert gdf_0.iloc[0].geometry.is_valid == gdf_1.iloc[0].geometry.is_valid
+
+def test_topology_round_coordinates_geojson():
+    # load example data representing continental Africa
+    data = topojson.utils.example_data_africa()
+    # compute the topology
+    topo = topojson.Topology(data)
+    # apply simplification on the topology and render as SVG
+    gjson = topo.topoquantize(10).to_geojson(decimals=2)
+    coord_0 = json.loads(gjson)['features'][0]['geometry']['coordinates'][0][0]
+    assert coord_0 == [35.85, -2.74]
+
+def test_topology_topoquantize():
+    # load example data representing continental Africa
+    data = topojson.utils.example_data_africa()
+    # compute the topology
+    topo = topojson.Topology(data, topoquantize=9).to_dict()
+
+    assert len(topo['arcs']) == 149    

--- a/topojson/__init__.py
+++ b/topojson/__init__.py
@@ -20,6 +20,6 @@ Main Features
   - Optional support for UI controls to exploring the results of topoquantize
     and toposimplify interactively if ipywidgets is installed.
 """
-__version__ = "1.3"
+__version__ = "1.4"
 
 from .core.topology import Topology  # noqa

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -4,7 +4,6 @@ import json
 from .ops import dequantize
 from .ops import bounds
 from .ops import np_array_from_arcs
-from .ops import lists_from_np_array
 from .ops import winding_order
 
 
@@ -474,7 +473,7 @@ def serialize_as_json(topo_object, fp, pretty=False, indent=4, maxlinelength=88)
 
 
 def serialize_as_geojson(
-    topo_object, fp=None, validate=False, objectname="data", order="CCW_CW"
+    topo_object, fp=None, validate=False, objectname="data", order="CCW_CW", decimals=None
 ):
     from shapely.geometry import shape
 
@@ -493,6 +492,10 @@ def serialize_as_geojson(
             np_arcs = dequantize(np_arcs, scale, translate)
     else:
         np_arcs = None
+
+    # evenly round the coordinates to the given number of decimals
+    if decimals is not None and isinstance(decimals, int):
+        np_arcs = np.around(np_arcs, decimals=decimals)
 
     # select object member from topology object
     if not objectname in topo_object["objects"].keys():


### PR DESCRIPTION
This PR introduce the option to set the number of decimals in the `.to_geojson()` function and builds upon https://numpy.org/doc/stable/reference/generated/numpy.around.html.

Next to this found out that the `topoquantize` setting within `Topology()` is not applied inplace. This PR applies a fix for this.
