### PR TITLE
Resolve MultiPolygon with holes

### DIFF
--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -30,9 +30,8 @@ def test_hashmap_geomcol_multipolygon_polygon():
     topo = Hashmap(data).to_dict()
 
     assert topo["objects"]["data"]["geometries"][0]["geometries"][0]["arcs"] == [
-        [[4, 0]],
-        [[1]],
-        [[2]],
+        [[4, 0], [1]], 
+        [[2]]
     ]
 
 
@@ -277,22 +276,22 @@ def test_hashmap_fiona_gpkg_to_dict():
 
     assert len(topo["linestrings"]) == 4
 
-# issue #148
-@pytest.mark.skip(reason="test is present, solution yet unknown.")
+# issue #148 and issue #167
 def test_hashmap_serializing_holes():
     mp = geometry.shape({
         "type": "MultiPolygon",
         "coordinates": [
             [
                 [[0, 0], [20, 0], [10, 20], [0, 0]],  # CCW
-                [[3, 2], [10, 16], [17, 2], [3, 2]],  # CW
+                [[8, 2], [12, 12], [17, 2], [8, 2]],  # CW
+                [[3, 2], [5, 6], [7, 2], [3, 2]],  # CW            
             ],
-            [[[6, 4], [14, 4], [10, 12], [6, 4]]],  # CCW
+            [[[10, 3], [15, 3], [12, 9], [10, 3]]],  # CCW
         ]
-    })   
+    })  
     topo = Hashmap(mp)
     topo = topo.to_dict()
 
     arc = topo['objects']['data']['geometries'][0]['arcs']
-    assert len(arc) == len(mp)
+    assert arc == [[[0], [1], [2]], [[3]]]
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -228,9 +228,9 @@ def test_topology_polygon():
 
 def test_topology_point_multipoint():
     data = [
-        {"type": "Point", "coordinates": [0.5, 0.5]},
+        {"type": "Point", "coordinates": [0.0, 0.0]},
         {"type": "MultiPoint", "coordinates": [[0.5, 0.5], [1.0, 1.0]]},
-        {"type": "Point", "coordinates": [2.5, 3.5]},
+        {"type": "Point", "coordinates": [1.5, 1.5]},
     ]
     topo = topojson.Topology(data, topoquantize=True).to_dict()
 


### PR DESCRIPTION
This PR fix #148 and #167.

I've changed the '_resolve_bookkeeping()' function. This function replace the geom ids with the corresponding arc ids. Before the corresponding arc ids were collected without considering the shape of the geom id. Now we take the `arcs_in_geom` as base and set the `arc_ids` for the corresponding arc in the same object.

This gives the right nesting for MultiPolygons and MultiPoint, but for other feature types the arcs become nested one level too deep. By updating the `_resolve_arcs()` to unnest nested arcs for the other features, I could make all the tests pass. Except one (`test_hashmap_geomcol_multipolygon_polygon`). 
Before the approach was done reversly. All single features were fine, but the multi features were nested one level deeper. 

Upon inspection of the failed test, I realized that this covers the issue as is described in both linked issues, but was asserted wrongly.. 

Now for this test the input MultiPolygon is also a MultiPolygon in the output.