### PR TITLE
Sorted-last-shapely-2-deprecation-warnings

### DIFF
--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -9,6 +9,7 @@ from ..utils import instance
 from ..utils import serialize_as_svg
 from ..utils import TopoOptions
 from ..ops import winding_order
+from ..ops import ignore_shapely2_warnings
 
 
 class Extract(object):
@@ -663,14 +664,15 @@ class Extract(object):
                     # then the object might be a GeoJSON Feature or FeatureCollection. If
                     # this fails as well then the object is not recognized and removed.
                     try:
-                        geom = geometry.shape(self._obj)
+                        with ignore_shapely2_warnings():
+                            geom = geometry.shape(self._obj)
                         # object can be mapped, but may not be valid. remove invalid objects
                         # and continue
                         if not geom.is_valid:
                             self._invalid_geoms += 1
                             del self._data[self._key]
                             continue
-                    except (ValueError, ShapelyError):
+                    except (ShapelyError, ValueError):
                         # object might be a GeoJSON Feature or FeatureCollection
                         # check if geojson is installed
                         try:

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -2,6 +2,7 @@
 import copy
 import pprint
 from shapely import geometry
+from shapely.errors import ShapelyError
 from shapely.wkb import loads
 from shapely.ops import shared_paths
 from shapely.ops import linemerge
@@ -271,7 +272,7 @@ class Join(Extract):
         # detect potential shared paths between two linestrings
         try:
             fw_bw = shared_paths(g1, g2)
-        except ValueError:
+        except (ShapelyError, ValueError):
             self._valerr = True
             fw_bw = False
 


### PR DESCRIPTION
This PR makes reduces the number of warnings from 184 to 0.

It was especially the `np.vstack` which access the array interface under the hood. Like in the following:
```python
import numpy as np
from shapely import geometry

a = {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]}
b = {"type": "LineString", "coordinates": [[0, 0], [1, 0], [2, 0]]}
arr = [geometry.shape(a), geometry.shape(b)]

np.vstack(arr)
```
```
<__array_function__ internals>:5: ShapelyDeprecationWarning: The array interface is deprecated and will no longer work in Shapely 2.0. Convert the '.coords' to a numpy array instead.
[1]:
array([[0., 0.],
       [1., 0.],
       [2., 0.],
       [0., 0.],
       [1., 0.],
       [2., 0.]])
```
Changing to `np.vstack([a.coords for a in arr])`