### PR TITLE
Fix bug with shared_coords=True where duplicates are found

### DIFF
--- a/topojson/core/cut.py
+++ b/topojson/core/cut.py
@@ -143,7 +143,7 @@ class Cut(Join):
                     lines_split.append(line_split)
                 else:
                     lines_split.append(
-                        remove_collinear_points(np.array([linestring.coords]))
+                        [remove_collinear_points(np.array(linestring.coords))]
                     )
             # flatten the splitted linestrings, create bookkeeping_geoms array
             # and find duplicates


### PR DESCRIPTION
In the following case 2 linestrings were not correctly identified as duplicate with `with shared_coords=True`:
      - one of them has extra point(s) that disappear with simplify(0).
      - there is another line combination in the dataset that creates junctions for
        shared_coords=False.

Practical case where this showed up. The combination of the above ingredients triggered the bug like this:
- At the top right the smaller polygon touches the outer boundary of the largest polygon, so both those polygons need to be split to create the relevant topologies -> this leads to junctions being created.
- The small polygon at the bottom left fills up an "island" in the large polygon contained an extra collinear point compared to the linearring describing the island.
![image](https://github.com/mattijn/topojson/assets/1565789/17a5c274-f899-41a3-ae97-c48f1521d463)
