### PR TITLE
Fix + improve performance for join with shared coords=false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version", "description"]
 authors = [
     {name = "Mattijn van Hoek", email = "mattijn@gmail.com"},
 ]
-dependencies = ["geopandas", "numpy", "pygeos", "shapely >= 1.8.0"]
+dependencies = ["numpy", "shapely >= 1.8.0"]
 keywords = ["topojson", "python", "github", "topology", "geojson"]
 readme = "README.md"
 classifiers = ["License :: OSI Approved :: BSD License"]
@@ -21,6 +21,7 @@ dev = [
     "simplification", 
     "pyshp", 
     "fiona", 
+    "geopandas", 
     "altair", 
     "ipywidgets"    
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version", "description"]
 authors = [
     {name = "Mattijn van Hoek", email = "mattijn@gmail.com"},
 ]
-dependencies = ["numpy", "shapely >= 1.8.0"]
+dependencies = ["geopandas", "numpy", "pygeos", "shapely >= 1.8.0"]
 keywords = ["topojson", "python", "github", "topology", "geojson"]
 readme = "README.md"
 classifiers = ["License :: OSI Approved :: BSD License"]
@@ -21,7 +21,6 @@ dev = [
     "simplification", 
     "pyshp", 
     "fiona", 
-    "geopandas", 
     "altair", 
     "ipywidgets"    
 ]

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -267,7 +267,7 @@ def test_cut_shared_paths_linemerge_multilinestring():
     topo = Cut(data, options={"shared_coords": False}).to_dict()
 
     assert len(topo["linestrings"]) == 12
-    assert len(topo["junctions"]) == 7
+    assert len(topo["junctions"]) == 6
 
 
 # cut exact duplicate rings ABCA & ABCA have no cuts

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,7 +1,8 @@
 import geopandas
+import geopandas.datasets
 from shapely import geometry
-from topojson.core.cut import Cut
 
+from topojson.core.cut import Cut
 
 # cut exact duplicate lines ABC & ABC have no cuts
 def test_cut_exact_duplicate_lines_ABC_ABC_no_cuts():
@@ -363,9 +364,9 @@ def test_cut_shared_paths_ring_ABCA_line_BCAB_no_cuts():
 # topoquantize can have low values, but prequantize cannot. this smells as a bug
 # fixed issue in find_duplicates()
 def test_cut_low_prequantize():
-    import topojson as tp
+    import topojson.utils
 
-    data = tp.utils.example_data_africa()
+    data = topojson.utils.example_data_africa()
     topo = Cut(data, options={"prequantize": 75}).to_dict()
 
     assert len(topo["bookkeeping_duplicates"]) == 153

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -198,7 +198,8 @@ def test_dedup_shared_paths_array_bk_sarcs_reference():
     topo = Dedup(data, options={"shared_coords": False}).to_dict()
 
     assert len(topo["bookkeeping_shared_arcs"]) == 1
-    assert len(topo["junctions"]) == 4
+    junctions = [list(junction.coords) for junction in topo["junctions"]]
+    assert sorted(junctions) == sorted([[(1.0, 1.0)], [(3.0, 1.0)]])
 
 
 # this test was added since there is an error stating the following during Dedup:
@@ -211,7 +212,7 @@ def test_dedup_shared_paths_s2_geometries():
     ]
     topo = Dedup(data, options={"shared_coords": False}).to_dict()
 
-    assert len(topo["junctions"]) == 6
+    assert len(topo["junctions"]) == 4
     assert len(topo["bookkeeping_duplicates"]) == 0
 
 
@@ -235,7 +236,7 @@ def test_dedup_shared_paths_linemerge_multilinestring():
     topo = Dedup(data, options={"shared_coords": False}).to_dict()
 
     assert len(topo["linestrings"]) == 9
-    assert len(topo["junctions"]) == 7
+    assert len(topo["junctions"]) == 6
 
 
 def test_dedup_topology_false():

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,7 +1,9 @@
 import geopandas
+import geopandas.datasets
 import geojson
 from shapely import geometry
 from shapely import wkt
+
 from topojson.core.dedup import Dedup
 
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -808,9 +808,8 @@ def test_join_shared_paths_line_ABD_deviates_line_ABC():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(0.0, 0.0), (2.0, 0.0)])
-    )
+    junctions = [list(junction.coords) for junction in topo["junctions"]]
+    assert sorted(junctions) == sorted([[(0.0, 0.0)], [(2.0, 0.0)]])
 
 
 # when a new line ABD deviates from a reversed old line CBA, there is a

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -637,7 +637,7 @@ def test_join_shared_paths_linemerge_multilinestring():
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
     assert len(topo["linestrings"]) == 2
-    assert len(topo["junctions"]) == 7
+    assert len(topo["junctions"]) == 6
 
 
 # the returned hashmap has true for junction points
@@ -648,9 +648,8 @@ def test_join_shared_paths_true_for_junction_points():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
-    )
+    junctions = [list(junction.coords) for junction in topo["junctions"]]
+    assert sorted(junctions) == sorted([[(0.0, 0.0)], [(1.0, 0.0)]])
 
 
 # forward backward lines
@@ -667,7 +666,7 @@ def test_join_shared_paths_forward_backward_lines():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert len(topo["junctions"]) == 5
+    assert len(topo["junctions"]) == 4
 
 
 # more than two lines
@@ -686,7 +685,7 @@ def test_join_shared_paths_more_than_two_lines():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert len(topo["junctions"]) == 5
+    assert len(topo["junctions"]) == 4
 
 
 # exact duplicate rings ABCA & ABCA have no junctions
@@ -795,9 +794,8 @@ def test_join_shared_paths_line_ABC_extends_line_BC():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0), (2.0, 0.0)])
-    )
+    junctions = [list(junction.coords) for junction in topo["junctions"]]
+    assert sorted(junctions) == sorted([[(1.0, 0.0)], [(2.0, 0.0)]])
 
 
 # when a new line ABD deviates from an old line ABC, there is a junction at B
@@ -835,9 +833,8 @@ def test_join_shared_paths_line_DBC_merge_line_ABC():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (0.0, 0.0)])
-    )
+    junctions = [list(junction.coords) for junction in topo["junctions"]]
+    assert sorted(junctions) == sorted([[(1.0, 0.0)], [(2.0, 0.0)]])
 
 
 # when a new line DBC merges into a reversed old line CBA, there is a junction at B
@@ -848,9 +845,8 @@ def test_join_shared_paths_line_DBC_merge_reversed_line_CBA():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(2.0, 0.0), (1.0, 0.0), (3.0, 0.0)])
-    )
+    junctions = [list(junction.coords) for junction in topo["junctions"]]
+    assert sorted(junctions) == sorted([[(1.0, 0.0)], [(2.0, 0.0)]])
 
 
 # when a new line DBE shares a single midpoint with an old line ABC, there is
@@ -984,7 +980,7 @@ def test_join_shared_paths_exact_duplicate_rings_ABCA_ACBA_share_ABCA():
     }
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
-    assert topo["junctions"] == []
+    assert list(topo["junctions"]) == []
 
 
 # coincident rings ABCA & BCAB share the arc BCAB, but contain no junctions

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,5 +1,7 @@
 import geopandas
+import geopandas.datasets
 from shapely import geometry, wkt
+
 from topojson.core.join import Join
 
 # the returned hashmap has undefined for non-junction points

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1053,3 +1053,30 @@ def test_join_shared_paths_polygons():
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
     assert len(topo["junctions"]) == 2
+
+
+# Bug: less arcs using fast shapely1 implementation
+def test_join_shared_paths_polygons_not_enoug_junctions():
+    p0 = wkt.loads(
+        "Polygon ((187 260, 187 265, 192 265, 192 264, 191 264, 191 263, 190 263, "
+        "190 262, 189 262, 189 261, 188 261, 188 260, 187 260))"
+    )
+    p1 = wkt.loads(
+        "Polygon ((188 261, 188 260, 189 260, 189 261, 188 261))"
+    )
+    p2 = wkt.loads(
+        "Polygon ((189 262, 189 261, 190 261, 190 262, 189 262))"
+    )
+    p3 = wkt.loads(
+        "Polygon ((190 263, 190 262, 191 262, 191 263, 190 263))"
+    )
+    p4 = wkt.loads(
+        "Polygon ((191 261, 191 259, 189 259, 189 260, 190 260, 190 261, 191 261))"
+    )
+
+    data = geopandas.GeoDataFrame(
+        {"name": ["a", "b", "c", "d", "e"], "geometry": [p0, p1, p2, p3, p4]}
+    )
+    topo = Join(data, options={"prequantize": False, "shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 4

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,5 +1,5 @@
 import geopandas
-from shapely import geometry
+from shapely import geometry, wkt
 from topojson.core.join import Join
 
 # the returned hashmap has undefined for non-junction points
@@ -1038,3 +1038,21 @@ def test_join_shared_paths_non_noded_intersection():
     topo = Join(data, options={"shared_coords": False}).to_dict()
 
     assert len(topo["junctions"]) == 321
+
+
+# Bug: start and end of ring is always detected as junction point, even if not the case
+# https://github.com/mattijn/topojson/issues/178
+def test_join_shared_paths_polygons():
+    p0 = wkt.loads(
+        "Polygon((520 1108, 520 1111, 531 1111, 531 1100, 530 1100, 530 1103, "
+        "529 1103, 529 1105, 524 1110, 523 1110, 523 1108, 520 1108))"
+    )
+    p1 = wkt.loads(
+        "Polygon((529 1099, 522 1107, 522 1108, 523 1108, 523 1110, 524 1110, "
+        "529 1105, 529 1103, 530 1103, 530 1099, 529 1099))")
+    data = geopandas.GeoDataFrame(
+        {"name": ["abc", "def"], "geometry": [p0, p1]}
+    )
+    topo = Join(data, options={"shared_coords": False}).to_dict()
+
+    assert len(topo["junctions"]) == 2

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -233,6 +233,21 @@ class Join(Extract):
                             geometry.Point(singleline.coords[-1])
                         ])
 
+            """
+            # the start and end points of lines are by convention also junctions.
+            # This also has as effect that lines are never rotated during cut.
+            # But, this increases the number of junctions significantly while there are
+            # also easy solutions in "cut" to deal with this...
+            for object_id, object_key in enumerate(data["objects"]):
+                object = data["objects"][object_key]
+                if object["type"] in ("LineString", "MultiLineString"):
+                    for line_id in data["bookkeeping_geoms"][object_id]:
+                        self._junctions.extend([
+                            geometry.Point(data["linestrings"][line_id].coords[0]),
+                            geometry.Point(data["linestrings"][line_id].coords[-1])
+                        ])
+            """
+
             # junctions can appear multiple times in multiple segments, remove
             # duplicates
             self._junctions = [
@@ -249,7 +264,6 @@ class Join(Extract):
         Return list of linestrings. If the linemerge was a MultiLineString
         then returns a list of multiple single linestrings
         """
-
         if not isinstance(merged_line, geometry.LineString):
             merged_line = [ls for ls in merged_line.geoms]
         else:

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -10,7 +10,7 @@ from shapely.ops import shared_paths
 from ..ops import bounds
 from ..ops import compare_bounds
 from ..ops import explode
-from ..ops import extract_lines
+from ..ops import linemerge_ext
 from ..ops import quantize
 from ..ops import select_unique_combs
 from ..utils import serialize_as_svg
@@ -206,16 +206,10 @@ class Join(Extract):
 
             # calculate line intersections between linestrings
             intersect_lines = [
-                extract_lines(geom1.intersection(geom2))
+                linemerge_ext(geom1.intersection(geom2))
                 for geom1, geom2 in geom_combs
             ]
-            # try to merge multilinestrings to one linestring
-            intersect_lines = [
-                line if isinstance(line, geometry.LineString)
-                else linemerge(line)
-                for line in intersect_lines
-                if not line.is_empty
-            ]
+            intersect_lines = [line for line in intersect_lines if not line.is_empty]
             intersect_lines = explode(intersect_lines)
 
             # the start and end points of the intersect_lines are the junctions

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -1,11 +1,17 @@
 # pylint: disable=unsubscriptable-object
 import copy
 import pprint
+import warnings
+
+import geopandas as gpd
+import numpy as np
+import pygeos
 from shapely import geometry
 from shapely.errors import ShapelyError
 from shapely.wkb import loads
 from shapely.ops import shared_paths
 from shapely.ops import linemerge
+
 from ..ops import select_unique_combs
 from ..ops import simplify
 from ..ops import quantize
@@ -190,42 +196,38 @@ class Join(Extract):
             self._junctions = [geometry.Point(xy) for xy in set(junctions)]
         else:
 
-            # create list with unique combinations of lines using a r-tree
-            line_combs = select_unique_combs(data["linestrings"])
+            # calculate line intersections between all linestrings
+            linestrings_gdf = gpd.GeoDataFrame(
+                geometry=data["linestrings"]  # type: ignore
+            ).reset_index()
+            with warnings.catch_warnings():
+                # Catch expected geopandas warning
+                warnings.filterwarnings(
+                    action="ignore",
+                    message="^`keep_geom_type=True` in overlay",
+                    category=UserWarning)
+                linestrings_inters_gdf = linestrings_gdf.overlay(
+                    linestrings_gdf, how='intersection',
+                ).query("index_1 != index_2")
+            linestrings_inters_gdf.geometry.array.data = pygeos.line_merge(
+                linestrings_inters_gdf.geometry.array.data
+            )
+            # the start and end points of the intersections are the junctions
+            for line in linestrings_inters_gdf.geometry:
+                if isinstance(line, geometry.LineString):
+                    self._junctions.extend([
+                        geometry.Point(line.coords[0]),
+                        geometry.Point(line.coords[-1])
+                    ])
+                else:
+                    for singleline in line.geoms:
+                        self._junctions.extend([
+                            geometry.Point(singleline.coords[0]),
+                            geometry.Point(singleline.coords[-1])
+                        ])
 
-            # iterate over index combinations
-            for i1, i2 in line_combs:
-                g1 = data["linestrings"][i1]
-                g2 = data["linestrings"][i2]
-
-                # check if geometry are equal
-                # being equal meaning the geometry object coincide with each other.
-                # a rotated polygon or reversed linestring are both considered equal.
-                if not g1.equals(g2):
-                    # geoms are unique, let's find junctions
-                    self._shared_segs(g1, g2)
-
-            # self._segments are nested lists of LineStrings, get coordinates of each nest
-            s_coords = []
-            for segment in self._segments:
-                s_coords.extend(
-                    [
-                        [
-                            (x.xy[0][y], x.xy[1][y])
-                            for x in segment
-                            for y in range(len(x.xy[0]))
-                        ]
-                    ]
-                )
-
-            # only keep junctions that appear only once in each segment (nested list)
-            # coordinates that appear multiple times are not junctions
-            for coords in s_coords:
-                self._junctions.extend(
-                    [geometry.Point(i) for i in coords if coords.count(i) == 1]
-                )
-
-            # junctions can appear multiple times in multiple segments, remove duplicates
+            # junctions can appear multiple times in multiple segments, remove
+            # duplicates
             self._junctions = [
                 loads(xy) for xy in list(set([x.wkb for x in self._junctions]))
             ]

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -233,21 +233,6 @@ class Join(Extract):
                             geometry.Point(singleline.coords[-1])
                         ])
 
-            """
-            # the start and end points of lines are by convention also junctions.
-            # This also has as effect that lines are never rotated during cut.
-            # But, this increases the number of junctions significantly while there are
-            # also easy solutions in "cut" to deal with this...
-            for object_id, object_key in enumerate(data["objects"]):
-                object = data["objects"][object_key]
-                if object["type"] in ("LineString", "MultiLineString"):
-                    for line_id in data["bookkeeping_geoms"][object_id]:
-                        self._junctions.extend([
-                            geometry.Point(data["linestrings"][line_id].coords[0]),
-                            geometry.Point(data["linestrings"][line_id].coords[-1])
-                        ])
-            """
-
             # junctions can appear multiple times in multiple segments, remove
             # duplicates
             self._junctions = [

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -204,23 +204,23 @@ class Join(Extract):
                 geoms for geoms in geom_combs if not geoms[0].equals(geoms[1])
             ]
 
-            # find line intersections between linestrings
-            intersections = [
-                geom1.intersection(geom2)
+            # calculate line intersections between linestrings
+            intersect_lines = [
+                extract_lines(geom1.intersection(geom2))
                 for geom1, geom2 in geom_combs
             ]
-            intersections = extract_lines(intersections)
-            intersections = [
-                linemerge(intersection)
-                if isinstance(intersection, geometry.MultiLineString)
-                else intersection
-                for intersection in intersections
+            # try to merge multilinestrings to one linestring
+            intersect_lines = [
+                line if isinstance(line, geometry.LineString)
+                else linemerge(line)
+                for line in intersect_lines
+                if not line.is_empty
             ]
-            intersections = explode(intersections)
+            intersect_lines = explode(intersect_lines)
 
-            # the start and end points of the intersections are the junctions
+            # the start and end points of the intersect_lines are the junctions
             junctions = [
-                junction for line in intersections
+                junction for line in intersect_lines
                 for junction in (line.coords[0], line.coords[-1])
             ]
             # keep unique junctions

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -211,18 +211,18 @@ class Join(Extract):
                 self._junctions = []
             else:
                 # find intersection between linestrings
-                segments = intersection_all(np.asarray(geom_combs), axis=1)
-                merged_segments = explode(shapely.line_merge(segments))
+                intersections = intersection_all(np.asarray(geom_combs), axis=1)
+                intersections = explode(shapely.line_merge(intersections))
 
-                # the start and end points of the merged_segments are the junctions
+                # the start and end points of the intersections are the junctions
                 coords, index_group_coords = shapely.get_coordinates(
-                    merged_segments, return_index=True
+                    intersections, return_index=True
                 )
                 _, idx_start_segment = np.unique(index_group_coords, return_index=True)
                 idx_start_end = np.append(idx_start_segment, idx_start_segment - 1)
 
                 junctions = coords[idx_start_end]
-                # junctions can appear in multiple segments, remove duplicates
+                # junctions can appear in multiple intersections, remove duplicates
                 _, idx_uniq_junction = np.unique(asvoid(junctions), return_index=True)
                 self._junctions = list(map(geometry.Point, junctions[idx_uniq_junction]))
 

--- a/topojson/core/join.py
+++ b/topojson/core/join.py
@@ -199,7 +199,8 @@ class Join(Extract):
             # calculate line intersections between all linestrings
             linestrings_gdf = gpd.GeoDataFrame(
                 geometry=data["linestrings"]  # type: ignore
-            ).reset_index()
+            )
+            linestrings_gdf["index"] = linestrings_gdf.index
             with warnings.catch_warnings():
                 # Catch expected geopandas warning
                 warnings.filterwarnings(
@@ -213,14 +214,20 @@ class Join(Extract):
                 linestrings_inters_gdf.geometry.array.data
             )
             # the start and end points of the intersections are the junctions
-            for line in linestrings_inters_gdf.geometry:
-                if isinstance(line, geometry.LineString):
+            for row in linestrings_inters_gdf.itertuples():
+                # if the linestrings are equal, no junctions
+                if pygeos.equals(
+                    linestrings_gdf.geometry.array.data[row.index_1],
+                    linestrings_gdf.geometry.array.data[row.index_2]
+                ):
+                    continue
+                if isinstance(row.geometry, geometry.LineString):
                     self._junctions.extend([
-                        geometry.Point(line.coords[0]),
-                        geometry.Point(line.coords[-1])
+                        geometry.Point(row.geometry.coords[0]),
+                        geometry.Point(row.geometry.coords[-1])
                     ])
                 else:
-                    for singleline in line.geoms:
+                    for singleline in row.geometry.geoms:
                         self._junctions.extend([
                             geometry.Point(singleline.coords[0]),
                             geometry.Point(singleline.coords[-1])

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -109,6 +109,8 @@ def strtree_query_index(tree, arc):
 
 
 def explode(segments):
+    if not isinstance(segments, list):
+        segments = [segments]
     list_explode = [
         list(geom.geoms) if hasattr(geom, "geoms") else [geom] for geom in segments
     ]

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -138,7 +138,7 @@ def extract_lines(geom: geometry.base.BaseGeometry) -> geometry.base.BaseGeometr
         ]
         if len(geoms) == 0:
             return geometry.LineString()
-        elif len(geoms) == 0:
+        elif len(geoms) == 1:
             return geoms[0]
         else:
             return geometry.MultiLineString(geoms)

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -120,6 +120,14 @@ def explode(segments):
     return list(itertools.chain.from_iterable(list_explode))
 
 
+def linemerge_ext(geom: geometry.base.BaseGeometry) -> geometry.base.BaseGeometry:
+    line = extract_lines(geom)
+    if isinstance(line, geometry.MultiLineString):
+        return linemerge(line)
+    else:
+        return line
+
+
 def extract_lines(geom: geometry.base.BaseGeometry) -> geometry.base.BaseGeometry:
     if isinstance(geom, geometry.LineString):
         return geom

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -120,26 +120,30 @@ def explode(segments):
     return list(itertools.chain.from_iterable(list_explode))
 
 
-def extract_lines(geoms: List[geometry.base.BaseGeometry]):
-    explodedcollections = [
-        list(geom.geoms) if isinstance(geom, geometry.GeometryCollection) else [geom]
-        for geom in geoms
-        if not geom.is_empty
-    ]
-    explodedcollections = itertools.chain.from_iterable(
-        explodedcollections  # type: ignore
-    )
-    lines = [
-        geom for geom in explodedcollections
-        if (
-            not geom.is_empty
-            and (
-                isinstance(geom, geometry.LineString)
-                or isinstance(geom, geometry.MultiLineString)
+def extract_lines(geom: geometry.base.BaseGeometry) -> geometry.base.BaseGeometry:
+    if isinstance(geom, geometry.LineString):
+        return geom
+    elif isinstance(geom, geometry.MultiLineString):
+        return geom
+    elif isinstance(geom, geometry.GeometryCollection):
+        geoms = [
+            geom for geom in geom.geoms
+            if (
+                not geom.is_empty
+                and (
+                    isinstance(geom, geometry.LineString)
+                    or isinstance(geom, geometry.MultiLineString)
+                )
             )
-        )
-    ]
-    return lines
+        ]
+        if len(geoms) == 0:
+            return geometry.LineString()
+        elif len(geoms) == 0:
+            return geoms[0]
+        else:
+            return geometry.MultiLineString(geoms)
+
+    return geometry.LineString()
 
 
 def np_array_bbox_points_line(line, tree_splitter):

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -108,6 +108,13 @@ def strtree_query_index(tree, arc):
     return tree_index
 
 
+def explode(segments):
+    list_explode = [
+        list(geom.geoms) if hasattr(geom, "geoms") else [geom] for geom in segments
+    ]
+    return list(itertools.chain.from_iterable(list_explode))
+
+
 def np_array_bbox_points_line(line, tree_splitter):
     """
     Get junctions within bbox of line and return both as numpy array
@@ -566,7 +573,7 @@ def select_unique_combs(linestrings):
 
     uniq_line_combs = combs[(np.diff(combs, axis=1) != 0).flatten()]
 
-    return uniq_line_combs
+    return uniq_line_combs, tree_idx
 
 
 def quantize(linestrings, bbox, quant_factor=1e6):

--- a/topojson/ops.py
+++ b/topojson/ops.py
@@ -1,11 +1,14 @@
+import copy
 import itertools
+import logging
+import pprint
+from typing import List
+
 import numpy as np
 from shapely import geometry
 from shapely import wkt
+from shapely.ops import linemerge
 from shapely.strtree import STRtree
-import pprint
-import copy
-import logging
 
 
 try:
@@ -115,6 +118,28 @@ def explode(segments):
         list(geom.geoms) if hasattr(geom, "geoms") else [geom] for geom in segments
     ]
     return list(itertools.chain.from_iterable(list_explode))
+
+
+def extract_lines(geoms: List[geometry.base.BaseGeometry]):
+    explodedcollections = [
+        list(geom.geoms) if isinstance(geom, geometry.GeometryCollection) else [geom]
+        for geom in geoms
+        if not geom.is_empty
+    ]
+    explodedcollections = itertools.chain.from_iterable(
+        explodedcollections  # type: ignore
+    )
+    lines = [
+        geom for geom in explodedcollections
+        if (
+            not geom.is_empty
+            and (
+                isinstance(geom, geometry.LineString)
+                or isinstance(geom, geometry.MultiLineString)
+            )
+        )
+    ]
+    return lines
 
 
 def np_array_bbox_points_line(line, tree_splitter):


### PR DESCRIPTION
Code to find junctions with shared_coords=False was quite slow and according to some tests (both mine + stated in unit tests) didn't seem to give consistent results. Because of the slow performance I opted for a reimplementation rather than trying to fix. The new implementation is based on using spatial overlays (intersection) instead of looping over points.

A test on a 2.5 MB geopackage with (multi)polygons showed the following timings to create the topology:
- shared_coords=True: ~10 s
- shared_coords=False, original implementation (release version): ~160 s
- shared_coords=False, new implementation in this PR: ~ 18 s
There are definitely more opportunities for performance improvements, but the "join" phase seemed to be the main bottleneck.

Regarding the resulting junctions, there were some choices to be made:
- "real" junctions: the coordinates where two features touch for a distance > 1 point, are (should be) detected consistently now.
- "artificial" junctions: the original [javascript topojson implementation](https://github.com/topojson/topojson-server/blob/master/src/join.js) also adds all start and end points of linestring objects (not for polygons/rings) as junctions. As they state in the comment in the code linked above this is to simplify some code regarding rotating rings versus splitting later on in the `cut` step. Because this is a kind of obscure way to force the non-rotating behaviour of lines and because it is easy to implement in a more transparent way in `cut` I opted not to add these "artificial" junctions. Additionally, artificially increasing the number of junctions is bound to reduce performance in the `cut` step.
  - PS: the original python code didn't seem to be very consistent in adding these end points either: when I added this behaviour, more unit tests showed up "red" than without.

I had to change quite some "asserts" in unit tests, for most of them I tried to deduct if the change was logical based on the input data and this seemed to be the case.

Obviously, feedback very welcome!

references #178 