### PR TITLE
CI: Run tests also on python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         shapely-version: ["1.8.0", "1.8.4", "2.0"]
-        include:
-          - python-version: "3.11"
-            shapely-version: "2.0"
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -43,12 +40,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m pip install flit codecov pytest flake8
+      - name: Install shapely version from matrix
+        run: python -m pip install "shapely==${{ matrix.shapely-version }}"
       - name: Install package dependencies
         run: flit install --deps develop
-      - name: Overrule shapely version from matrix
-        run: python -m pip install "shapely==${{ matrix.shapely-version }}"
       - name: Lint with flake8
         run: flake8 topojson
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        shapely-version: ["1.8.0", "1.8.4", "2.0"]
+        shapely-version: ["1.8", "2.0"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         shapely-version: ["1.8.0", "1.8.4", "2.0"]
       fail-fast: false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10"]
         shapely-version: ["1.8.0", "1.8.4", "2.0"]
+        include:
+          - python-version: "3.11"
+            shapely-version: "2.0"
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        shapely-version: ["1.8", "2.0"]
+        shapely-version: ["1.8.5", "2.0"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- It seems a bit too soon for python 3.12: shapely/geos doesn't seem ready yet
- Python 3.11 in combination with shapely < 2.0 gives issues: when the github action tries to replace shapely 2.0 by 1.8.x, this fails