### PR TITLE
Fix None to 'null' when calling Topology.to_json(pretty=True)

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -351,6 +351,28 @@ def test_topology_to_json(tmp_path):
     assert topo_reloaded
 
 
+def test_topology_to_json_pretty_and_null():
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {
+                    "end_date": None,
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+                }
+            }
+        ]
+    }
+    data = geopandas.GeoDataFrame.from_features(data)
+    topo = topojson.Topology(data).to_json(pretty=True)
+
+    assert '"end_date": null' in topo
+
+
 def test_topology_topoquantize():
     data = [
         {"type": "LineString", "coordinates": [[4, 0], [2, 2], [0, 0]]},

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -310,6 +310,9 @@ def basictype2str(obj):
         strobj = '"' + str(obj) + '"'
     elif isinstance(obj, bool):
         strobj = {True: "true", False: "false"}[obj]
+    # convert None to 'null' since None is not a valid syntax in JSON
+    elif obj is None:
+        strobj = 'null'
     else:
         strobj = str(obj)
     return strobj


### PR DESCRIPTION
In current version, when you call Topology.to_json(pretty=True) on data with properties set to None, it will output None in the result. None is not valid JSON syntax, None should be replace with null

For more info, please look at this issue: #149 

This PR includes a fix to that issue, and a test case for the test suite