### PR TITLE
reduce warnings for multipart geoms

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -11,7 +11,7 @@ def test_join_undefined_for_non_junction_points():
     }
     topo = Join(data).to_dict()
 
-    assert geometry.Point(1.0, 0.0) not in geometry.MultiPoint(topo["junctions"])
+    assert geometry.Point(1.0, 0.0) not in geometry.MultiPoint(topo["junctions"]).geoms
 
 
 # exact duplicate lines ABC & ABC have no junctions
@@ -57,7 +57,7 @@ def test_join_reversed_line_CBA_extends_new_line_AB():
     }
     topo = Join(data).to_dict()
 
-    assert geometry.Point(1.0, 0.0) in geometry.MultiPoint(topo["junctions"])
+    assert geometry.Point(1.0, 0.0) in geometry.MultiPoint(topo["junctions"]).geoms
 
 
 # when a new line ABC extends an old line AB, there is a junction at B

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -44,7 +44,7 @@ class Extract(object):
         object created including the keys `type`, `linestrings`, `coordinates` `bookkeeping_geoms`, `bookkeeping_coords`, `objects`
     """
 
-    def     __init__(self, data, options={}):
+    def __init__(self, data, options={}):
         # initation topology options
         if isinstance(options, TopoOptions):
             self.options = options
@@ -268,7 +268,7 @@ class Extract(object):
             data = [geom]
             return self._extractor(data)
 
-        for line in geom:
+        for line in geom.geoms:
             self._extract_line(line)
 
     def _extract_ring(self, geom):
@@ -298,9 +298,9 @@ class Extract(object):
         if isinstance(boundary, geometry.MultiLineString):
             # record index as list of items
             # and store each linestring geom
-            lst_idx = list(range(idx_ls, idx_ls + len(list(boundary))))
+            lst_idx = list(range(idx_ls, idx_ls + len(boundary.geoms)))
             self._bookkeeping_geoms.append(lst_idx)
-            for ls in boundary:
+            for ls in boundary.geoms:
                 self._linestrings.append(ls)
         else:
             # record index and store single linestring geom
@@ -329,7 +329,7 @@ class Extract(object):
         if self._is_single:
             return self._extractor([geom])
 
-        for ring in geom:
+        for ring in geom.geoms:
             self._extract_ring(ring)
 
     def _extract_point(self, geom):
@@ -377,7 +377,7 @@ class Extract(object):
         if self._is_single:
             return self._extractor([geom])
 
-        for point in geom:
+        for point in geom.geoms:
             self._extract_point(point)
 
     def _extract_geometrycollection(self, geom):
@@ -400,17 +400,17 @@ class Extract(object):
 
         # obj = self._data[self._key]
         self._geomcollection_counter += 1
-        self.records_collection = len(geom)
+        self.records_collection = len(geom.geoms)
 
         # iterate over the parsed shape(geom)
         # the original data objects is set as self._obj
         # the following lines can catch a GeometryCollection untill two levels deep
         # improvements on this are welcome
-        for idx, geo in enumerate(geom):
+        for idx, geo in enumerate(geom.geoms):
             # if geom is GeometryCollection, collect geometries within collection
             # on right level
             if isinstance(geo, geometry.GeometryCollection):
-                self.records_collection = len(geo)
+                self.records_collection = len(geo.geoms)
                 if self._geomcollection_counter == 1:
                     self._obj = obj["geometries"]
                     self._geom_level_1 = idx

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -245,7 +245,7 @@ class Join(Extract):
         """
 
         if not isinstance(merged_line, geometry.LineString):
-            merged_line = [ls for ls in merged_line]
+            merged_line = [ls for ls in merged_line.geoms]
         else:
             merged_line = [merged_line]
         return merged_line
@@ -278,8 +278,8 @@ class Join(Extract):
         # continue if any shared path was detected
         if fw_bw and not fw_bw.is_empty:
 
-            forward = fw_bw[0]
-            backward = fw_bw[1]
+            forward = fw_bw.geoms[0]
+            backward = fw_bw.geoms[1]
 
             if backward.is_empty:
                 # only contains forward objects
@@ -295,7 +295,7 @@ class Join(Extract):
                 shared_segments = geometry.MultiLineString(forward + backward)
 
             # add shared paths to segments
-            self._segments.extend([list(shared_segments)])
+            self._segments.extend([list(shared_segments.geoms)])
 
             # also add the first coordinates of both geoms as a vertice to segments
             p1_g1 = geometry.Point([g1.xy[0][0], g1.xy[1][0]])

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -138,7 +138,7 @@ def insert_coords_in_line(line, tree_splitter):
 
     # compute the distance from the beginning of the linestring for each junction on line
     splitter_dist = np.array(
-        [line.project(pt) for pt in geometry.MultiPoint(pts_xy_nonexst)]
+        [line.project(pt) for pt in geometry.MultiPoint(pts_xy_nonexst).geoms]
     )
     splitter_dist = splitter_dist[splitter_dist > 0]
 


### PR DESCRIPTION
This PR aims to reduce the number of warnings related to:

ShapelyDeprecationWarning: __len__ OR __getitem__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.

This PR reduces the number of warnings of the test-suite from 589 to 337.

Still a long way to go before realizing full support for shapely 2.0..