### PR TITLE
extract gdf index and use it during serialization of `.to_geojson()` and `.to_gdf()`

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -607,3 +607,15 @@ def test_topology_topoquantize():
     topo = topojson.Topology(data, topoquantize=9).to_dict()
 
     assert len(topo["arcs"]) == 149
+
+# test for https://github.com/mattijn/topojson/issues/164
+def test_topology_gdf_keep_index():
+    gdf = (
+        geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        .query('continent == "Africa"')
+        .head()
+    )
+    topo = topojson.Topology(data=gdf)
+    gdf_idx = topo.to_gdf().index.to_list()
+
+    assert gdf_idx == [1, 2, 11, 12, 13]

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -542,8 +542,14 @@ class Extract(object):
         geom : geopandas.GeoDataFrame
             GeoDataFrame instance
         """
-
-        self._data = dict(enumerate(geom.to_dict(orient="records")))
+        
+        if geom.crs:
+            self._defined_crs_source = geom.crs
+        # DataFrame index must be unique for orient='index'.
+        if geom.index.is_unique:
+            self._data = geom.to_dict(orient="index")
+        else:
+            self._data = dict(enumerate(geom.to_dict(orient="records")))
         self._extract_dictionary(self._data)
 
     def _extract_geopandas_geoseries(self, geom):

--- a/topojson/core/hashmap.py
+++ b/topojson/core/hashmap.py
@@ -96,6 +96,7 @@ class Hashmap(Dedup):
         objects["type"] = "GeometryCollection"
         for feature in data["objects"]:
             feat = data["objects"][feature]
+            feat["id"] = feature
 
             if "geometries" in feat and len(feat["geometries"]) == 1:
                 feat["type"] = feat["geometries"][0]["type"]

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -272,7 +272,7 @@ class Topology(Hashmap):
         ----------
         crs : str, dict
             coordinate reference system to set on the resulting frame.
-            Default is `None`.
+            Default tries to use crs from data-input, otherwise is `None`.
         validate : boolean
             Set to `True` to validate each feature before inclusion in the GeoJSON. Only
             features that are valid geometries objects will be included.
@@ -292,6 +292,9 @@ class Topology(Hashmap):
         fc = serialize_as_geojson(
             topo_object, validate=validate, objectname=objectname, order=winding_order
         )
+        
+        if crs is None and hasattr(self, '_defined_crs_source'):
+            crs = self._defined_crs_source
         return serialize_as_geodataframe(fc, crs=crs)
 
     def to_alt(self, color=None, tooltip=True, projection="identity"):

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -385,6 +385,8 @@ def serialize_as_geodataframe(fc, crs=None):
     import geopandas
 
     gdf = geopandas.GeoDataFrame().from_features(features=fc["features"], crs=crs)
+    gdf = gdf.set_index(geopandas.pd.json_normalize(fc["features"])["id"].values)
+
     return gdf
 
 
@@ -515,11 +517,8 @@ def serialize_as_geojson(
 
     # fill the featurecollection with geometry object members
     for index, feature in enumerate(features):
-        f = {"id": index, "type": "Feature"}
-        if "properties" in feature.keys():
-            f["properties"] = feature["properties"].copy()
-        else:
-            f["properties"] = {}
+        f = {"id": feature.get('id', index), "type": "Feature"}
+        f["properties"] = feature.get('properties', {})
 
         # the transform is only used in cases of points or multipoints
         geom_map = geometry(feature, np_arcs, transform)


### PR DESCRIPTION
This PR fix issue #164.

It a source geodataframe has a unique index, it will be used during extraction and used as index again when using the `.to_gdf()` function call. This also means that the commonly used identifier is being used as a member for all features in the serialization process creating geosjon (`.to_geojson()`).

Additionally, this PR also tries to use the `.crs` of the source geodataframe.