### PR TITLE
Fix the bugs of generating topojson with complicated geojson

### DIFF
--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -458,13 +458,19 @@ class Extract(object):
 
         # each Feature becomes a new GeometryCollection
         for idx, feature in enumerate(obj["features"]):
-            # A GeoJSON Feature is mapped to a GeometryCollection
-            feature["type"] = "GeometryCollection"
-            feature["geometries"] = [feature["geometry"]]
-            feature.pop("geometry", None)
-            data["feature_{}".format(str(idx).zfill(zfill_value))] = geometry.shape(
-                feature
-            )  # feature
+            # A GeoJSON Feature is mapped to a GeometryCollection => directly mapped to specific geometry, so that to save the attributes
+            feature["type"] = feature["geometry"]['type']
+            # feature["geometry"] = feature["geometry"]
+            # feature.pop("geometry", None)
+
+            ### here not save the features for visualization:
+            data["feature_{}".format(str(idx).zfill(zfill_value))] = {**feature['properties'],**{'geometry':geometry.shape(
+                feature['geometry']
+            )}}  # feature
+
+            # data["feature_{}".format(str(idx).zfill(zfill_value))] = geometry.shape(
+            #     feature
+            # )  # feature
 
         # new data dictionary is created, throw the geometries back to main()
         self._is_single = False

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -44,7 +44,7 @@ class Extract(object):
         object created including the keys `type`, `linestrings`, `coordinates` `bookkeeping_geoms`, `bookkeeping_coords`, `objects`
     """
 
-    def __init__(self, data, options={}):
+    def     __init__(self, data, options={}):
         # initation topology options
         if isinstance(options, TopoOptions):
             self.options = options
@@ -463,10 +463,15 @@ class Extract(object):
             # feature["geometry"] = feature["geometry"]
             # feature.pop("geometry", None)
 
-            ### here not save the features for visualization:
-            data["feature_{}".format(str(idx).zfill(zfill_value))] = {**feature['properties'],**{'geometry':geometry.shape(
+            feature_dict = {**(feature.get('properties') if feature.get('properties') else {}), **{'geometry' : geometry.shape(
                 feature['geometry']
-            )}}  # feature
+            )}}
+
+            if feature["type"] == 'GeometryCollection':
+                feature_dict['geometries'] = feature['geometry']['geometries']
+
+            ### here not save the features for visualization:
+            data["feature_{}".format(str(idx).zfill(zfill_value))] = feature_dict  # feature
 
             # data["feature_{}".format(str(idx).zfill(zfill_value))] = geometry.shape(
             #     feature
@@ -636,7 +641,14 @@ class Extract(object):
                     # extract geometry and collect type and properties
                     geom = self._obj["geometry"]
                     self._obj.pop("geometry", None)
-                    self._obj = {"properties": self._obj, "type": geom.geom_type}
+
+                    if geom.geom_type == 'GeometryCollection':
+                        geometries = self._obj["geometries"]
+                        self._obj.pop("geometries",None)
+                        self._obj = {"properties" : self._obj, "type" : geom.geom_type,'geometries':geometries}
+                    else:
+                        self._obj = {"properties": self._obj, "type": geom.geom_type}
+
                     self._data[self._key] = self._obj
 
                 # no direct shapely geometries available. Try forcing


### PR DESCRIPTION
I did the test again with proper path and debug the code. 

This time there are three fails in all test:
Two fails are related to test_extract in the assertion of intermediate dict structure. I think these fails are inevitable since I changed the process structure of feature and geometry collections. 

One fail is related to `test_topology_to_geojson_nested_geometrycollection` in `test_topology`. This is also an assertion fail as in my process, I changed the geojson structure of nested geometrycollection, so it cannot be reverted to the same geojson after it is converted to topojson. But as far as I read the generated geojson, I think they can refer to the original geojson with the same geometry. 

I am sorry that I cannot solve the remaining fails since they are much related to other data structures. But I think at least this adaption can be utilized for generating topojson from geojson with attributes. I am not sure whether to merge it or not, so I leave the decision to the maintainers. 