### PR TITLE
changes to accomodate the deprecated array interface

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -356,8 +356,12 @@ def test_extract_fiona_file():
 
 
 def test_extract_fiona_file_gpkg():
-    with fiona.open("tests/files_shapefile/rivers.gpkg") as data:
-        feats = data[24:26]
+    with fiona.open("tests/files_shapefile/rivers.gpkg") as col:
+        feats = []
+        for idx, feat in enumerate(col):
+            if idx in [24,25]:
+                feats.append(feat)
+            
     topo = Extract(feats).to_dict()
 
     assert len(topo["bookkeeping_geoms"]) == 4

--- a/topojson/core/dedup.py
+++ b/topojson/core/dedup.py
@@ -69,7 +69,7 @@ class Dedup(Cut):
         # deduplicate equal geometries
         # create numpy array from bookkeeping_geoms variable for numerical computation
         if not self.options.topology and data["linestrings"]:
-            data["linestrings"] = [np.asarray(d) for d in data["linestrings"]]
+            data["linestrings"] = [np.array(d.coords) for d in data["linestrings"]]
 
         if len(data["bookkeeping_linestrings"]):
             array_bk = np.vstack(data["bookkeeping_linestrings"])
@@ -139,7 +139,7 @@ class Dedup(Cut):
             # use in1d function as proxy for contains
             merged_arcs_bool = [
                 np.in1d(
-                    asvoid(data["linestrings"][i]), asvoid(ndp_arcs[segment_idx])
+                    asvoid(data["linestrings"][i]), asvoid(ndp_arcs.geoms[segment_idx].coords)
                 ).any()
                 for i in ndp_arcs_bk
             ]
@@ -232,8 +232,8 @@ class Dedup(Cut):
             # apply linemerge
             ndp_arcs = linemerge([data["linestrings"][i] for i in ndp_arcs_bk])
             if isinstance(ndp_arcs, geometry.LineString):
-                ndp_arcs = [ndp_arcs]
-            no_ndp_arcs = len(ndp_arcs)
+                ndp_arcs = geometry.MultiLineString([ndp_arcs])
+            no_ndp_arcs = len(ndp_arcs.geoms)
 
             # if no_ndp_arcs is different than no_ndp_arcs_bk, than a merge took place
             # if lengths are equal, than no merge did occur and no need to solve the
@@ -247,7 +247,7 @@ class Dedup(Cut):
                 # replace arc with highest index of non-duplicate arcs
                 # and collect remaining arcs as duplicates
                 idx_keep = merged_dedups[0][0]
-                data["linestrings"][idx_keep] = np.asarray(ndp_arcs[idx_merg_arc])
+                data["linestrings"][idx_keep] = np.array(ndp_arcs.geoms[idx_merg_arc].coords)
                 list_merged_dups.append(merged_dedups)
 
         if len(list_merged_dups):

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -353,7 +353,7 @@ class Extract(object):
             idx_pt = len(self._coordinates)
             # record index and store linestring geom
             self._bookkeeping_coords.append([idx_pt])
-            self._coordinates.append(np.expand_dims(np.asarray(geom), axis=0))
+            self._coordinates.append(np.array(geom.coords))
 
             # track record in object as well
             obj = self._obj

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -558,11 +558,9 @@ class Topology(Hashmap):
         # apply delta-encoding if prequantization is applied
         if self.options.prequantize > 0:
             self.output["arcs"] = delta_encoding(self.output["arcs"])
-            # no delta-encoding
-            # self.output["arcs"] = [arc.tolist() for arc in self.output["arcs"]]
         else:
             for idx, ls in enumerate(self.output["arcs"]):
-                self.output["arcs"][idx] = np.array(ls).tolist()
+                self.output["arcs"][idx] = ls.tolist()
 
         # toposimplify linestrings if required
         if self.options.toposimplify > 0:


### PR DESCRIPTION
This PR changes the code to reduces number of deprecation warnings. It targets the following:

ShapelyDeprecationWarning: The array interface is deprecated and will no longer work in Shapely 2.0. Convert the '.coords' to a numpy array instead.

The number of warnings of the test suite goes from 337 to 184 after this PR.