### PR TITLE
Improve vscode settings and launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Python: current file",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    },
+    {
       "name": "Python: TopoJSON",
       "type": "python",
       "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "python.formatting.blackArgs": ["--line-length", "88", "--py36"],
   "editor.formatOnSave": true,
   "[markdown]": {
     "editor.formatOnSave": false


### PR DESCRIPTION
I made some changes to the settings and launch file that - I think - might be useful for other developers as well:
- settings.json: remove the blackargs settting:
  - the --py36 param breaks black for me
  - line length 88 is the default for black, so doesn't need to be specified
- launch.json: a run current file setting