### PR TITLE
change default shared_coords from True to False

### DIFF
--- a/docs/example/settings-tuning.md
+++ b/docs/example/settings-tuning.md
@@ -317,11 +317,11 @@ topo.to_alt().properties(title='toposimplify')
 
 boolean
 {: .text-delta}
-Sets the strategy to detect junctions. When set to `True` a path is 
+Sets the strategy to detect junctions. When set to `False` a path is considered
+shared when coordinates are the same path (`path-connected`). The path-connected
+strategy is more 'correct', but slightly slower. When set to `True` a path is 
 considered shared when all coordinates appear in both paths 
-(`coords-connected`). When set to `False` a path is considered shared when 
-coordinates are the same path (`path-connected`). The path-connected strategy 
-is more 'correct', but slower. Default is `True`.
+(`coords-connected`). Default is `False`.
 
 <div class="code-example mx-1 bg-example">
 <div class="example-label" markdown="1">

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -42,8 +42,8 @@ def test_cut_overlapping_rings_are_cut():
     }
     topo = Cut(data).to_dict()
 
-    assert topo["bookkeeping_linestrings"].size == 6
-    assert topo["bookkeeping_duplicates"].tolist() == [[4, 1]]
+    assert topo["bookkeeping_linestrings"].size == 4
+    assert topo["bookkeeping_duplicates"].tolist() == [[3, 0]]
 
 
 # currently the border between Sudan and Egypt is not recognized as duplicate
@@ -62,7 +62,7 @@ def test_cut_nybb_fast_split():
     data.set_index("BoroCode", inplace=True)
     topo = Cut(data).to_dict()
 
-    assert topo["bookkeeping_linestrings"].size == 5618
+    assert topo["bookkeeping_linestrings"].size == 4664
 
 
 # this test was added since the fast_split was really slow on geometries
@@ -146,8 +146,8 @@ def test_cut_linemerge_multilinestring():
     ]
     topo = Cut(data).to_dict()
 
-    assert len(topo["linestrings"]) == 2
-    assert len(topo["junctions"]) == 0
+    assert len(topo["linestrings"]) == 12
+    assert len(topo["junctions"]) == 6
 
 
 # cut exact duplicate rings ABCA & ABCA have no cuts
@@ -158,7 +158,7 @@ def test_cut_exact_duplicate_rings_ABCA_ABCA_no_cuts():
     }
     topo = Cut(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
     assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
 
@@ -170,13 +170,11 @@ def test_cut_reversed_rings_ABCA_ACBA_no_cuts():
     }
     topo = Cut(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
     assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
 
 # cut rotated duplicate rings BCAB & ABCA have no cuts
-# changed the assertion of bookkeeping_duplicates, since the method rotated polygons are
-# not detected anymore in find_duplicate function when shapely is used for shared_paths.
 def test_cut_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
     data = {
         "abca": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [2, 1], [0, 0]]]},
@@ -184,8 +182,8 @@ def test_cut_rotated_duplicates_rings_BCAB_ABCA_no_cuts():
     }
     topo = Cut(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
-    assert len(topo["bookkeeping_duplicates"]) == 2
+    assert len(topo["junctions"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 1
 
 
 # cut ring ABCA & line ABCA have no cuts
@@ -202,13 +200,11 @@ def test_cut_ring_ABCA_line_ABCA_no_cuts():
     }
     topo = Cut(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
     assert topo["bookkeeping_duplicates"].tolist() == [[1, 0]]
 
 
 # cut ring BCAB & line ABCA have no cuts
-# changed the assertion of bookkeeping_duplicates, since the method rotated polygons are
-# not detected anymore in find_duplicate function when shapely is used for shared_paths.
 def test_cut_ring_BCAB_line_ABCA_no_cuts():
     data = {
         "abcaLine": {
@@ -222,13 +218,11 @@ def test_cut_ring_BCAB_line_ABCA_no_cuts():
     }
     topo = Cut(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
-    assert len(topo["bookkeeping_duplicates"]) == 2
+    assert len(topo["junctions"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 1
 
 
 # cut ring ABCA & line BCAB have no cuts
-# changed the assertion of bookkeeping_duplicates, since the method rotated polygons are
-# not detected anymore in find_duplicate function when shapely is used for shared_paths.
 def test_cut_ring_ABCA_line_BCAB_no_cuts():
     data = {
         "bcabLine": {
@@ -242,8 +236,8 @@ def test_cut_ring_ABCA_line_BCAB_no_cuts():
     }
     topo = Cut(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
-    assert len(topo["bookkeeping_duplicates"]) == 2
+    assert len(topo["junctions"]) == 0
+    assert len(topo["bookkeeping_duplicates"]) == 1
 
 
 # this test is added since its seems no extra junctions are placed at lines where other
@@ -369,4 +363,4 @@ def test_cut_low_prequantize():
     data = topojson.utils.example_data_africa()
     topo = Cut(data, options={"prequantize": 75}).to_dict()
 
-    assert len(topo["bookkeeping_duplicates"]) == 153
+    assert len(topo["bookkeeping_duplicates"]) == 163

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -105,7 +105,7 @@ def test_dedup_arc_not_shared_arcs_got_deleted():
     ]
     topo = Dedup(data).to_dict()
 
-    assert len(topo["bookkeeping_shared_arcs"]) == 9
+    assert len(topo["bookkeeping_shared_arcs"]) == 10
     assert len(topo["bookkeeping_duplicates"]) == 0
 
 
@@ -145,8 +145,8 @@ def test_dedup_array_bk_sarcs_reference():
     }
     topo = Dedup(data).to_dict()
 
-    assert len(topo["bookkeeping_shared_arcs"]) == 0
-    assert len(topo["junctions"]) == 1
+    assert len(topo["bookkeeping_shared_arcs"]) == 1
+    assert len(topo["junctions"]) == 2
 
 
 # this test was added since there is an error stating the following during Dedup:
@@ -159,7 +159,7 @@ def test_dedup_s2_geometries():
     ]
     topo = Dedup(data).to_dict()
 
-    assert len(topo["junctions"]) == 8
+    assert len(topo["junctions"]) == 4
     assert len(topo["bookkeeping_duplicates"]) == 0
 
 
@@ -182,8 +182,8 @@ def test_dedup_linemerge_multilinestring():
     ]
     topo = Dedup(data).to_dict()
 
-    assert len(topo["linestrings"]) == 2
-    assert len(topo["junctions"]) == 0
+    assert len(topo["linestrings"]) == 9
+    assert len(topo["junctions"]) == 6
 
 
 # this test was added since the local variable "array_bk_sarcs" was
@@ -273,8 +273,8 @@ def test_dedup_merge_continuous():
     ]
     topo = Dedup(data, options={"prequantize": False}).to_dict()
 
-    assert len(topo["linestrings"]) == 6
-    assert len(topo["junctions"]) == 5
+    assert len(topo["linestrings"]) == 4
+    assert len(topo["junctions"]) == 2
 
 
 def test_dedup_merge_continuous_shared_path():

--- a/tests/test_hashmap.py
+++ b/tests/test_hashmap.py
@@ -100,7 +100,7 @@ def test_hashmap_shared_arcs_ordering_issues():
         | (data.name == "Zambia")
     ]
     topo = Hashmap(data).to_dict()
-    assert len(topo["linestrings"]) == 17
+    assert len(topo["linestrings"]) == 16
 
 
 def test_hashmap_super_function():

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -111,7 +111,7 @@ def test_join_shared_junctions_in_shared_paths():
     ]
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 6
+    assert len(topo["junctions"]) == 4
 
 
 # this test was added since a shared path can be detected of two linestrings where
@@ -127,7 +127,7 @@ def test_join_shared_segment_partly_start_partly_end_segment():
     ]
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 6
+    assert len(topo["junctions"]) == 4
 
 
 def test_join_super_function_extract():
@@ -217,7 +217,7 @@ def test_join_linemerge_multilinestring():
     topo = Join(data).to_dict()
 
     assert len(topo["linestrings"]) == 2
-    assert len(topo["junctions"]) == 0
+    assert len(topo["junctions"]) == 6
 
 
 # the returned hashmap has true for junction points
@@ -245,7 +245,7 @@ def test_join_forward_backward_lines():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 0
+    assert len(topo["junctions"]) == 4
 
 
 # more than two lines
@@ -264,7 +264,7 @@ def test_join_more_than_two_lines():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 4
 
 
 # exact duplicate rings ABCA & ABCA have no junctions
@@ -275,7 +275,7 @@ def test_join_exact_duplicate_rings():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # reversed duplicate rings ABCA & ACBA have no junctions
@@ -286,7 +286,7 @@ def test_join_reversed_duplicate_rings():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # rotated duplicate rings BCAB & ABCA have no junctions
@@ -296,7 +296,7 @@ def test_join_rotated_duplicate_rings():
         "bcab": {"type": "Polygon", "coordinates": [[[1, 1], [2, 0], [0, 0], [1, 1]]]},
     }
     topo = Join(data).to_dict()
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 # ring ABCA & line ABCA have no junction at A
@@ -313,7 +313,7 @@ def test_join_equal_ring_and_line_no_junctions():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # ring ABCA & line ABCA have no junctions
@@ -330,7 +330,7 @@ def test_join_rotated_ring_and_line_no_junctions():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 # when a new arc ADE shares its start with an old arc ABC, there is no junction at A
@@ -341,7 +341,7 @@ def test_join_line_ADE_share_starts_with_ABC():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # ring ABA has no junctions
@@ -351,7 +351,7 @@ def test_join_single_ring_ABCA():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a new line DEC shares its end with an old line ABC, there is no junction at C
@@ -362,7 +362,7 @@ def test_join_line_DEC_share_line_ABC():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a new line starts BC in the middle of an old line ABC, there is a
@@ -386,7 +386,7 @@ def test_join_line_ABD_deviates_line_ABC():
     topo = Join(data).to_dict()
 
     assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])
+        geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
     )
 
 
@@ -400,7 +400,7 @@ def test_join_line_ABD_deviates_line_CBA():
     topo = Join(data).to_dict()
 
     assert geometry.MultiPoint(topo["junctions"]).equals(
-        geometry.MultiPoint([(1.0, 0.0), (0.0, 0.0)])
+        geometry.MultiPoint([(2.0, 0.0), (0.0, 0.0)])
     )
 
 
@@ -438,7 +438,7 @@ def test_join_line_DBE_share_singe_midpoint_line_ABC():
         "dbe": {"type": "LineString", "coordinates": [[0, 1], [1, 0], [2, 1]]},
     }
     topo = Join(data).to_dict()
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a new line ABDE skips a point with an old line ABCDE, there is a no junction
@@ -451,7 +451,7 @@ def test_join_line_ABDE_skips_point_line_ABCDE():
         "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
     }
     topo = Join(data).to_dict()
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 # when a new line ABDE skips a point with a reversed old line EDCBA, there is
@@ -465,7 +465,7 @@ def test_join_line_ABDE_skips_point_reversed_line_EDCBA():
         "abde": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [3, 0], [4, 0]]},
     }
     topo = Join(data).to_dict()
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 # when a line ABCDBE self-intersects with its middle, there are no junctions
@@ -478,7 +478,7 @@ def test_join_line_ABCDBE_self_intersects_with_middle():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a line ABACD self-intersects with its start, there are no junctions
@@ -491,7 +491,7 @@ def test_join_line_ABACD_self_intersects_with_middle():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a line ABCDBD self-intersects with its end, there are no junctions
@@ -504,7 +504,7 @@ def test_join_line_ABCDBD_self_intersects_with_end():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when an old line ABCDBE self-intersects and shares a point B, there is
@@ -519,7 +519,7 @@ def test_join_line_ABCDB_self_intersects():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a line ABCA is closed, there is no junction at A
@@ -528,7 +528,7 @@ def test_join_line_ABCA_is_closed():
         "abca": {"type": "LineString", "coordinates": [[0, 0], [1, 0], [0, 1], [0, 0]]}
     }
     topo = Join(data).to_dict()
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # when a ring ABCA is closed, there are no junctions
@@ -538,7 +538,7 @@ def test_join_ring_ABCA_is_closed():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # exact duplicate rings ABCA & ABCA share the arc ABCA, but contain no junctions
@@ -549,7 +549,7 @@ def test_join_exact_duplicate_rings_ABCA_ABCA_share_ABCA():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # reversed duplicate rings ABCA & ACBA share the arc ABCA, but contain no junctions
@@ -560,7 +560,7 @@ def test_join_exact_duplicate_rings_ABCA_ACBA_share_ABCA():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 1
+    assert len(topo["junctions"]) == 0
 
 
 # coincident rings ABCA & BCAB share the arc BCAB, but contain no junctions
@@ -573,7 +573,7 @@ def test_join_coincident_rings_ABCA_BCAB_share_BCAB():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 # coincident rings ABCA & BACB share the arc BCAB
@@ -584,7 +584,7 @@ def test_join_coincident_rings_ABCA_BACB_share_BCAB():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 # coincident rings ABCA & DBED share the point B, but is no junction
@@ -595,7 +595,7 @@ def test_join_coincident_rings_ABCA_DBED_share_B():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 3
+    assert len(topo["junctions"]) == 0
 
 
 # coincident ring ABCA & line DBE share the point B
@@ -606,14 +606,14 @@ def test_join_coincident_ring_ABCA_and_line_DBE_share_B():
     }
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 2
+    assert len(topo["junctions"]) == 0
 
 
 def test_join_non_noded_intersection():
     data = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     topo = Join(data).to_dict()
 
-    assert len(topo["junctions"]) == 440
+    assert len(topo["junctions"]) == 321
 
 
 ################## shared_coords:False ##################

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -117,7 +117,7 @@ def test_topology_computing_topology():
     no_topo = topojson.Topology(data, topology=False, prequantize=False).to_dict()
     topo = topojson.Topology(data, topology=True, prequantize=False).to_dict()
 
-    assert len(topo["arcs"]) == 4
+    assert len(topo["arcs"]) == 5
     assert len(no_topo["arcs"]) == 2
 
 
@@ -528,7 +528,7 @@ def test_topology_topoquantization_dups():
     topo = topojson.Topology(data=gdf, prequantize=False).toposimplify(4)
     topo = topo.topoquantize(50).to_dict()
 
-    assert topo["arcs"][6] == [[44, 47], [0, 0]]
+    assert topo["arcs"][6] == [[47, 48], [-3, 1]]
 
 
 # parse topojson from file

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -61,12 +61,12 @@ class Topology(Hashmap):
         in the range of `0.0001` to `10`.
         Defaults to `False`.
     shared_coords : boolean
-        Sets the strategy to detect junctions. When set to `True` a path is
+        Sets the strategy to detect junctions. When set to `False` a path is considered
+        shared when coordinates are the same path (`path-connected`). The path-connected
+        strategy is more 'correct', but slightly slower. When set to `True` a path is
         considered shared when all coordinates appear in both paths
-        (`coords-connected`). When set to `False` a path is considered shared when
-        coordinates are the same path (`path-connected`). The path-connected strategy
-        is more 'correct', but slower.
-        Default is `True`.
+        (`coords-connected`). 
+        Default is `False`.
     prevent_oversimplify: boolean
         If this setting is set to `True`, the simplification is slower, but the
         likelihood of producing valid geometries is higher as it prevents
@@ -108,7 +108,7 @@ class Topology(Hashmap):
         topoquantize=False,
         presimplify=False,
         toposimplify=False,
-        shared_coords=True,
+        shared_coords=False,
         prevent_oversimplify=True,
         simplify_with="shapely",
         simplify_algorithm="dp",

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -21,7 +21,7 @@ class TopoOptions(object):
         topoquantize=False,
         presimplify=False,
         toposimplify=False,
-        shared_coords=True,
+        shared_coords=False,
         prevent_oversimplify=True,
         simplify_with="shapely",
         simplify_algorithm="dp",
@@ -61,7 +61,7 @@ class TopoOptions(object):
         if "shared_coords" in arguments:
             self.shared_coords = arguments["shared_coords"]
         else:
-            self.shared_coords = True
+            self.shared_coords = False
 
         if "prevent_oversimplify" in arguments:
             self.prevent_oversimplify = arguments["prevent_oversimplify"]


### PR DESCRIPTION
This PR changes the default from `shared_coords` from `True` to `False`. The impact is that computed topologies will use by default the strategy of _path-connected_ (`shared_coords=False`), where before the default was  _coords-connected_ (`shared_coords=True`).
See for more info on the differences in the docs: https://mattijn.github.io/topojson/example/settings-tuning.html#shared_coords.