### PR TITLE
Github Action, shapely version overrule from matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flit codecov pytest flake8
-      - name: Install matrix-shapely version
-        run: python -m pip install "shapely~=${{ matrix.shapely-version }}"       
+          python -m pip install flit codecov pytest flake8     
       - name: Install package dependencies
         run: flit install --deps develop        
+      - name: Overrule shapely version from matrix
+        run: python -m pip install "shapely~=${{ matrix.shapely-version }}"          
       - name: Lint with flake8
         run: flake8 topojson
         continue-on-error: true


### PR DESCRIPTION
Realised that the installed shapely version as defined in `matrix` in GitHub action was uninstalled when installing the dependencies. So all tests pass (https://github.com/mattijn/topojson/pull/172). This PR change the order, trying to overrule the installed version from the dependencies with the one as defined in the matrix.