### PR TITLE
Geojson ids option

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from topojson.core.extract import Extract
 from shapely import geometry
 import geopandas
@@ -468,6 +469,36 @@ def test_extract_keep_properties():
     assert topo["objects"]["feature_0"]["properties"]["name"] == "abc"
     assert topo["objects"]["feature_1"]["properties"]["name"]["def"] == "ghi"
 
+
+def test_extract_geojson_keep_index():
+    feat_1 = Feature(
+        id="custom_index",
+        geometry=Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]),
+    )
+    feat_2 = Feature(
+        geometry=Polygon([[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]),
+    )
+    data = FeatureCollection([feat_1, feat_2])
+    topo = Extract(data).to_dict()
+    objects = topo["objects"]
+
+    assert bool(objects.get("custom_index")) == True
+    assert bool(objects.get("feature_1")) == True
+
+
+def test_extract_geojson_keep_index_duplicates():
+    feat_1 = Feature(
+        id="duplicate_id",
+        geometry=Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]),
+    )
+    feat_2 = Feature(
+        id="duplicate_id",
+        geometry=Polygon([[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]),
+    )
+    data = FeatureCollection([feat_1,feat_2])
+    with pytest.raises(IndexError):
+        Extract(data)
+        
 
 # why cannot load geojson file using json module?
 def test_extract_read_geojson_from_json_dict():

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -699,3 +699,23 @@ def test_topology_write_multiple_object_json_dict():
     topo_dict = topo.to_dict()
 
     assert len(topo_dict["objects"]) == 2
+
+def test_topology_ignore_index_true_geojson():
+    
+    from geojson import Feature, FeatureCollection, Polygon
+    feat_1 = Feature(
+        id="duplicate_id",
+        geometry=Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]),
+    )
+    feat_2 = Feature(
+        id="duplicate_id",
+        geometry=Polygon([[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]),
+    )
+    fc = FeatureCollection([feat_1,feat_2])
+
+    # Using ignore_index to use default feature ids.
+    topo = topojson.Topology(fc, ignore_index=True).to_dict(options=True)
+    geom = topo["objects"]["data"]["geometries"]
+
+    index = [obj["id"] for obj in geom]
+    assert index == ["feature_0","feature_1"]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -96,7 +96,7 @@ def test_topology_winding_order_TopoOptions():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 11
+    assert len(topo["options"]) == 12
 
 
 # test winding order using kwarg variables
@@ -106,7 +106,7 @@ def test_topology_winding_order_kwarg_vars():
     topo = topojson.Topology(data, winding_order="CW_CCW").to_dict(options=True)
 
     assert len(topo["objects"]) == 1
-    assert len(topo["options"]) == 11
+    assert len(topo["options"]) == 12
 
 
 def test_topology_computing_topology():

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -470,8 +470,8 @@ class Extract(object):
 
         # check for overwritten duplicate keys
         if len(data) < len(obj["features"]):
-            # slight problem here is it doesn't say which one/ones were duplicated
-            raise IndexError("id in geojson data duplicated")
+            msg = "index in data duplicated, use `ignore_index=True` to overwrite index"
+            raise IndexError(msg)
 
         # new data dictionary is created, throw the geometries back to main()
         self._is_single = False

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -460,8 +460,9 @@ class Extract(object):
 
             if feature["type"] == "GeometryCollection":
                 feature_dict["geometries"] = feature["geometry"]["geometries"]
+            # if feature has an id use that
             data[
-                "feature_{}".format(str(idx).zfill(zfill_value))
+                feature.get("id") or "feature_{}".format(str(idx).zfill(zfill_value))
             ] = feature_dict  # feature
         # new data dictionary is created, throw the geometries back to main()
         self._is_single = False

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -464,6 +464,10 @@ class Extract(object):
             data[
                 feature.get("id") or "feature_{}".format(str(idx).zfill(zfill_value))
             ] = feature_dict  # feature
+        # check for overwritten duplicate keys
+        if len(data) < len(obj["features"]):
+            # slight problem here is it doesn't say which one/ones were duplicated
+            raise ValueError("id in geojson data duplicated")
         # new data dictionary is created, throw the geometries back to main()
         self._is_single = False
         self._extractor(data)

--- a/topojson/core/extract.py
+++ b/topojson/core/extract.py
@@ -460,14 +460,19 @@ class Extract(object):
 
             if feature["type"] == "GeometryCollection":
                 feature_dict["geometries"] = feature["geometry"]["geometries"]
-            # if feature has an id use that
-            data[
-                feature.get("id") or "feature_{}".format(str(idx).zfill(zfill_value))
-            ] = feature_dict  # feature
+
+            if self.options.ignore_index or not feature.get("id"):
+                data[
+                    "feature_{}".format(str(idx).zfill(zfill_value))
+                ] = feature_dict
+            else:
+                data[feature.get("id")] = feature_dict  # feature
+
         # check for overwritten duplicate keys
         if len(data) < len(obj["features"]):
             # slight problem here is it doesn't say which one/ones were duplicated
-            raise ValueError("id in geojson data duplicated")
+            raise IndexError("id in geojson data duplicated")
+
         # new data dictionary is created, throw the geometries back to main()
         self._is_single = False
         self._extractor(data)

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -99,8 +99,8 @@ class Topology(Hashmap):
         combination with an equal length list of `data` objects.
         Default is a single object named `data`.
     ignore_index : bool
-        If set to true existing ids/indexes will be ignored and overwritten otherwise
-        they will be passed through into the output.
+        If set to true existing ids/indexes of geojson FeatureCollections will be
+        ignored and overwritten. Otherwise features with ids will use their existing one.
         If indexes are not ignored and a duplicate id exists an exception will be raised.
         Default is false.
     """

--- a/topojson/core/topology.py
+++ b/topojson/core/topology.py
@@ -98,6 +98,11 @@ class Topology(Hashmap):
         case it is required to provide a list of the referenced `object_name` in
         combination with an equal length list of `data` objects.
         Default is a single object named `data`.
+    ignore_index : bool
+        If set to true existing ids/indexes will be ignored and overwritten otherwise
+        they will be passed through into the output.
+        If indexes are not ignored and a duplicate id exists an exception will be raised.
+        Default is false.
     """
 
     def __init__(
@@ -114,6 +119,7 @@ class Topology(Hashmap):
         simplify_algorithm="dp",
         winding_order="CW_CCW",
         object_name="data",
+        ignore_index=False,
     ):
         options = TopoOptions(locals())
 

--- a/topojson/utils.py
+++ b/topojson/utils.py
@@ -27,6 +27,7 @@ class TopoOptions(object):
         simplify_algorithm="dp",
         winding_order=None,
         object_name="data",
+        ignore_index=False,
     ):
         # get all arguments
         arguments = locals()
@@ -90,6 +91,11 @@ class TopoOptions(object):
                 self.object_name = arguments["object_name"]
         else:
             self.object_name = ["data"]
+
+        if "ignore_index" in arguments:
+            self.ignore_index = arguments["ignore_index"]
+        else:
+            self.ignore_index = False
 
     def __repr__(self):
         return "TopoOptions(\n  {}\n)".format(pprint.pformat(self.__dict__))


### PR DESCRIPTION
PR for #219 

Change makes it so that `geojson.FeatureCollections` with Features that have ids will have those ids passed through to the output of Topology. 
A new option `ignore_index` that allows that behavior to be reverted to what it was before also added. Left off by default

Added three tests.

1. Checking index is passed through extract
2. Checking duplicate index raises an error
3. Checking that ignore_index=True uses the original "feature_0", "feature_0" index

Two tests that counted the number of options were modified to increase the expected count by one.